### PR TITLE
Update @types/globalize to 0.0.34 and remove hack for old typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -243,9 +243,9 @@
       }
     },
     "@types/globalize": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/globalize/-/globalize-0.0.33.tgz",
-      "integrity": "sha512-/K9PuwA7R2vGpLeTdTmSt9ipFOhT4QpSP9mmr19hBlfZ7R1p5eSsYI8s5XMU2L4pGs4H073+ShdabWzwBYziXw==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/globalize/-/globalize-0.0.34.tgz",
+      "integrity": "sha512-FQTLuqZxqf+T1Ao6RzaIP7HcTcNvgDf0YQfK90YGYt1N6KeU5GE0M/hsxdQlpqvuztxjEwEQqIO3paSO/tZ4Pw==",
       "dev": true,
       "requires": {
         "@types/cldrjs": "*"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/dojo/framework#readme",
   "dependencies": {
     "@types/cldrjs": "~0.4.20",
-    "@types/globalize": "0.0.33",
+    "@types/globalize": "0.0.34",
     "@types/web-animations-js": "2.2.5",
     "@webcomponents/webcomponentsjs": "1.1.0",
     "cldr-data": "~32.0.0",

--- a/src/i18n/cldr/load.ts
+++ b/src/i18n/cldr/load.ts
@@ -1,11 +1,8 @@
 // required for Globalize/Cldr to properly resolve locales in the browser.
-import * as GlobalizeType from 'globalize';
 import 'cldrjs/dist/cldr/unresolved';
+import * as Globalize from 'globalize/dist/globalize';
 import supportedLocales from './locales';
 import { generateLocales, validateLocale } from '../util/main';
-
-// TODO: use normal imports after landing https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27271
-const Globalize: typeof GlobalizeType = require('globalize/dist/globalize');
 
 export interface CldrData {
 	main?: LocaleData;

--- a/src/i18n/date.ts
+++ b/src/i18n/date.ts
@@ -1,4 +1,3 @@
-import 'globalize/dist/globalize';
 import 'globalize/dist/globalize/number';
 import 'globalize/dist/globalize/date';
 import 'globalize/dist/globalize/relative-time';

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,5 +1,4 @@
 /* tslint:disable:interface-name */
-import 'globalize/dist/globalize/message';
 import global from '../shim/global';
 import Map from '../shim/Map';
 import Evented from '../core/Evented';
@@ -7,12 +6,9 @@ import has from '../core/has';
 import uuid from '../core/uuid';
 import { Handle } from '../core/interfaces';
 import { useDefault } from '../core/load/util';
-import * as GlobalizeType from 'globalize';
+import * as Globalize from 'globalize/dist/globalize/message';
 import { isLoaded } from './cldr/load';
 import { generateLocales, normalizeLocale } from './util/main';
-
-// TODO: use normal imports after landing https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27271
-const Globalize: typeof GlobalizeType = require('globalize/dist/globalize');
 
 /**
  * A default bundle used as basis for loading locale-specific bundles.

--- a/src/i18n/number.ts
+++ b/src/i18n/number.ts
@@ -1,4 +1,3 @@
-import 'globalize/dist/globalize';
 import 'globalize/dist/globalize/number';
 import 'globalize/dist/globalize/plural';
 import 'globalize/dist/globalize/currency';

--- a/src/i18n/unit.ts
+++ b/src/i18n/unit.ts
@@ -1,4 +1,3 @@
-import 'globalize/dist/globalize';
 import 'globalize/dist/globalize/number';
 import 'globalize/dist/globalize/plural';
 import 'globalize/dist/globalize/unit';

--- a/src/i18n/util/globalize.ts
+++ b/src/i18n/util/globalize.ts
@@ -1,9 +1,5 @@
-import 'globalize/dist/globalize';
-import * as GlobalizeType from 'globalize';
+import * as Globalize from 'globalize/dist/globalize';
 import i18n from '../i18n';
-
-// TODO: use normal imports after landing https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27271
-const Globalize: typeof GlobalizeType = require('globalize/dist/globalize');
 
 /**
  * @private


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removes the hack in the codebase for the old `@types/globalize` definitions and uses new version of typings with submodules defined.