### PR TITLE
fix paths to docs pages and API for framework

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -138,15 +138,15 @@ See [LICENSE](LICENSE) for details.
 
 <!-- doc-viewer-config
 {
-	"api": "docs/api.json",
+	"api": "docs/core/api.json",
 	"pages": [
-		"docs/UrlSearchParams.md",
-		"docs/has.md",
-		"docs/lang.md",
-		"docs/load.md",
-		"docs/on.md",
-		"docs/request.md",
-		"docs/stringExtras.md"
+		"docs/core/UrlSearchParams.md",
+		"docs/core/has.md",
+		"docs/core/lang.md",
+		"docs/core/load.md",
+		"docs/core/on.md",
+		"docs/core/request.md",
+		"docs/core/stringExtras.md"
 	]
 }
 -->

--- a/src/has/README.md
+++ b/src/has/README.md
@@ -237,5 +237,5 @@ The original Dojo 1 `has()` API was based upon Peter Higgin's [has.js](https://g
 
 <!-- doc-viewer-config
 {
-	"api": "docs/api.json"
+	"api": "docs/has/api.json"
 }

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -435,6 +435,6 @@ Test cases MUST be written using Intern using the Object test interface and Asse
 
 <!-- doc-viewer-config
 {
-	"api": "docs/api.json"
+	"api": "docs/i18n/api.json"
 }
 -->

--- a/src/routing/README.md
+++ b/src/routing/README.md
@@ -408,6 +408,6 @@ or
 
 <!-- doc-viewer-config
 {
-	"api": "docs/api.json"
+	"api": "docs/routing/api.json"
 }
 -->

--- a/src/shim/README.md
+++ b/src/shim/README.md
@@ -200,14 +200,14 @@ or
 
 <!-- doc-viewer-config
 {
-	"api": "docs/api.json",
+	"api": "docs/shim/api.json",
 	"pages": [
-		"docs/array.md",
-		"docs/Map.md",
-		"docs/math.md",
-		"docs/Observable.md",
-		"docs/Promise.md",
-		"docs/string.md"
+		"docs/shim/array.md",
+		"docs/shim/Map.md",
+		"docs/shim/math.md",
+		"docs/shim/Observable.md",
+		"docs/shim/Promise.md",
+		"docs/shim/string.md"
 	]
 }
 -->

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -624,6 +624,6 @@ or
 
 <!-- doc-viewer-config
 {
-	"api": "docs/api.json"
+	"api": "docs/stores/api.json"
 }
 -->


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:


* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

With the path changes for framework, the `doc-viewer-config` comments in each of the README files needs the paths updated to point to the correct `docs/` subdirectories.
