### PR TITLE
Update all the readmes after the move to framework

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,24 +1,7 @@
-# @dojo/core
+# core
 
-[![Build Status](https://travis-ci.org/dojo/core.svg?branch=master)](https://travis-ci.org/dojo/core)
-[![codecov.io](https://codecov.io/github/dojo/core/coverage.svg?branch=master)](https://codecov.io/github/dojo/core?branch=master)
-[![npm version](https://badge.fury.io/js/%40dojo%2Fcore.svg)](https://badge.fury.io/js/%40dojo%2Fcore)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fdojo%2Fcore.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fdojo%2Fcore?ref=badge_shield)
-
-This package provides a set of language helpers, utility functions, and classes for writing TypeScript applications. It includes APIs for feature detection, asynchronous operations, basic event handling,
+Provides a set of language helpers, utility functions, and classes for writing TypeScript applications. It includes APIs for feature detection, asynchronous operations, basic event handling,
 and making HTTP requests.
-
-## Usage
-
-To use `@dojo/core`, install the package along with its required peer dependencies:
-
-```bash
-npm install @dojo/core
-
-# peer dependencies
-npm install @dojo/has
-npm install @dojo/shim
-```
 
 ## Features
 
@@ -36,7 +19,7 @@ npm install @dojo/shim
 
 ### Feature Detection
 
-Using the latest Web technologies isn't always as straightforward as developers would like due to differing support across platforms. [`@dojo/core/has`](../../docs/core/has.md) provides a simple feature detection API that makes it easy to
+Using the latest Web technologies isn't always as straightforward as developers would like due to differing support across platforms. [`@dojo/framework/core/has`](../../docs/core/has.md) provides a simple feature detection API that makes it easy to
 detect which platforms support which features.
 
 ### Language Utilities
@@ -46,95 +29,41 @@ on methods in the ES2015 proposal; others are additional APIs for commonly-perfo
 
 #### lang
 
-The [`@dojo/core/lang` module](../../docs/core/lang.md) contains various utility functions for tasks such as copying objects
+The [`@dojo/framework/core/lang` module](../../docs/core/lang.md) contains various utility functions for tasks such as copying objects
 and creating late-bound or partially applied functions.
 
 ### load
-The [`@dojo/core/load` module](../../docs/core/load.md) can be used to dynamically load modules or other arbitrary resources via plugins.
+The [`@dojo/framework/core/load` module](../../docs/core/load.md) can be used to dynamically load modules or other arbitrary resources via plugins.
 
 #### string
 
-The [`@dojo/core/stringExtras` module](../../docs/core/stringExtras.md) contains various string functions that are not available as part of the ES2015 String APIs.
+The [`@dojo/framework/core/stringExtras` module](../../docs/core/stringExtras.md) contains various string functions that are not available as part of the ES2015 String APIs.
 
 #### UrlSearchParams
 
-The [`@dojo/core/UrlSearchParams` class](../../docs/core/UrlSearchParams.md) can be used to parse and generate URL query strings.
+The [`@dojo/framework/core/UrlSearchParams` class](../../docs/core/UrlSearchParams.md) can be used to parse and generate URL query strings.
 
 #### Event handling
 
-The [`@dojo/core/on` module](../../docs/core/on.md) contains methods to handle events across types of listeners.  It also includes methods to handle different event use cases including only firing
+The [`@dojo/framework/core/on` module](../../docs/core/on.md) contains methods to handle events across types of listeners.  It also includes methods to handle different event use cases including only firing
 once and pauseable events.
 
 #### HTTP requests
 
-The [`@dojo/core/request` module](../../docs/core/request.md) contains methods to simplify making HTTP requests. It can handle
+The [`@dojo/framework/core/request` module](../../docs/core/request.md) contains methods to simplify making HTTP requests. It can handle
 making requests in both node and the browser through the same methods.
 
 ### Promises and Asynchronous Operations
 
 #### Promise
 
-The `@dojo/core/Promise` class is an implementation of the ES2015 Promise API that also includes static state inspection and a `finally` method for cleanup actions.
+The `@dojo/framework/core/Promise` class is an implementation of the ES2015 Promise API that also includes static state inspection and a `finally` method for cleanup actions.
 
-`@dojo/core/async` contains a number of classes and utility modules to simplify working with asynchronous operations.
+`@dojo/framework/core/async` contains a number of classes and utility modules to simplify working with asynchronous operations.
 
 #### Task
 
-The `@dojo/core/async/Task` class is an extension of `@dojo/core/Promise` that provides cancelation support.
-
-## How Do I Contribute?
-
-We appreciate your interest! Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme)
-for the Contributing Guidelines.
-
-### Code Style
-
-This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the project's `package.json`.
-
-An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
-
-```bash
-npm run prettier
-```
-
-### Installation
-
-To start working with this package, clone the repository and run `npm install`.
-
-In order to build the project run `grunt dev` or `grunt dist`.
-
-### Testing
-
-Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
-
-90% branch coverage MUST be provided for all code submitted to this repository, as reported by istanbul’s combined coverage results for all supported platforms.
-
-To test locally in node run:
-
-`grunt test`
-
-To test against browsers with a local selenium server run:
-
-`grunt test:local`
-
-To test against BrowserStack or Sauce Labs run:
-
-`grunt test:browserstack`
-
-or
-
-`grunt test:saucelabs`
-
-## Licensing information
-
-© 2004–2018 [JS Foundation](https://js.foundation/) & contributors. [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
-
-Some string functions (`codePointAt`, `fromCodePoint`, and `repeat`) adopted from polyfills by Mathias Bynens,
-under the [MIT](http://opensource.org/licenses/MIT) license.
-
-See [LICENSE](LICENSE) for details.
-
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fdojo%2Fcore.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fdojo%2Fcore?ref=badge_large)
+The `@dojo/framework/core/async/Task` class is an extension of `@dojo/framework/core/Promise` that provides cancelation support.
 
 <!-- doc-viewer-config
 {

--- a/src/core/request/README.md
+++ b/src/core/request/README.md
@@ -19,8 +19,8 @@ To make simple GET requests, you must register your provider (node, or XHR) then
 format of the API resembles the [Fetch Standard](https://fetch.spec.whatwg.org/).
 
 ```ts
-import request from 'dojo/framework/core/request';
-import node from 'dojo/framework/core/providers/node';
+import request from '@dojo/framework/core/request';
+import node from '@dojo/framework/core/providers/node';
 
 request.setDefaultProvider(node);
 

--- a/src/core/request/README.md
+++ b/src/core/request/README.md
@@ -19,8 +19,8 @@ To make simple GET requests, you must register your provider (node, or XHR) then
 format of the API resembles the [Fetch Standard](https://fetch.spec.whatwg.org/).
 
 ```ts
-import request from 'dojo-request';
-import node from 'dojo-request/providers/node';
+import request from 'dojo/framework/core/request';
+import node from 'dojo/framework/core/providers/node';
 
 request.setDefaultProvider(node);
 

--- a/src/has/README.md
+++ b/src/has/README.md
@@ -1,41 +1,16 @@
-# @dojo/has
+# has
 
-[![Build Status](https://travis-ci.org/dojo/has.svg?branch=master)](https://travis-ci.org/dojo/has)
-[![codecov](https://codecov.io/gh/dojo/has/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/has)
-[![npm version](https://badge.fury.io/js/%40dojo%2Fhas.svg)](https://badge.fury.io/js/%40dojo%2Fhas)
-
-A feature detection library.
-
-This package provides an API for expressing feature detection to allow developers to branch code based upon the
+Provides an API for expressing feature detection to allow developers to branch code based upon the
 detected features.  The features can also be asserted statically, thereby allowing integration into a build
 optimization tool that can be used to create "dead" code branches which can be elided during a build
 step.  The `has` module is also capable of allowing conditional loading of modules with certain loaders.
 
-- [Usage](#usage)
 - [Features](#features)
     - [Feature Branching](#feature-branching)
 	- [Included Features](#included-features)
 	- [Adding a Feature Test/Feature Detection](#adding-a-feature-testfeature-detection)
 	- [Conditional Module Loading](#conditional-module-loading)
 	- [Static Features](#static-features)
-
-## Usage
-
-To use `@dojo/has`, simply install the package:
-
-```bash
-npm install @dojo/has
-```
-
-and import it into your application,
-
-```typescript
-import has from '@dojo/has';
-
-if (has('some-feature')) {
-	/* use some feature */
-}
-```
 
 ## Features
 
@@ -48,7 +23,7 @@ The `has()` module is the default export of the main module of the package:
 For example:
 
 ```typescript
-import has from '@dojo/has';
+import has from '@dojo/framework/has';
 
 if (has('host-browser')) {
 	/* Browser Related Code */
@@ -87,7 +62,7 @@ requested from `has()`, or a thenable (an object with a `then` method, like a Pr
 An example of adding a feature:
 
 ```typescript
-import { add } from '@dojo/has';
+import { add } from '@dojo/framework/has';
 
 add('my-feature', true);
 add('my-lazy-feature', () => {
@@ -114,7 +89,7 @@ add('my-feature', false, true);
 The module also has an `exists()` function which returns `true` if the feature flag has been added to `has()`:
 
 ```typescript
-import { exists, add } from '@dojo/has';
+import { exists, add } from '@dojo/framework/has';
 
 if (!exists('my-feature')) {
 	add('my-feature', false);
@@ -127,12 +102,12 @@ proper value can be returned.
 ### Conditional Module Loading
 
 When using an AMD loader that supports loader plugins (such as [`@dojo/loader`](https://github.com/dojo/loader)) then
-`@dojo/has` can be used to conditionally load modules or substitute one module for another.  The module ID is specified
+`@dojo/framework/has` can be used to conditionally load modules or substitute one module for another.  The module ID is specified
 using the plugin syntax followed by the feature flag and a ternary operator of what to do if the feature is *truthy*
 or *falsey*:
 
 ```typescript
-import foo from '@dojo/has!host-browser?foo/browser:foo/node';
+import foo from '@dojo/framework/has!host-browser?foo/browser:foo/node';
 
 /* foo is now the default export from either `foo/browser` or `foo/node` */
 ```
@@ -145,7 +120,7 @@ have to make a global declaration of the module that is in the scope of the proj
 full MID you will be importing:
 
 ```typescript
-declare module '@dojo/has!host-browser?foo/browser:foo/node' {
+declare module '@dojo/framework/has!host-browser?foo/browser:foo/node' {
 	export * from 'foo/browser'; /* Assumes that foo/browser and foo/node have the same shape */
 }
 ```
@@ -185,55 +160,6 @@ window.DojoHasEnvironment = {
 
 This function will be run once when the module is loaded and the values returned from the function will be used as the
 static features.
-
-## How do I contribute?
-
-We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines.
-
-### Code Style
-
-This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the project's `package.json`.
-
-An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
-
-```bash
-npm run prettier
-```
-
-## Installation
-
-To start working with this package, clone the repository and run `npm install`.
-
-In order to build the project run `grunt dev` or `grunt dist`.
-
-## Testing
-
-Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
-
-90% branch coverage MUST be provided for all code submitted to this repository, as reported by istanbul’s combined coverage results for all supported platforms.
-
-To test locally in node run:
-
-`grunt test`
-
-To test against browsers with a local selenium server run:
-
-`grunt test:local`
-
-To test against BrowserStack or Sauce Labs run:
-
-`grunt test:browserstack`
-
-or
-
-`grunt test:saucelabs`
-
-## Licensing information
-
-The original Dojo 1 `has()` API was based upon Peter Higgin's [has.js](https://github.com/phiggins42/has.js/).
-
-© 2018 [JS Foundation](https://js.foundation/) & contributors. [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
 
 <!-- doc-viewer-config
 {

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -1,12 +1,7 @@
-# @dojo/i18n
+# i18n
 
-[![Build Status](https://travis-ci.org/dojo/i18n.svg?branch=master)](https://travis-ci.org/dojo/i18n)
-[![codecov.io](http://codecov.io/github/dojo/i18n/coverage.svg?branch=master)](http://codecov.io/github/dojo/i18n?branch=master)
-[![npm version](https://badge.fury.io/js/%40dojo%2Fi18n.svg)](https://badge.fury.io/js/%40dojo%2Fi18n)
+An internationalization package that provides locale-specific message loading, and support for locale-specific message, date, and number formatting.
 
-An internationalization library that provides locale-specific message loading, and support for locale-specific message, date, and number formatting.
-
-- [Usage](#usage)
 - [Features](#features)
   - [Message Bundle Loading](#message-bundle-loading)
   - [Determining the Current Locale](#determining-the-current-locale)
@@ -14,28 +9,9 @@ An internationalization library that provides locale-specific message loading, a
   - [Loading CLDR data](#loading-cldr-data)
   - [Message Formatting](#message-formatting)
   - [Date and number formatting](#date-and-number-formatting)
-- [How do I contribute?](#how-do-i-contribute)
-  - [Installation](#installation)
-  - [Testing](#testing)
-- [Licensing information](#licensing-information)
-
-## Usage
-
-To use `@dojo/i18n`, install the package along with its required peer dependencies:
-
-```bash
-npm install @dojo/i18n
-
-# peer dependencies
-npm install @dojo/core
-npm install @dojo/has
-npm install @dojo/shim
-```
-
-With TypeScript or ES6 modules, you would generally want to just import the @dojo/i18n/i18n module:
 
 ```typescript
-import i18n, { Messages } from '@dojo/i18n/i18n';
+import i18n, { Messages } from '@dojo/framework/i18n/i18n';
 import messageBundle from 'path/to/bundle';
 
 i18n(messageBundle, 'fr').then((messages: Messages) => {
@@ -49,7 +25,7 @@ The examples below are provided in TypeScript syntax. The package does work unde
 
 ### Message Bundle Loading
 
-`@dojo/i18n` provides a means for loading locale-specific messages and updating those messages when the locale changes. Each bundle has a default module that is `import`ed like any other TypeScript module. Locale-specific messages are then loaded via the `i18n` method. Every default bundle MUST provide a `messages` map containing default messages, and an optional `locales` object that maps supported locales to functions that load their respective translations. Further, each default bundle is assigned a unique `id` property that is used internally to manage caching and handle interoperability with Globalize.js (see below). While it is possible to include an `id` with your message bundles, doing so is neither necessary nor recommended.
+`@dojo/framework/i18n` provides a means for loading locale-specific messages and updating those messages when the locale changes. Each bundle has a default module that is `import`ed like any other TypeScript module. Locale-specific messages are then loaded via the `i18n` method. Every default bundle MUST provide a `messages` map containing default messages, and an optional `locales` object that maps supported locales to functions that load their respective translations. Further, each default bundle is assigned a unique `id` property that is used internally to manage caching and handle interoperability with Globalize.js (see below). While it is possible to include an `id` with your message bundles, doing so is neither necessary nor recommended.
 
 ```typescript
 import fr from './fr/main';
@@ -83,7 +59,7 @@ export default messages;
 Once the default bundle is in place, any locale-specific messages are loaded by passing the default bundle to the `i18n` function. Using the previous example as the default bundle, any locale-specific messages are loaded as follows:
 
 ```typescript
-import i18n, { Messages } from '@dojo/i18n/main';
+import i18n, { Messages } from '@dojo/framework/i18n/main';
 import bundle from 'nls/main';
 
 i18n(bundle, 'fr').then(function (messages: Messages) {
@@ -97,7 +73,7 @@ If an unsupported locale is passed to `i18n`, then the default messages are retu
 Alternatively, locale messages can be manually loaded by passing them to `setLocaleMessages`. This is useful for pre-caching locale-specific messages so that an additional HTTP request is not sent to load them. Locale-specific messages are merged with the default messages, so partial message bundles are acceptable:
 
 ```typescript
-import i18n, { setLocaleMessages } from '@dojo/i18n/i18n';
+import i18n, { setLocaleMessages } from '@dojo/framework/i18n/i18n';
 import bundle from 'nls/main';
 
 const partialMessages = { hello: 'Ahoj' };
@@ -112,7 +88,7 @@ i18n(bundle, 'cz').then((messages) => {
 Once locale dictionaries for a bundle have been loaded, they are cached and can be accessed synchronously via `getCachedMessages`:
 
 ```typescript
-import { getCachedMessages } from '@dojo/i18n/i18n';
+import { getCachedMessages } from '@dojo/framework/i18n/i18n';
 import bundle from 'nls/main';
 
 const messages = getCachedMessages(bundle, 'fr');
@@ -124,7 +100,7 @@ console.log(messages.goodbye); // "Au revoir"
 
 
 ```typescript
-import { getCachedMessages } from '@dojo/i18n/i18n';
+import { getCachedMessages } from '@dojo/framework/i18n/i18n';
 import bundle from 'nls/main';
 
 const frenchMessages = getCachedMessages(bundle, 'fr-CA');
@@ -139,7 +115,7 @@ console.log(madeUpLocaleMessages.goodbye); // "Goodbye"
 If need be, bundle caches can be cleared with `invalidate`. If called with a bundle, only the messages for that particular bundle are removed from the cache. Otherwise, all messages are cleared:
 
 ```typescript
-import i18n, { getCachedMessages, invalidate } from '@dojo/i18n/main';
+import i18n, { getCachedMessages, invalidate } from '@dojo/framework/i18n/main';
 import bundle from 'nls/main';
 
 i18n(bundle, 'ar').then(() => {
@@ -157,7 +133,7 @@ The current locale can be accessed via the read-only property `i18n.locale`, whi
 The `switchLocale` method changes the root locale and notifies all consumers registered with `observeLocale`, which accepts a function that receives the new locale string as its sole argument. For example, suppose the system locale is `en-GB`:
 
 ```typescript
-import i18n, { observeLocale, switchLocale, systemLocale } from '@dojo/i18n/i18n';
+import i18n, { observeLocale, switchLocale, systemLocale } from '@dojo/framework/i18n/i18n';
 import bundle from 'nls/bundle';
 
 // Register an event listener
@@ -179,10 +155,10 @@ console.log(systemLocale); // 'en-GB' (the system locale does not change with th
 
 ### Loading CLDR data
 
-Given the very large size of the [Unicode CLDR data](http://cldr.unicode.org), it is not included as a dependency of `@dojo/i18n`. For applications that use `@dojo/i18n` only for selecting unformatted, locale-specific messages, this is not a concern. However, if using the [ICU-formatted messages](http://userguide.icu-project.org/formatparse/messages) or any of the other formatters provided by `@dojo/i18n` (see below), applications must explicitly load any required CLDR data via the `loadCldrData` method exported by `@dojo/i18n/cldr/load`. `loadCldrData` accepts an object of CLDR data. All CLDR data MUST match the format used by the [Unicode CLDR JSON](https://github.com/unicode-cldr/cldr-json) files. Supplemental data MUST be nested within a top-level `supplemental` object, and locale-specific data MUST be nested under locale objects within a top-level `main` object:
+Given the very large size of the [Unicode CLDR data](http://cldr.unicode.org), it is not included as a dependency of `@dojo/framework/i18n`. For applications that use `@dojo/framework/i18n` only for selecting unformatted, locale-specific messages, this is not a concern. However, if using the [ICU-formatted messages](http://userguide.icu-project.org/formatparse/messages) or any of the other formatters provided by `@dojo/framework/i18n` (see below), applications must explicitly load any required CLDR data via the `loadCldrData` method exported by `@dojo/framework/i18n/cldr/load`. `loadCldrData` accepts an object of CLDR data. All CLDR data MUST match the format used by the [Unicode CLDR JSON](https://github.com/unicode-cldr/cldr-json) files. Supplemental data MUST be nested within a top-level `supplemental` object, and locale-specific data MUST be nested under locale objects within a top-level `main` object:
 
 ```typescript
-import loadCldrData from '@dojo/i18n/cldr/load';
+import loadCldrData from '@dojo/framework/i18n/cldr/load';
 
 loadCldrData({
 	"supplemental": {
@@ -196,7 +172,7 @@ loadCldrData({
 });
 ```
 
-`@dojo/i18n` requires the following CLDR data:
+`@dojo/framework/i18n` requires the following CLDR data:
 
 For ICU message formatting:
 
@@ -239,10 +215,10 @@ For unit formatting:
 
 The `i18n` module exposes two methods that handle message formatting: 1) `formatMessage`, which directly returns a formatted message based on its inputs, and 2) `getMessageFormatter`, which returns a method dedicated to formatting a single message. Both of these methods operate on bundle objects, which must first be registered with the i18n ecosystem by passing them to the `i18n` function (see below).
 
-`@dojo/i18n` supports the ICU message format (see below), but that requires CLDR data and is not something that every application requires. As such, if the `supplemental/likeSubtags` and `supplemental/plurals` data are not loaded, then both `formatMessage` and `getMessageFormatter` will perform simple token replacement. For example, given the `guestInfo` message `{host} invites {guest} to the party.`, an object with `host` and `guest` properties can be provided to a formatter without the need to load CLDR data:
+`@dojo/framework/i18n` supports the ICU message format (see below), but that requires CLDR data and is not something that every application requires. As such, if the `supplemental/likeSubtags` and `supplemental/plurals` data are not loaded, then both `formatMessage` and `getMessageFormatter` will perform simple token replacement. For example, given the `guestInfo` message `{host} invites {guest} to the party.`, an object with `host` and `guest` properties can be provided to a formatter without the need to load CLDR data:
 
 ```typescript
-import i18n, { formatMessage, getMessageFormatter } from '@dojo/i18n/i18n';
+import i18n, { formatMessage, getMessageFormatter } from '@dojo/framework/i18n/i18n';
 import bundle from 'nls/main';
 
 i18n(bundle, 'en').then(() => {
@@ -267,7 +243,7 @@ i18n(bundle, 'en').then(() => {
 
 **Note**: This feature requires CLDR data (see above).
 
-`@dojo/i18n` relies on [Globalize.js](https://github.com/jquery/globalize/blob/master/doc/api/message/message-formatter.md) for [ICU message formatting](http://userguide.icu-project.org/formatparse/messages), and as such all of the features offered by Globalize.js are available through `@dojo/i18n`.
+`@dojo/framework/i18n` relies on [Globalize.js](https://github.com/jquery/globalize/blob/master/doc/api/message/message-formatter.md) for [ICU message formatting](http://userguide.icu-project.org/formatparse/messages), and as such all of the features offered by Globalize.js are available through `@dojo/framework/i18n`.
 
 As an example, suppose there is a locale bundle with a `guestInfo` message:
 
@@ -298,10 +274,10 @@ export default messages;
 
 The above message can be converted directly with `formatMessage`, or `getMessageFormatter` can be used to generate a function that can be used over and over with different options. Note that the formatters created and used by both methods are cached, so there is no performance penalty from compiling the same message multiple times.
 
-Since the Globalize.js formatting methods use message paths rather than the message strings themselves, the `@dojo/i18n` methods also require that the bundle itself be provided, so its unique identifier can be resolved to a message path within the Globalize.js ecosystem. If an optional locale is provided, then the corresponding locale-specific message will be used. Otherwise, the current locale is assumed.
+Since the Globalize.js formatting methods use message paths rather than the message strings themselves, the `@dojo/framework/i18n` methods also require that the bundle itself be provided, so its unique identifier can be resolved to a message path within the Globalize.js ecosystem. If an optional locale is provided, then the corresponding locale-specific message will be used. Otherwise, the current locale is assumed.
 
 ```typescript
-import i18n, { formatMessage, getMessageFormatter } from '@dojo/i18n/i18n';
+import i18n, { formatMessage, getMessageFormatter } from '@dojo/framework/i18n/i18n';
 import bundle from 'nls/main';
 
 // 1. Load the messages for the locale.
@@ -334,14 +310,14 @@ i18n(bundle, 'en').then(() => {
 
 **Note**: This feature requires CLDR data (see above).
 
-As with the message formatting capabilities, `@dojo/i18n` relies on Globalize.js to provide locale-specific formatting for dates, times, currencies, numbers, and units. The formatters themselves are essentially light wrappers around their Globalize.js counterparts, which helps maintain consistency with the Dojo ecosystem and prevents the need to work with the `Globalize` object directly. Unlike the message formatters, the date, number, and unit formatters are not cached, as they have a more complex set of options. As such, executing the various "get formatter" methods multiple times with the same inputs does not return the exact same function object.
+As with the message formatting capabilities, `@dojo/framework/i18n` relies on Globalize.js to provide locale-specific formatting for dates, times, currencies, numbers, and units. The formatters themselves are essentially light wrappers around their Globalize.js counterparts, which helps maintain consistency with the Dojo ecosystem and prevents the need to work with the `Globalize` object directly. Unlike the message formatters, the date, number, and unit formatters are not cached, as they have a more complex set of options. As such, executing the various "get formatter" methods multiple times with the same inputs does not return the exact same function object.
 
-`@dojo/i18n` groups the various formatters accordingly: date and time formatters (`@dojo/i18n/date`); number, currency, and pluralization formatters (`@dojo/i18n/number`); and unit formatters (`@dojo/i18n/unit`). Each method corresponds to a Globalize.js method (see below), and each method follows the same basic format: the last argument is an optional locale, and the penultimate argument is the method options. If specifying a locale but no options, pass `null` as the `options` argument. If no locale is provided, then the current (`i18n.locale`) is assumed.
+`@dojo/framework/i18n` groups the various formatters accordingly: date and time formatters (`@dojo/framework/i18n/date`); number, currency, and pluralization formatters (`@dojo/framework/i18n/number`); and unit formatters (`@dojo/framework/i18n/unit`). Each method corresponds to a Globalize.js method (see below), and each method follows the same basic format: the last argument is an optional locale, and the penultimate argument is the method options. If specifying a locale but no options, pass `null` as the `options` argument. If no locale is provided, then the current (`i18n.locale`) is assumed.
 
 ```typescript
-import { formatDate, getDateFormatter, formatRelativeTime } from '@dojo/i18n/date';
-import { formatCurrency, getCurrencyFormatter } from '@dojo/i18n/number';
-import { formatUnit, getUnitFormatter } from '@dojo/i18n/unit';
+import { formatDate, getDateFormatter, formatRelativeTime } from '@dojo/framework/i18n/date';
+import { formatCurrency, getCurrencyFormatter } from '@dojo/framework/i18n/number';
+import { formatUnit, getUnitFormatter } from '@dojo/framework/i18n/unit';
 
 const date = new Date(1815, 11, 10, 11, 27);
 
@@ -376,7 +352,7 @@ frUnitFormatter(1000); // 1 000 mètres'
 formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 ```
 
-**`@dojo/i18n/date` methods:**
+**`@dojo/framework/i18n/date` methods:**
 
 - `formatDate` => [`Globalize.formatDate`](https://github.com/globalizejs/globalize/blob/master/doc/api/date/date-formatter.md)
 - `formatRelativeTime` => [`Globalize.formatRelativeTime`](https://github.com/globalizejs/globalize/blob/master/doc/api/relative-time/relative-time-formatter.md)
@@ -385,7 +361,7 @@ formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 - `getRelativeTimeFormatter` => [`Globalize.relativeTimeFormatter`](https://github.com/globalizejs/globalize/blob/master/doc/api/relative-time/relative-time-formatter.md)
 - `parseDate` => [`Globalize.parseDate`](https://github.com/globalizejs/globalize/blob/master/doc/api/date/date-parser.md)
 
-**`@dojo/i18n/number` methods:**
+**`@dojo/framework/i18n/number` methods:**
 
 - `formatCurrency` => [`Globalize.formatCurrency`](https://github.com/globalizejs/globalize/blob/master/doc/api/currency/currency-formatter.md)
 - `formatNumber` => [`Globalize.formatNumber`](https://github.com/globalizejs/globalize/blob/master/doc/api/number/number-formatter.md)
@@ -396,42 +372,10 @@ formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 - `parseNumber` => [`Globalize.parseNumber`](https://github.com/globalizejs/globalize/blob/master/doc/api/number/number-parser.md)
 - `pluralize` => [`Globalize.plural`](https://github.com/globalizejs/globalize/blob/master/doc/api/plural/plural-generator.md)
 
-**`@dojo/i18n/unit` methods:**
+**`@dojo/framework/i18n/unit` methods:**
 
 - `formatUnit` => [`Globalize.formatUnit`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)
 - `getUnitFormatter` => [`Globalize.unitFormatter`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)
-
-## How do I contribute?
-
-We appreciate your interest!  Please see the [Guidelines Repository](https://github.com/dojo/guidelines#readme) for the Contributing Guidelines.
-
-### Code Style
-
-This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the project's `package.json`.
-
-An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
-
-```bash
-npm run prettier
-```
-
-### Installation
-
-To start working with this package, clone the repository and run `npm install`.
-
-In order to build the project run `grunt dev` or `grunt dist`.
-
-### Testing
-
-Test cases MUST be written using Intern using the Object test interface and Assert assertion interface.
-
-90% branch coverage MUST be provided for all code submitted to this repository, as reported by istanbul’s combined coverage results for all supported platforms.
-
-## Licensing information
-
-* [Globalize.js](https://github.com/globalizejs/globalize) ([MIT](http://spdx.org/licenses/MIT))
-
-© 2018 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
 
 <!-- doc-viewer-config
 {

--- a/src/routing/README.md
+++ b/src/routing/README.md
@@ -1,12 +1,8 @@
-# @dojo/routing
+# routing
 
 <!-- start-github-only -->
 
-[![Build Status](https://travis-ci.org/dojo/routing.svg?branch=master)](https://travis-ci.org/dojo/routing)
-[![codecov.io](https://codecov.io/github/dojo/routing/coverage.svg?branch=master)](https://codecov.io/github/dojo/routing?branch=master)
-[![npm version](https://badge.fury.io/js/%40dojo%2Frouting.svg)](https://badge.fury.io/js/%40dojo%2Frouting)
-
-A routing library for Dojo applications.
+Routing for Dojo applications.
 
  - [Features](#features)
    - [Route Configuration](#route-configuration)
@@ -20,20 +16,6 @@ A routing library for Dojo applications.
    - [Link](#link)
 
 <!-- end-github-only -->
-
-## Usage
-
-To use `@dojo/routing`, install the package along with its required peer dependencies:
-
-```bash
-npm install @dojo/routing
-
-# peer dependencies
-npm install @dojo/core
-npm install @dojo/has
-npm install @dojo/shim
-npm install @dojo/widget-core
-```
 
 ## Features
 
@@ -52,7 +34,7 @@ Application routes are registered using a `RouteConfig`, which defines a route's
 Example routing configuration:
 
 ```ts
-import { RouteConfig } from '@dojo/routing/interfaces';
+import { RouteConfig } from '@dojo/framework/routing/interfaces';
 
 const config: RouteConfig[] = [
 	{
@@ -154,7 +136,7 @@ const router = new Router(config);
 The router will automatically be registered with a `HashHistory` history manager. This can be overridden by passing a different history manager as the second parameter.
 
 ```ts
-import { MemoryHistory } from '@dojo/routing/MemoryHistory';
+import { MemoryHistory } from '@dojo/framework/routing/MemoryHistory';
 
 const router = new Router(config, MemoryHistory);
 ```
@@ -188,11 +170,11 @@ const router = new Router(config, MemoryHistory);
 
 ##### Hash History
 
-The hash-based manager uses the fragment identifier to store navigation state and is the default manager used within `@dojo/routing`.
+The hash-based manager uses the fragment identifier to store navigation state and is the default manager used within `@dojo/framework/routing`.
 
 ```ts
-import { Router } from '@dojo/routing/Router';
-import { HashHistory } from '@dojo/routing/history/HashHistory';
+import { Router } from '@dojo/framework/routing/Router';
+import { HashHistory } from '@dojo/framework/routing/history/HashHistory';
 
 const router = new Router(config, HashHistory);
 ```
@@ -208,8 +190,8 @@ The state history uses the browser's history API, `pushState()` and `replaceStat
 The `MemoryHistory` does not rely on any browser API but keeps its own internal path state. It should not be used in production applications but is useful for testing routing.
 
 ```ts
-import { Router } from '@dojo/routing/Router';
-import { MemoryHistory } from '@dojo/routing/history/MemoryHistory';
+import { Router } from '@dojo/framework/routing/Router';
+import { MemoryHistory } from '@dojo/framework/routing/history/MemoryHistory';
 
 const router = new Router(config, MemoryHistory);
 ```
@@ -220,7 +202,7 @@ The `RouterInjector` module exports a helper function, `registerRouterInjector`,
 
 ```ts
 import { Registry } from '@dojo/widget-core/Registry';
-import { registerRouterInjector } from '@dojo/routing/RoutingInjector';
+import { registerRouterInjector } from '@dojo/framework/routing/RoutingInjector';
 
 const registry = new Registry();
 const router = registerRouterInjector(config, registry);
@@ -230,7 +212,7 @@ The defaults can be overridden using `RouterInjectorOptions`:
 
 ```ts
 import { Registry } from '@dojo/widget-core/Registry';
-import { registerRouterInjector } from '@dojo/routing/RoutingInjector';
+import { registerRouterInjector } from '@dojo/framework/routing/RoutingInjector';
 import { MemoryHistory } from './history/MemoryHistory';
 
 const registry = new Registry();
@@ -250,7 +232,7 @@ The number of widgets that can be mapped to a single outlet identifier is not re
 The following example configures a stateless widget with an outlet called `foo`. The resulting `FooOutlet` can be used in a widgets `render` in the same way as any other Dojo Widget.
 
 ```ts
-import { Outlet } from '@dojo/routing/Outlet';
+import { Outlet } from '@dojo/framework/routing/Outlet';
 import { MyViewWidget } from './MyViewWidget';
 
 const FooOutlet = Outlet(MyViewWidget, 'foo');
@@ -348,7 +330,7 @@ The `Link` component is a wrapper around an `a` DOM element that enables consume
 If the generated link requires specific path or query parameters that are not in the route, they can be passed via the `params` property.
 
 ```ts
-import { Link } from '@dojo/routing/Link';
+import { Link } from '@dojo/framework/routing/Link';
 
 render() {
 	return v('div', [
@@ -359,52 +341,6 @@ render() {
 ```
 
 All the standard `VNodeProperties` are available for the `Link` component as they would be creating an `a` DOM Element using `v()` with `@dojo/widget-core`.
-
-## How do I contribute?
-
-We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the Contributing Guidelines.
-
-### Code Style
-
-This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the project's `package.json`.
-
-An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
-
-```bash
-npm run prettier
-```
-
-### Installation
-
-To start working with this package, clone the repository and run `npm install`.
-
-In order to build the project run `grunt dev` or `grunt dist`.
-
-### Testing
-
-Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
-
-90% branch coverage MUST be provided for all code submitted to this repository, as reported by istanbul’s combined coverage results for all supported platforms.
-
-To test locally in node run:
-
-`grunt test`
-
-To test against browsers with a local selenium server run:
-
-`grunt test:local`
-
-To test against BrowserStack or Sauce Labs run:
-
-`grunt test:browserstack`
-
-or
-
-`grunt test:saucelabs`
-
-## Licensing information
-
-© 2018 [JS Foundation](https://js.foundation/) & contributors. [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
 
 <!-- doc-viewer-config
 {

--- a/src/shim/README.md
+++ b/src/shim/README.md
@@ -1,8 +1,4 @@
-# @dojo/shim
-
-[![Build Status](https://travis-ci.org/dojo/shim.svg?branch=master)](https://travis-ci.org/dojo/shim)
-[![codecov](https://codecov.io/gh/dojo/shim/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/shim)
-[![npm version](https://badge.fury.io/js/%40dojo%2Fshim.svg)](https://badge.fury.io/js/%40dojo%2Fshim)
+# shim
 
 This package provides functional shims for ECMAScript, access to the Typescript helpers, and a quick way to include the polyfills needed to run Dojo in the browser.
 
@@ -12,19 +8,10 @@ There are two exceptions to this. One is the `Promise` object, which needs to be
 
 ## Usage
 
-To use `@dojo/shim`, install the package along with its required peer dependencies:
-
-```bash
-npm install @dojo/shim
-
-# peer dependencies
-npm install @dojo/has
-```
-
 Include the module in your project to load the global shims and Typescript helpers.
 
 ```typescript
-import '@dojo/shim';
+import '@dojo/framework/shim';
 ```
 
 Since the main module loads the Typescript helpers, you'll want to turn off helper generation in your project. Add the following option to your `tsconfig.json`.
@@ -37,11 +24,11 @@ Since the main module loads the Typescript helpers, you'll want to turn off help
 }
 ```
 
-If you are using Dojo in the browser, you will want to load the browser polyfills. These are available by simply importing the `@dojo/shim/browser` module.
+If you are using Dojo in the browser, you will want to load the browser polyfills. These are available by simply importing the `@dojo/framework/shim/browser` module.
 
 ```typescript
 // load polyfills for features used by Dojo
-import '@dojo/shim/browser';
+import '@dojo/framework/shim/browser';
 ```
 
 *Note*: Other Dojo packages will include these dependencies.  You only need to worry about this if you are using this package stand alone.
@@ -69,21 +56,21 @@ Many of the features in this package will fallback to a native implementation if
 
 ### Array Methods
 
-[`@dojo/shim/array`](../../docs/shim/array.md) provides implementations of many array utilities.
+[`@dojo/framework/shim/array`](../../docs/shim/array.md) provides implementations of many array utilities.
 
 ### Data Structures
 
 #### Map
 
-The [`@dojo/shim/Map` class](../../docs/shim/Map.md) is an implementation of the ES2015 Map specification
+The [`@dojo/framework/shim/Map` class](../../docs/shim/Map.md) is an implementation of the ES2015 Map specification
 without iterators for use in older browsers.
 
 #### Set
 
-The `@dojo/shim/Set` class is an implementation of the [ES2015 Set specification](http://www.ecma-international.org/ecma-262/6.0/#sec-set-objects).  A Set is used to create a collection of unique values.
+The `@dojo/framework/shim/Set` class is an implementation of the [ES2015 Set specification](http://www.ecma-international.org/ecma-262/6.0/#sec-set-objects).  A Set is used to create a collection of unique values.
 
 ```typescript
-import Set from '@dojo/shim/Set';
+import Set from '@dojo/framework/shim/Set';
 
 const values = new Set<string>();
 values.add('one');
@@ -101,7 +88,7 @@ values.forEach((value) => {
 
 #### WeakMap
 
-The `@dojo/shim/WeakMap` class is an implementation of the ES2015 WeakMap specification
+The `@dojo/framework/shim/WeakMap` class is an implementation of the ES2015 WeakMap specification
 without iterators for use in older browsers. The main difference between WeakMap and Map
 is that WeakMap's keys can only be objects and that the store has a weak reference
 to the key/value pair. This allows for the garbage collector to remove pairs.
@@ -110,11 +97,11 @@ See the [Map](../../docs/shim/Map.md) documentation for more information on how 
 
 ### Iterators
 
-The `@dojo/shim/iterator` module is an implementation of the [ES2015 Iterator specification](http://www.ecma-international.org/ecma-262/6.0/#sec-iteration).
+The `@dojo/framework/shim/iterator` module is an implementation of the [ES2015 Iterator specification](http://www.ecma-international.org/ecma-262/6.0/#sec-iteration).
 
 ### Math
 
-The [`@dojo/shim/math`](../../docs/shim/math.md) module provides implementations for many math methods.
+The [`@dojo/framework/shim/math`](../../docs/shim/math.md) module provides implementations for many math methods.
 
 ### Number
 
@@ -138,65 +125,19 @@ The `dojo/shim/object` provides implementations of `Object` methods.
 
 ### Observables
 
-The [`@dojo/shim/Observable`](../../docs/shim/Observable.md) class is an implementation of the proposed [Observable specification](https://tc39.github.io/proposal-observable/).  Observables are further extended in [`@dojo/core/Observable`](https://github.com/dojo/core/blob/master/src/Observable.ts).
+The [`@dojo/framework/shim/Observable`](../../docs/shim/Observable.md) class is an implementation of the proposed [Observable specification](https://tc39.github.io/proposal-observable/).  Observables are further extended in [`@dojo/core/Observable`](https://github.com/dojo/core/blob/master/src/Observable.ts).
 
 ### Promises
 
-[`@dojo/shim/Promise`](../../docs/shim/Promise.md) is an implementation of the [ES2015 Promise specification](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects).
+[`@dojo/framework/shim/Promise`](../../docs/shim/Promise.md) is an implementation of the [ES2015 Promise specification](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects).
 
 ### String
 
-The [`@dojo/shim/string`](../../docs/shim/string.md) module contains `String` methods.
+The [`@dojo/framework/shim/string`](../../docs/shim/string.md) module contains `String` methods.
 
 ### Symbols
 
-`@dojo/shim/Symbol` provides an implementation of the [ES2015 Symbol specification](http://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects) for environments that do not natively support `Symbol`.
-
-## How do I contribute?
-
-We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the Contributing Guidelines.
-
-### Code Style
-
-This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the project's `package.json`.
-
-An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
-
-```bash
-npm run prettier
-```
-
-### Installation
-
-To start working with this package, clone the repository and run `npm install`.
-
-In order to build the project run `grunt dev` or `grunt dist`.
-
-### Testing
-
-Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
-
-90% branch coverage MUST be provided for all code submitted to this repository, as reported by istanbul’s combined coverage results for all supported platforms.
-
-To test locally in node run:
-
-`grunt test`
-
-To test against browsers with a local selenium server run:
-
-`grunt test:local`
-
-To test against BrowserStack or Sauce Labs run:
-
-`grunt test:browserstack`
-
-or
-
-`grunt test:saucelabs`
-
-## Licensing information
-
-© 2018 [JS Foundation](https://js.foundation/) & contributors. [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
+`@dojo/framework/shim/Symbol` provides an implementation of the [ES2015 Symbol specification](http://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects) for environments that do not natively support `Symbol`.
 
 <!-- doc-viewer-config
 {

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -1,24 +1,6 @@
-# @dojo/stores
+# stores
 
-[![Build Status](https://travis-ci.org/dojo/stores.svg?branch=master)](https://travis-ci.org/dojo/stores)
-[![codecov.io](https://codecov.io/gh/dojo/stores/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/stores/branch/master)
-[![npm version](https://badge.fury.io/js/%40dojo%2Fstores.svg)](https://badge.fury.io/js/%40dojo%2Fstores)
-
-This library provides an application store designed to complement @dojo/widgets and @dojo/widget-core or any other reactive application.
-
-## Usage
-
-To use `@dojo/stores`, install the package along with its required peer dependencies:
-
-```bash
-npm install @dojo/stores
-
-# peer dependencies
-npm install @dojo/core
-npm install @dojo/has
-npm install @dojo/shim
-npm install @dojo/widget-core
-```
+An application store designed to complement @dojo/widgets and @dojo/widget-core or any other reactive application.
 
 ## Features
 
@@ -46,10 +28,6 @@ npm install @dojo/widget-core
      - [Executing Concurrent Commands](#executing-concurrent-commands)
      - [Decorating Processes](#decorating-processes)
         - [Decorating Multiple Processes](#decorating-multiple-processes)
- - [How Do I Contribute?](#how-do-i-contribute)
-    - [Setup Installation](#setup-installation)
-    - [Testing](#testing)
- - [Licensing Information](#licensing-information)
 
 -----
 
@@ -57,17 +35,17 @@ npm install @dojo/widget-core
 
 ## Overview
 
-Dojo stores is a predictable, consistent state container for Javascript applications with inspiration from Redux and Flux architectures. However, the `@dojo/stores` package aims to provide more built-in support for common patterns such as asynchronous behaviors, undo support and **more**!
+Dojo stores is a predictable, consistent state container for Javascript applications with inspiration from Redux and Flux architectures. However, the `@dojo/framework/stores` package aims to provide more built-in support for common patterns such as asynchronous behaviors, undo support and **more**!
 
 Managing state can become difficult to coordinate when an application becomes complicated with multiple views, widgets, components, and models. With each of these attempting to update attributes of state at varying points within the application lifecycle things can get **confusing**. When state changes are hard to understand and/or non-deterministic it becomes increasingly difficult to identify and reproduce bugs or add new features.
 
-The `@dojo/stores` package provides a centralized store, designed to be the **single source of truth** for an application. It operates using uni-directional data flow. This means all application data follows the same lifecycle, ensuring the application logic is predictable and easy to understand.
+The `@dojo/framework/stores` package provides a centralized store, designed to be the **single source of truth** for an application. It operates using uni-directional data flow. This means all application data follows the same lifecycle, ensuring the application logic is predictable and easy to understand.
 
 __Note__: Do you need a centralized store? Lifting state up to parent widgets and using local state are likely to be sufficient in less complex applications.
 
 ## Basics
 
-To work with `@dojo/stores` there are three core but simple concepts - Operations, Commands, and Processes.
+To work with `@dojo/framework/stores` there are three core but simple concepts - Operations, Commands, and Processes.
 
  * `Operation`
    * Granular instructions to manipulate state based on JSON Patch
@@ -83,8 +61,8 @@ Operations are the raw instructions the store uses to make modifications to the 
 Dojo stores support four of the six JSON Patch operations: "add", "remove", "replace", and "test". The "copy" and "move" operations are not currently supported. Each operation is a simple object which contains instructions with the `OperationType`, `path` and optionally the `value` (depending on operation).
 
 ```ts
-import { OperationType } from '@dojo/stores/State/patch';
-import { Pointer } from '@dojo/stores/state/Pointer';
+import { OperationType } from '@dojo/framework/stores/State/patch';
+import { Pointer } from '@dojo/framework/stores/state/Pointer';
 
 const operations = [{
 	op: OperationType.ADD,
@@ -100,7 +78,7 @@ const operations = [{
 }];
 ```
 
-Dojo stores provides a helper package that can generate `PatchOperation` objects from `@dojo/stores/state/operations`:
+Dojo stores provides a helper package that can generate `PatchOperation` objects from `@dojo/framework/stores/state/operations`:
 
 * `add` - Returns a `PatchOperation` of type `OperationType.ADD` for the `path` and `value`
 * `remove`  - Returns a `PatchOperation` of type `OperationType.REMOVE` for the `path`
@@ -198,7 +176,7 @@ const calculateCountsCommand = createCommand(({ get, path }) => {
 });
 ```
 
- *Important:* Access to state root is not permitted and will throw an error, for example, `get(path('/'))`. This applies to `Operations` also, it is not possible to create an operation that will update the state root. Best practices with @dojo/stores mean touching the smallest part of the store as is necessary.
+ *Important:* Access to state root is not permitted and will throw an error, for example, `get(path('/'))`. This applies to `Operations` also, it is not possible to create an operation that will update the state root. Best practices with @dojo/framework/stores mean touching the smallest part of the store as is necessary.
 
 ##### Asynchronous Commands
 
@@ -380,15 +358,15 @@ store.on('invalidate', () => {
 
 ### Connecting Store Updates To Widgets
 
-Store data can be connected to widgets within your application using the [Containers & Injectors Pattern](../widget-core#containers--injectors) supported by `@dojo/widget-core`. The `@dojo/stores` package provides a specialized injector that invalidates store containers on two conditions:
+Store data can be connected to widgets within your application using the [Containers & Injectors Pattern](../widget-core#containers--injectors) supported by `@dojo/widget-core`. The `@dojo/framework/stores` package provides a specialized injector that invalidates store containers on two conditions:
 
 1. The recommended approach is to register `paths` on container creation to ensure invalidation will only occur when state you are interested in changes.
 2. A catch-all when no `paths` are defined for the container, it will invalidate when any data changes in the store.
 
 ```ts
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { Store } from '@dojo/stores/Stores';
-import { StoreContainer } from '@dojo/stores/StoreInjector';
+import { Store } from '@dojo/framework/stores/Stores';
+import { StoreContainer } from '@dojo/framework/stores/StoreInjector';
 
 interface State {
 	foo: string;
@@ -420,7 +398,7 @@ const Container = StoreContainer<State>(WidgetBase, 'state', { getProperties(sto
 }});
 ```
 
-Instead of typing `StoreContainer` for every usage, it is possible to create a pre-typed StoreContainer that can be used across your application. To do this use `createStoreContainer` from `@dojo/stores/StoreInjector` passing the stores state interface as the generic argument. The result of this can be exported and used across your application.
+Instead of typing `StoreContainer` for every usage, it is possible to create a pre-typed StoreContainer that can be used across your application. To do this use `createStoreContainer` from `@dojo/framework/stores/StoreInjector` passing the stores state interface as the generic argument. The result of this can be exported and used across your application.
 
 ```ts
 interface State {
@@ -582,53 +560,6 @@ const myCallbackDecorator = createCallbackDecorator(myCallback);
 // use the callback decorator as normal
 const myProcess = createProcess('my-process', [ commandOne ], myCallbackDecorator());
 ```
-
-## How do I contribute?
-
-We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines.
-
-### Code Style
-
-This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the project's `package.json`.
-
-An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
-
-```bash
-npm run prettier
-```
-
-### Installation
-
-To start working with this package, clone the repository and run `npm install`.
-
-In order to build the project run `grunt dev` or `grunt dist`.
-
-### Testing
-
-Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
-
-90% branch coverage MUST be provided for all code submitted to this repository, as reported by istanbul’s combined coverage results for all supported platforms.
-
-To test locally in node run:
-
-`grunt test`
-
-To test against browsers with a local selenium server run:
-
-`grunt test:local`
-
-To test against BrowserStack or Sauce Labs run:
-
-`grunt test:browserstack`
-
-or
-
-`grunt test:saucelabs`
-
-## Licensing information
-
-© 2018 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
 
 <!-- doc-viewer-config
 {

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -1,10 +1,6 @@
-# @dojo/test-extras
+# testing
 
-[![Build Status](https://travis-ci.org/dojo/test-extras.svg?branch=master)](https://travis-ci.org/dojo/test-extras)
-[![codecov](https://codecov.io/gh/dojo/test-extras/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/test-extras)
-[![npm version](https://badge.fury.io/js/%40dojo%2Ftest-extras.svg)](http://badge.fury.io/js/%40dojo%2Ftest-extras)
-
-Provides a simple API for testing and asserting Dojo widget's expected virtual DOM and behavior.
+Simple API for testing and asserting Dojo widget's expected virtual DOM and behavior.
 
 - [Features](#features)
 - [`harness`](#harness)
@@ -13,11 +9,6 @@ Provides a simple API for testing and asserting Dojo widget's expected virtual D
 - [`harness.expect`](#harnessexpect)
 - [`harness.expectPartial`](#harnessexpectpartial)
 - [`harness.trigger`](#harnesstrigger)
-- [How Do I Contribute?](#how-do-i-contribute)
-    - [Code Style](#code-style)
-    - [Setup Installation](#installation)
-    - [Testing](#testing)
-- [Licensing Information](#licensing-information)
 
 ## Features
 
@@ -28,7 +19,7 @@ Provides a simple API for testing and asserting Dojo widget's expected virtual D
 
 ## harness
 
-`harness()` is the primary API when working with `@dojo/test-extras`, essentially setting up each test and providing a context to perform virtual DOM assertions and interactions. Designed to mirror the core behavior for widgets when updating `properties` or `children` and widget invalidation, with no special or custom logic required.
+`harness()` is the primary API when working with `@dojo/framework/testing`, essentially setting up each test and providing a context to perform virtual DOM assertions and interactions. Designed to mirror the core behavior for widgets when updating `properties` or `children` and widget invalidation, with no special or custom logic required.
 
 ### API
 
@@ -241,50 +232,3 @@ const render = h.getRender();
 // Returns the result of the render for the index provided
 h.getRender(1);
 ```
-
-
-## How Do I Contribute?
-
-We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the Contributing Guidelines.
-
-### Code Style
-
-This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
-
-An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
-
-```bash
-npm run prettier
-```
-
-### Installation
-
-To start working with this package, clone the repository and run `npm install`.
-
-In order to build the project, run `grunt dev` or `grunt dist`.
-
-## Testing
-
-Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
-
-90% branch coverage MUST be provided for all code submitted to this repository, as reported by istanbul’s combined coverage results for all supported platforms.
-
-To test locally in node run:
-
-`grunt test`
-
-To test against browsers with a local selenium server run:
-
-`grunt test:local`
-
-To test against BrowserStack or Sauce Labs run:
-
-`grunt test:browserstack`
-
-or
-
-`grunt test:saucelabs`
-
-## Licensing information
-
-© 2018 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -1,8 +1,4 @@
-# @dojo/widget-core
-
-[![Build Status](https://travis-ci.org/dojo/widget-core.svg?branch=master)](https://travis-ci.org/dojo/widget-core)
-[![codecov](https://codecov.io/gh/dojo/widget-core/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/widget-core)
-[![npm version](https://badge.fury.io/js/%40dojo%2Fwidget-core.svg)](https://badge.fury.io/js/%40dojo%2Fwidget-core)
+# widget-core
 
 widget-core is a library to create powerful, composable user interface widgets.
 
@@ -13,7 +9,6 @@ widget-core is a library to create powerful, composable user interface widgets.
 
 -----
 
- - [Installation](#installation)
  - [Features](#features)
      - [Basic Widgets](#basic-widgets)
         - [Rendering a Widget in the DOM](#rendering-a-widget-in-the-dom)
@@ -37,26 +32,6 @@ widget-core is a library to create powerful, composable user interface widgets.
     - [Inserting DOM Nodes Into The VDom Tree](#inserting-dom-nodes-into-the-vdom-tree)
     - [JSX Support](#jsx-support)
     - [Web Components](#web-components)
-- [How Do I Contribute?](#how-do-i-contribute)
-    - [Setup Installation](#setup-installation)
-    - [Testing](#testing)
-- [Licensing Information](#licensing-information)
-
-## Installation
-
-To use @dojo/widget-core, install the package along with its required peer dependencies:
-
-```shell
-npm install @dojo/widget-core
-
-# peer dependencies
-npm install @dojo/has
-npm install @dojo/shim
-npm install @dojo/core
-npm install @dojo/i18n
-```
-
-You can also use the [dojo cli](https://github.com/dojo/cli) to create a complete Dojo skeleton application.
 
 ## Features
 
@@ -64,7 +39,7 @@ You can also use the [dojo cli](https://github.com/dojo/cli) to create a complet
 
 Dojo applications use the Virtual DOM (vdom) paradigm to represent what should be shown on the view. These vdom nodes are plain JavaScript objects that are more efficient to create from a performance perspective than browser DOM elements. Dojo uses these vdom elements to synchronize and update the browser DOM so that the application shows the expected view.
 
-There are two types of vdom within Dojo. The first type provides a pure representation of DOM elements, the fundamental building blocks of all Dojo applications. These are called `VNode`s and are created using the `v()` function available from the `@dojo/widget-core/d` module.
+There are two types of vdom within Dojo. The first type provides a pure representation of DOM elements, the fundamental building blocks of all Dojo applications. These are called `VNode`s and are created using the `v()` function available from the `@dojo/framework/widget-core/d` module.
 
 The following will create a `VNode` that represents a simple `div` DOM element, with a text node child: `Hello, Dojo!`:
 
@@ -72,7 +47,7 @@ The following will create a `VNode` that represents a simple `div` DOM element, 
 v('div', [ 'Hello, Dojo!' ])
 ```
 
-The second vdom type, `WNode`, represent widgets. A widget is a class that extends `WidgetBase` from `@dojo/widget-core/WidgetBase` and implements a `render` function that returns one of the Dojo vdom types (known as a `DNode`). Widgets are used to represent reusable, independent sections of a Dojo application.
+The second vdom type, `WNode`, represent widgets. A widget is a class that extends `WidgetBase` from `@dojo/framework/widget-core/WidgetBase` and implements a `render` function that returns one of the Dojo vdom types (known as a `DNode`). Widgets are used to represent reusable, independent sections of a Dojo application.
 
 The following returns the `VNode` example from above from the `render` function:
 
@@ -86,7 +61,7 @@ class HelloDojo extends WidgetBase {
 
 #### Rendering a Widget in the DOM
 
-To display your new component in the view you will need to decorate it with some functionality needed to "project" the widget into the browser. This is done using the `ProjectorMixin` from `@dojo/widget-core/mixins/Projector`.
+To display your new component in the view you will need to decorate it with some functionality needed to "project" the widget into the browser. This is done using the `ProjectorMixin` from `@dojo/framework/widget-core/mixins/Projector`.
 
 ```ts
 const Projector = ProjectorMixin(HelloDojo);
@@ -117,7 +92,7 @@ projector.append(root);
 
 We have created a widget used to project our `VNode`s into the DOM, however, widgets can be composed of other widgets and `properties` which are used to determine if a widget needs to be re-rendered.
 
-Properties are available on the widget instance, defined by an interface and passed as a [`generic`](https://www.typescriptlang.org/docs/handbook/generics.html) to the `WidgetBase` class when creating your custom widget. The properties interface should extend the base `WidgetProperties` provided from `@dojo/widget-core/interfaces`:
+Properties are available on the widget instance, defined by an interface and passed as a [`generic`](https://www.typescriptlang.org/docs/handbook/generics.html) to the `WidgetBase` class when creating your custom widget. The properties interface should extend the base `WidgetProperties` provided from `@dojo/framework/widget-core/interfaces`:
 
 ```ts
 interface MyProperties extends WidgetProperties {
@@ -139,7 +114,7 @@ New properties are compared with the previous properties to determine if a widge
 
 As mentioned, often widgets are composed of other widgets in their `render` output. This promotes widget reuse across an application (or multiple applications) and promotes widget best practices.
 
-To compose widgets, we need to create `WNode`s and we can do this using the `w()` function from `@dojo/widget-core/d`.
+To compose widgets, we need to create `WNode`s and we can do this using the `w()` function from `@dojo/framework/widget-core/d`.
 
 Consider the previous `Hello` widget that we created:
 
@@ -444,7 +419,7 @@ export default class AnimatedWidget extends WidgetBase {
 
 #### Overview
 
-Dojo widget-core provides `ThemedMixin` to decorate a widget with theming functionality and a `@theme` decorator to specify the classes available to the widget. Both `ThemedMixin` and `@theme` are provided by `@dojo/widget-core/mixins/Themed`.
+Dojo widget-core provides `ThemedMixin` to decorate a widget with theming functionality and a `@theme` decorator to specify the classes available to the widget. Both `ThemedMixin` and `@theme` are provided by `@dojo/framework/widget-core/mixins/Themed`.
 
 To specify the theme classes for a widget, an interface needs to be imported with named exports for each class and passed to the `@theme` decorator. Importing the interface provides IntelliSense / auto-complete for the class names and passing this via the `@theme` decorator informs the `ThemedMixin` which classes can be themed.
 
@@ -467,7 +442,7 @@ The following example passes `css.root` that will be themeable and `css.rootFixe
 
 ```typescript
 import * as css from './styles/myWidget.m.css';
-import { ThemedMixin, theme } from '@dojo/widget-core/mixins/Themed';
+import { ThemedMixin, theme } from '@dojo/framework/widget-core/mixins/Themed';
 
 @theme(css)
 export default class MyWidget extends ThemedMixin(WidgetBase) {
@@ -542,7 +517,7 @@ In the above example, the tabPanel will receive its original `root` class in add
 
 ### Internationalization
 
-Widgets can be internationalized by adding the `I18nMixin` mixin from `@dojo/widget-core/mixins/I18n`. [Message bundles](https://github.com/dojo/i18n) are localized by passing them to `localizeBundle`. Note that with this pattern it is possible for a widget to obtain its messages from multiple bundles; however, we strongly recommend limiting widgets to a single bundle whenever possible.
+Widgets can be internationalized by adding the `I18nMixin` mixin from `@dojo/framework/widget-core/mixins/I18n`. [Message bundles](https://github.com/dojo/i18n) are localized by passing them to `localizeBundle`. Note that with this pattern it is possible for a widget to obtain its messages from multiple bundles; however, we strongly recommend limiting widgets to a single bundle whenever possible.
 
 If the bundle supports the widget's current locale, but those locale-specific messages have not yet been loaded, then a bundle of blank message values is returned. Alternatively, the `localizeBundle` method accepts a second boolean argument, which, when `true`, causes the default messages to be returned instead of the blank bundle. The widget will be invalidated once the locale-specific messages have been loaded, triggering a re-render with the localized message content.
 
@@ -625,7 +600,7 @@ These are some of the **important** principles to keep in mind when creating and
    - The Dojo widget system manages all instances required including caching and destruction, trying to create and manage other widgets will cause issues and will not work as expected.
 3. **Never** update `properties` within a widget instance, they should be considered pure.
    - Properties are considered read-only and should not be updated within a widget instance, updating properties could cause unexpected behavior and introduce bugs in your application.
-4. Hyperscript should **always** be written using the `@dojo/widget-core/d#v()` function.
+4. Hyperscript should **always** be written using the `@dojo/framework/widget-core/d#v()` function.
    - The widget-core abstraction for Hyperscript is the only type of vdom that widget-core can process for standard DOM elements, any other mechanism will not work properly or at all.
 
 ## Advanced Concepts
@@ -634,7 +609,7 @@ This section provides some details on more advanced Dojo functionality and confi
 
 ### Handling Focus
 
-Handling focus is an important aspect in any application and can be tricky to do correctly. To help with this issue, `@dojo/widget-core` provides a primitive mechanism built into the Virtual DOM system that enables users to focus a Virtual DOM node once it has been appended to the DOM. This uses a special property called `focus` on the `VNodeProperties` interface that can be passed when using `v()`. The `focus` property is either a `boolean` or a function that returns a `boolean`.
+Handling focus is an important aspect in any application and can be tricky to do correctly. To help with this issue, `@dojo/framework/widget-core` provides a primitive mechanism built into the Virtual DOM system that enables users to focus a Virtual DOM node once it has been appended to the DOM. This uses a special property called `focus` on the `VNodeProperties` interface that can be passed when using `v()`. The `focus` property is either a `boolean` or a function that returns a `boolean`.
 
 When passing a function, focus will be called when `true` is returned without comparing the value of the previous result. However, when passing a `boolean`, focus will only be applied if the property is `true` and the previous property value was not.
 
@@ -705,7 +680,7 @@ An example usage controlling focus across child VNodes (DOM) and WNodes (widgets
 					v('button', { onclick: this._next }, ['Next']),
 					// `this.shouldFocus` is passed to the child that requires focus based on
 					// some widget logic. If the child is a widget it can then deal with that
-					// in whatever manner is necessary. The widget may also have internal 
+					// in whatever manner is necessary. The widget may also have internal
 					// logic and pass its own `this.shouldFocus` down further or it could apply
 					// directly to a VNode child.
 					w(FocusInputChild, {
@@ -744,7 +719,7 @@ See this [focus example on codesandbox.io](https://codesandbox.io/s/ox5y97vqz5).
 
 Controlling the diffing strategy can be done at an individual property level using the `diffProperty` decorator on a widget class.
 
-`widget-core` provides a set of diffing strategy functions from `@dojo/widget-core/diff.ts` that can be used. When these functions do not provide the required functionality a custom diffing function can be provided. Properties that have been configured with a specific diffing type will be excluded from the automatic diffing.
+`widget-core` provides a set of diffing strategy functions from `@dojo/framework/widget-core/diff.ts` that can be used. When these functions do not provide the required functionality a custom diffing function can be provided. Properties that have been configured with a specific diffing type will be excluded from the automatic diffing.
 
 | Diff Function                 | Description                                                                       |
 | -------------------- | ----------------------------------------------------------------------------------|
@@ -826,7 +801,7 @@ The `Registry` provides a mechanism to define widgets and injectors (see the [`C
 A main registry can be provided to the `projector`, which will be automatically passed to all widgets within the tree (referred to as `baseRegistry`). Each widget also gets access to a private `Registry` instance that can be used to define registry items that are scoped to the widget. The locally defined registry items are considered a higher precedence than an item registered in the `baseRegistry`.
 
 ```ts
-import { Registry } from '@dojo/widget-core/Registry';
+import { Registry } from '@dojo/framework/widget-core/Registry';
 
 import { MyWidget } from './MyWidget';
 import { MyAppContext } from './MyAppContext';
@@ -1023,7 +998,7 @@ To connect the registered `payload` to a widget, we can use the `Container` HOC 
 `getProperties` receives the `payload` returned from the injector function and the `properties` passed to the container HOC component. These are used to map into the wrapped widget's properties.
 
 ```ts
-import { Container } from '@dojo/widget-core/Container';
+import { Container } from '@dojo/framework/widget-core/Container';
 import { MyWidget } from './MyWidget';
 
 function getProperties(payload: any, properties: any) {
@@ -1138,10 +1113,10 @@ The Intersection Meta provides information on whether a Node is visible in the a
 This example renders a list with images, the image src is only added when the item is in the viewport which prevents needlessly downloading images until the user scrolls to them:
 
 ```ts
-import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { v, w } from '@dojo/widget-core/d';
-import { DNode } from '@dojo/widget-core/interfaces';
-import { Intersection } from '@dojo/widget-core/meta/Intersection';
+import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { v, w } from '@dojo/framework/widget-core/d';
+import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { Intersection } from '@dojo/framework/widget-core/meta/Intersection';
 
 // Add image URLs here to load
 const images = [];
@@ -1385,7 +1360,7 @@ class TestWidget extends WidgetBase<WidgetProperties> {
 You can create your own meta if you need access to DOM nodes.
 
 ```typescript
-import MetaBase from "@dojo/widget-core/meta/Base";
+import MetaBase from "@dojo/framework/widget-core/meta/Base";
 
 class HtmlMeta extends MetaBase {
     get(key: string): string {
@@ -1420,7 +1395,7 @@ Extending the base class found in `meta/Base` will provide the following functio
 Meta classes that require extra options should accept them in their methods.
 
 ```typescript
-import MetaBase from "@dojo/widget-core/meta/Base";
+import MetaBase from "@dojo/framework/widget-core/meta/Base";
 
 interface IsTallMetaOptions {
     minHeight: number;
@@ -1470,7 +1445,7 @@ const vnode = dom({
 
 ### JSX Support
 
-In addition to creating widgets functionally using the `v()` and `w()` functions from `@dojo/widget-core/d`, Dojo optionally supports the use of the `jsx` syntax known as [`tsx`](https://www.typescriptlang.org/docs/handbook/jsx.html) in TypeScript.
+In addition to creating widgets functionally using the `v()` and `w()` functions from `@dojo/framework/widget-core/d`, Dojo optionally supports the use of the `jsx` syntax known as [`tsx`](https://www.typescriptlang.org/docs/handbook/jsx.html) in TypeScript.
 
 To start to use `jsx` in your project, widgets need to be named with a `.tsx` extension and some configuration is required in the project's `tsconfig.json`:
 
@@ -1493,7 +1468,7 @@ Include `.tsx` files in the project:
 Once the project is configured, `tsx` can be used in a widget's `render` function simply by importing the `tsx` function as:
 
 ```ts
-import { tsx } from '@dojo/widget-core/tsx';
+import { tsx } from '@dojo/framework/widget-core/tsx';
 ```
 
 ```tsx
@@ -1546,8 +1521,8 @@ class MyWidget extends WidgetBase<MyWidgetProperties> {
 Custom Elements in all browsers supported by Dojo, a polyfill needs to be
 included such as webcomponents/custom-elements/master/custom-elements.min.js.
 Dojo does not include the polyfill by default, so will need to be
-added as a script tag in your index.html. Note that this polyfill cannot 
-currently be ponyfilled like other polyfills used in Dojo, so it cannot 
+added as a script tag in your index.html. Note that this polyfill cannot
+currently be ponyfilled like other polyfills used in Dojo, so it cannot
 be added with @dojo/shim/browser or imported using ES modules.
 
 No additional steps are required. The custom element
@@ -1616,57 +1591,3 @@ The initialization function is run from the context of the HTML element.
 ```
 
 It should be noted that children nodes are removed from the DOM when attached, and added as children to the widget instance.
-
-## How Do I Contribute?
-
-We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the Contributing Guidelines.
-
-### Code Style
-
-This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the project's `package.json`.
-
-An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
-
-```bash
-npm run prettier
-```
-
-### Setup Installation
-
-To start working with this package, clone the repository and run `npm install`.
-
-In order to build the project, run `grunt dev` or `grunt dist`.
-
-### Testing
-
-Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
-
-90% branch coverage MUST be provided for all code submitted to this repository, as reported by Istanbul’s combined coverage results for all supported platforms.
-
-To test locally in node run:
-
-`grunt test`
-
-To test against browsers with a local selenium server run:
-
-`grunt test:local`
-
-To test against BrowserStack or Sauce Labs run:
-
-`grunt test:browserstack`
-
-or
-
-`grunt test:saucelabs`
-
-### Benchmarks
-
-To run the JavaScript benchmarks, run:
-
-`npm run benchmark`
-
-The benchmarking setup relies heavily on [js-framework-benchmark](https://github.com/krausest/js-framework-benchmark) from GitHub.
-
-## Licensing Information
-
-© 2018 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

* Updates all readme code references to use the new `@dojo/framework` import path
* Removes all the legacy badges from READMEs
* Removes contributing section the inner READMEs
* Removes the incorrect installation instructions
