### PR TITLE
Abort controller signal to request and AbortController/AbortSignal shims

### DIFF
--- a/src/core/request/interfaces.d.ts
+++ b/src/core/request/interfaces.d.ts
@@ -1,3 +1,4 @@
+import { AbortSignal } from '../../shim/AbortController';
 import { IterableIterator } from '../../shim/iterator';
 import Task from '../async/Task';
 import UrlSearchParams, { ParamList } from '../UrlSearchParams';
@@ -57,6 +58,10 @@ export interface RequestOptions {
 	 * Password for HTTP authentication
 	 */
 	password?: string;
+	/**
+	 * Abort signal, allowing for cancelable requests
+	 */
+	signal?: AbortSignal;
 	/**
 	 * Number of milliseconds before the request times out and is canceled
 	 */

--- a/src/shim/AbortController.ts
+++ b/src/shim/AbortController.ts
@@ -1,0 +1,109 @@
+import global from './global';
+import has from './support/has';
+import { findIndex } from './array';
+
+export interface AbortSignal extends EventTarget {
+	aborted: boolean;
+	onabort: (ev: Event) => any;
+}
+
+export interface AbortSignalConstructor {
+	readonly prototype: AbortSignal;
+	new (): AbortSignal;
+}
+
+// tslint:disable-next-line variable-name
+export let ShimAbortSignal: AbortSignalConstructor = global.AbortSignal;
+
+if (!has('abort-signal')) {
+	global.AbortSignal = ShimAbortSignal = class implements AbortSignal {
+		private _aborted = false;
+		onabort: (ev: Event) => any;
+
+		listeners: { [type: string]: ((event: Event) => void)[] } = {};
+
+		get aborted(): boolean {
+			return this._aborted;
+		}
+
+		addEventListener(type: string, callback: (event: Event) => void): void {
+			if (!(type in this.listeners)) {
+				this.listeners[type] = [];
+			}
+			this.listeners[type].push(callback);
+		}
+
+		removeEventListener(type: string, callback: (event: any) => void): void {
+			if (!(type in this.listeners)) {
+				return;
+			}
+
+			const index = findIndex(this.listeners[type], (cb: (event: any) => void) => cb === callback);
+
+			if (index >= 0) {
+				this.listeners[type].splice(index, 1);
+			}
+		}
+
+		dispatchEvent(event: Event): boolean {
+			const { type } = event;
+			if (type === 'abort') {
+				this._aborted = true;
+				if (typeof this.onabort === 'function') {
+					this.onabort.call(this, event);
+				}
+			}
+
+			if (!(type in this.listeners)) {
+				return false;
+			}
+
+			this.listeners[type].forEach((callback: (event: any) => void) => {
+				setTimeout(() => callback.call(this, event));
+			});
+
+			return !event.preventDefault;
+		}
+	};
+}
+
+export interface AbortController {
+	readonly signal: AbortSignal;
+	abort(): void;
+}
+
+export interface AbortControllerConstructor {
+	readonly prototype: AbortController;
+	new (): AbortController;
+}
+
+// tslint:disable-next-line variable-name
+export let ShimAbortController: AbortControllerConstructor = global.AbortController;
+
+if (!has('abort-controller')) {
+	global.AbortController = ShimAbortController = class implements AbortController {
+		readonly signal: AbortSignal = new ShimAbortSignal();
+
+		abort(): void {
+			let event: Event;
+			try {
+				event = new Event('abort');
+			} catch (e) {
+				if (typeof document !== 'undefined') {
+					event = document.createEvent('Event');
+					event.initEvent('abort', false, false);
+				} else {
+					event = {
+						type: 'abort',
+						bubbles: false,
+						cancelable: false
+					} as Event;
+				}
+			}
+
+			this.signal.dispatchEvent(event);
+		}
+	};
+}
+
+export default ShimAbortController;

--- a/src/shim/support/has.ts
+++ b/src/shim/support/has.ts
@@ -263,3 +263,7 @@ add(
 	() => has('host-browser') && global.Animation !== undefined && global.KeyframeEffect !== undefined,
 	true
 );
+
+add('abort-controller', () => typeof global.AbortController !== 'undefined');
+
+add('abort-signal', () => typeof global.AbortSignal !== 'undefined');

--- a/tests/core/unit/request/node.ts
+++ b/tests/core/unit/request/node.ts
@@ -7,6 +7,7 @@ import * as zlib from 'zlib';
 import { Response } from '../../../../src/core/request/interfaces';
 import { default as nodeRequest, NodeResponse } from '../../../../src/core/request/providers/node';
 import TimeoutError from '../../../../src/core/request/TimeoutError';
+import AbortController from '../../../../src/shim/AbortController';
 
 const serverPort = 8124;
 const serverUrl = 'http://localhost:' + serverPort;
@@ -461,6 +462,20 @@ registerSuite('request/node', {
 					}),
 					dfd.reject.bind(dfd)
 				);
+			},
+
+			signal(this: any) {
+				const dfd = this.async();
+				const url = getRequestUrl('foo.json');
+				const controller = new AbortController();
+				const { signal } = controller;
+				const request = nodeRequest(url, { signal });
+				request.catch(
+					dfd.callback((error: Error) => {
+						assert.strictEqual(error.name, 'AbortError');
+					})
+				);
+				controller.abort();
 			},
 
 			'user and password': {

--- a/tests/core/unit/request/xhr.ts
+++ b/tests/core/unit/request/xhr.ts
@@ -1,6 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
+import AbortController from '../../../../src/shim/AbortController';
 import xhrRequest, { XhrResponse } from '../../../../src/core/request/providers/xhr';
 import { Response } from '../../../../src/core/request/interfaces';
 import UrlSearchParams from '../../../../src/core/UrlSearchParams';
@@ -102,6 +103,23 @@ registerSuite('request/providers/xhr', {
 						assert.strictEqual(error.name, 'TimeoutError');
 					}
 				);
+			},
+
+			'"signal"'(this: any) {
+				if (!echoServerAvailable) {
+					this.skip('No echo server available');
+				}
+				const dfd = this.async();
+				const controller = new AbortController();
+				const { signal } = controller;
+				const request = xhrRequest('/__echo/foo.json', { signal, timeout: 100 });
+				request.catch(
+					dfd.callback((error: Error) => {
+						assert.strictEqual(error.name, 'AbortError');
+					})
+				);
+
+				controller.abort();
 			},
 
 			'user and password'(this: any) {

--- a/tests/shim/unit/AbortController.ts
+++ b/tests/shim/unit/AbortController.ts
@@ -1,0 +1,111 @@
+import { AbortController, AbortSignal, ShimAbortController, ShimAbortSignal } from '../../../src/shim/AbortController';
+
+let controller: AbortController;
+let signal: AbortSignal;
+
+import has from '../../../src/shim/support/has';
+
+const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
+
+registerSuite('AbortController and AbortSignal', {
+	beforeEach() {
+		controller = new ShimAbortController();
+		signal = controller.signal;
+	},
+	tests: {
+		'native AbortController'() {
+			if (!has('abort-controller')) {
+				this.skip('checking native implementation');
+			}
+			assert.include(
+				ShimAbortController.toString(),
+				'native',
+				'native implementation should represent native code'
+			);
+		},
+
+		'native AbortSignal'() {
+			if (!has('abort-signal')) {
+				this.skip('checking native implementation');
+			}
+			assert.include(ShimAbortSignal.toString(), 'native', 'native implementation should represent native code');
+		},
+
+		'AbortController defaults'() {
+			assert.isFunction(controller.abort, 'should provide an `abort` method');
+			assert.isDefined(controller.signal, 'should provide a signal property');
+		},
+
+		'AbortSignal defaults'() {
+			assert.isFalse(signal.aborted);
+			assert.notExists(signal.onabort);
+		},
+
+		'abort event'() {
+			const dfd = this.async();
+			signal.addEventListener(
+				'abort',
+				dfd.callback((event: Event) => {
+					assert.strictEqual(event.type, 'abort');
+					assert.isTrue(signal.aborted);
+				})
+			);
+			controller.abort();
+		},
+
+		'onabort method callback'() {
+			const dfd = this.async();
+			signal.onabort = dfd.callback((event: Event) => {
+				assert.strictEqual(event.type, 'abort');
+			});
+			controller.abort();
+		},
+
+		'remove event listener'() {
+			let called = false;
+			const callback = () => (called = true);
+			signal.addEventListener('abort', callback);
+			signal.removeEventListener('abort', callback);
+			controller.abort();
+			assert.isFalse(called, 'callback should not have been called');
+		},
+
+		'dispatch event'() {
+			return new Promise((resolve) => {
+				let called = 0;
+				const expectedCalls = 2;
+				const createEvent = (type: string) => {
+					let event: Event;
+					try {
+						event = new Event(type);
+					} catch (e) {
+						if (typeof document !== 'undefined') {
+							event = document.createEvent('Event');
+							event.initEvent(type, false, false);
+						}
+						else {
+							event = {
+								type,
+								bubbles: false,
+								cancelable: false
+							} as Event;
+						}
+					}
+					return event;
+				};
+				const callback = () => {
+					called++;
+					if (called === expectedCalls) {
+						assert.strictEqual(called, 2, 'should be called twice');
+						resolve();
+					}
+				};
+				signal.onabort = callback;
+				signal.addEventListener('abort', callback);
+				signal.dispatchEvent(createEvent('test'));
+				signal.dispatchEvent(createEvent('abort'));
+			});
+		}
+	}
+});

--- a/tests/shim/unit/all.ts
+++ b/tests/shim/unit/all.ts
@@ -4,6 +4,7 @@ import './support/decorators';
 import './support/has';
 import './support/queue';
 import './support/util';
+import './AbortController';
 import './array';
 import './global';
 import './iterator';

--- a/tests/shim/unit/support/has.ts
+++ b/tests/shim/unit/support/has.ts
@@ -26,7 +26,9 @@ registerSuite('support/has', {
 			'microtasks',
 			'postmessage',
 			'raf',
-			'setimmediate'
+			'setimmediate',
+			'abort-controller',
+			'abort-signal'
 		].forEach((feature) => assert.isTrue(exists(feature)));
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves dojo/core#390

add support for a `signal: AbortSignal` property in the request options. When provided, the request can be aborted by calling the `AbortController#abort` method, similar to the fetch API. When a request is aborted, the `Promise` is rejected with an `AbortError`, if possible.