### PR TITLE
hook up credentials RequestOptions to xhr

### DIFF
--- a/src/core/request/interfaces.d.ts
+++ b/src/core/request/interfaces.d.ts
@@ -41,6 +41,12 @@ export interface RequestOptions {
 	 * requested URL
 	 */
 	cacheBust?: boolean;
+	/**
+	 * Cause browsers to send a request with credentials included.
+	 * 'same-origin' - (default) Only send credentials for same origin
+	 * 'omit' - Do not send credentials
+	 * 'include' - Include credentials for cross-domain requests
+	 */
 	credentials?: 'omit' | 'same-origin' | 'include';
 	/**
 	 * Body to send along with the http request

--- a/src/core/request/providers/xhr.ts
+++ b/src/core/request/providers/xhr.ts
@@ -194,6 +194,14 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 		options.method = 'GET';
 	}
 
+	const { credentials = 'same-origin' } = options;
+
+	if (credentials === 'include') {
+		request.withCredentials = true;
+	} else if (credentials === 'omit') {
+		request.withCredentials = false;
+	}
+
 	let isAborted = false;
 
 	function abort() {

--- a/tests/core/unit/request/xhr.ts
+++ b/tests/core/unit/request/xhr.ts
@@ -135,6 +135,18 @@ registerSuite('request/providers/xhr', {
 				});
 			},
 
+			async credentials(this: any) {
+				if (!echoServerAvailable) {
+					this.skip('No echo server available');
+				}
+				const makeRequest = async (credentials: 'include' | 'omit' | 'same-origin') =>
+					await xhrRequest('/__echo/foo.json', { credentials });
+
+				assert.isTrue((await makeRequest('include')).nativeResponse.withCredentials);
+				assert.isFalse((await makeRequest('omit')).nativeResponse.withCredentials);
+				assert.isFalse((await makeRequest('same-origin')).nativeResponse.withCredentials);
+			},
+
 			'upload monitoring'(this: any) {
 				if (!echoServerAvailable) {
 					this.skip('No echo server available');


### PR DESCRIPTION
Hook up credentials ReqestOptions option to tie into XHR's
withCredentials option

**Type:** bug / missing feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`RequestOptions` currently has a `credentials` option, but it's not hooked up to anything. This PR changes that and ties it into the underlying XHR's `withCredentials` property.
