### PR TITLE
Add pragma to merge properties and replace children onto an existing vnode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-kEyKjH/HRMf7rXxFiOvM0Lco8fPcoGtECZx8kr2tskgrIBPN8F3aaRTT8GZ9duUjoIp953RK8ggbMzBt7+ap+Q==",
       "dev": true,
       "requires": {
-        "tslib": "~1.8.1"
+        "tslib": "1.8.1"
       }
     },
     "@dojo/has": {
@@ -25,7 +25,7 @@
       "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
       "dev": true,
       "requires": {
-        "@types/yargs": "^8.0.2"
+        "@types/yargs": "8.0.3"
       }
     },
     "@dojo/loader": {
@@ -40,15 +40,15 @@
       "integrity": "sha512-XpP//+d0HKSbzm3c3BV3oYJN+jWxofLQ7UONoHkctIBhLHVyizWQw6GCwiLPaiedDhdUIoF4rDs+yYeseKmdow==",
       "dev": true,
       "requires": {
-        "chalk": "~2.4.0",
-        "intern": "~4.2.0",
-        "parse-git-config": "~2.0.2",
+        "chalk": "2.4.1",
+        "intern": "4.2.2",
+        "parse-git-config": "2.0.2",
         "prettier": "1.13.7",
-        "rxjs": "^5.5.6",
-        "tslint": "~5.11.0",
-        "tslint-language-service": "~0.9.9",
-        "typescript": "~2.6.2",
-        "yargs": "~10.1.2"
+        "rxjs": "5.5.11",
+        "tslint": "5.11.0",
+        "tslint-language-service": "0.9.9",
+        "typescript": "2.6.2",
+        "yargs": "10.1.2"
       }
     },
     "@dojo/shim": {
@@ -59,7 +59,7 @@
       "requires": {
         "intersection-observer": "0.4.2",
         "pepjs": "0.4.2",
-        "tslib": "~1.8.0",
+        "tslib": "1.8.1",
         "web-animations-js": "2.3.1"
       }
     },
@@ -78,14 +78,14 @@
       "integrity": "sha512-r1QjsLCeBk6UiK2nA6g3P+nc5V/drSU6w8zmvEWIsCl397xog1h6yEovu8V9KVjISL2LbyyOLEGGnNDSlEpcVQ==",
       "dev": true,
       "requires": {
-        "@dojo/core": "~2.0.0",
-        "@dojo/has": "~2.0.0",
-        "@dojo/interfaces": "~0.2.0",
-        "@dojo/shim": "~2.0.0",
-        "command-exists": "~1.2.6",
-        "decompress": "~4.2.0",
-        "semver": "~5.5.0",
-        "tslib": "~1.9.0"
+        "@dojo/core": "2.0.0",
+        "@dojo/has": "2.0.0",
+        "@dojo/interfaces": "0.2.1",
+        "@dojo/shim": "2.0.0",
+        "command-exists": "1.2.7",
+        "decompress": "4.2.0",
+        "semver": "5.5.0",
+        "tslib": "1.9.3"
       },
       "dependencies": {
         "@dojo/core": {
@@ -94,7 +94,7 @@
           "integrity": "sha512-iojqMIn49L/bwv/Ryy2v7qKeioHxjHQqJNLhEXBJ+zJoQ47IeG92Y5tmdGsZ6SKZk6sFuWHl7gL9Wbw0qVySHw==",
           "dev": true,
           "requires": {
-            "tslib": "~1.8.1"
+            "tslib": "1.8.1"
           },
           "dependencies": {
             "tslib": {
@@ -119,7 +119,7 @@
           "requires": {
             "intersection-observer": "0.4.2",
             "pepjs": "0.4.2",
-            "tslib": "~1.8.0",
+            "tslib": "1.8.1",
             "web-animations-js": "2.3.1"
           },
           "dependencies": {
@@ -145,13 +145,13 @@
       "integrity": "sha512-g1XqAUIedSRUWTG8ElhcsXBwFtMk00VmHYYqzfRbBdM5JXcqv2uzDP04Td4sT7eGQWVrHW2pC38Zk8Hb810jsw==",
       "dev": true,
       "requires": {
-        "@dojo/core": "~2.0.0",
-        "@dojo/has": "~2.0.0",
-        "@dojo/interfaces": "~0.2.1",
-        "@dojo/shim": "~2.0.0",
-        "@types/jszip": "~3.1.3",
-        "jszip": "~3.1.3",
-        "tslib": "~1.9.0"
+        "@dojo/core": "2.0.0",
+        "@dojo/has": "2.0.0",
+        "@dojo/interfaces": "0.2.1",
+        "@dojo/shim": "2.0.0",
+        "@types/jszip": "3.1.4",
+        "jszip": "3.1.5",
+        "tslib": "1.9.3"
       },
       "dependencies": {
         "@dojo/core": {
@@ -160,7 +160,7 @@
           "integrity": "sha512-iojqMIn49L/bwv/Ryy2v7qKeioHxjHQqJNLhEXBJ+zJoQ47IeG92Y5tmdGsZ6SKZk6sFuWHl7gL9Wbw0qVySHw==",
           "dev": true,
           "requires": {
-            "tslib": "~1.8.1"
+            "tslib": "1.8.1"
           },
           "dependencies": {
             "tslib": {
@@ -185,7 +185,7 @@
           "requires": {
             "intersection-observer": "0.4.2",
             "pepjs": "0.4.2",
-            "tslib": "~1.8.0",
+            "tslib": "1.8.1",
             "web-animations-js": "2.3.1"
           },
           "dependencies": {
@@ -223,8 +223,8 @@
       "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
       "dev": true,
       "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
+        "@types/connect": "3.4.32",
+        "@types/node": "9.6.28"
       }
     },
     "@types/chai": {
@@ -239,7 +239,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.28"
       }
     },
     "@types/cldrjs": {
@@ -253,7 +253,7 @@
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.28"
       }
     },
     "@types/diff": {
@@ -274,9 +274,9 @@
       "integrity": "sha512-ttWle8cnPA5rAelauSWeWJimtY2RsUf2aspYZs7xPHiWgOlPn6nnUfBMtrkcnjFJuIHJF4gNOdVvpLK2Zmvh6g==",
       "dev": true,
       "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
+        "@types/body-parser": "1.17.0",
+        "@types/express-serve-static-core": "4.16.0",
+        "@types/serve-static": "1.13.2"
       }
     },
     "@types/express-serve-static-core": {
@@ -285,9 +285,9 @@
       "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/node": "*",
-        "@types/range-parser": "*"
+        "@types/events": "1.2.0",
+        "@types/node": "9.6.28",
+        "@types/range-parser": "1.2.2"
       }
     },
     "@types/globalize": {
@@ -295,7 +295,7 @@
       "resolved": "https://registry.npmjs.org/@types/globalize/-/globalize-0.0.34.tgz",
       "integrity": "sha512-FQTLuqZxqf+T1Ao6RzaIP7HcTcNvgDf0YQfK90YGYt1N6KeU5GE0M/hsxdQlpqvuztxjEwEQqIO3paSO/tZ4Pw==",
       "requires": {
-        "@types/cldrjs": "*"
+        "@types/cldrjs": "0.4.20"
       }
     },
     "@types/http-errors": {
@@ -322,9 +322,9 @@
       "integrity": "sha512-SWIpdKneXqThfrKIokt9dXSPeslS2NWcxhtr+/a2+N81aLyOMAsVTMmwaKuCoEahcI0FfhY3/79AR6Vilk9i8A==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "*",
-        "@types/istanbul-lib-coverage": "*",
-        "source-map": "^0.6.1"
+        "@types/babel-types": "7.0.4",
+        "@types/istanbul-lib-coverage": "1.1.0",
+        "source-map": "0.6.1"
       }
     },
     "@types/istanbul-lib-report": {
@@ -333,7 +333,7 @@
       "integrity": "sha512-nW5QuzmMhr7fHPijtaGOemFFI8Ctrxb/dIXgouSlKmWT16RxWlGLEX/nGghIBOReKe9hPFZXoNh338nFQk2xcA==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-coverage": "*"
+        "@types/istanbul-lib-coverage": "1.1.0"
       }
     },
     "@types/istanbul-lib-source-maps": {
@@ -342,8 +342,8 @@
       "integrity": "sha512-K0IvmTFbI2GjLG0O4AOLPV2hFItE5Bg/TY41IBZIThhLhYthJc3VjpZpM8/sIaIVtnQcX8b2k3muPDvsvhk+Fg==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-coverage": "*",
-        "source-map": "^0.6.1"
+        "@types/istanbul-lib-coverage": "1.1.0",
+        "source-map": "0.6.1"
       }
     },
     "@types/istanbul-reports": {
@@ -352,14 +352,14 @@
       "integrity": "sha512-wrJUtE1+HuaRz0Le7fc5l1nMTermRh6wlEvOdQPilseNScyYgQK8MdgDP2cf/X8+6e1dtsX/zP4W4kH/jyHvFw==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
+        "@types/istanbul-lib-coverage": "1.1.0",
+        "@types/istanbul-lib-report": "1.1.0"
       }
     },
     "@types/jquery": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.5.tgz",
-      "integrity": "sha512-18OnkBZ+9pOx8grC2w4i256VS+9j/Ya/N0DcWkZRgPrg7V2oolgk8n7790goBlnChL6nIXAXy1lBTrz/r4lJTg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.6.tgz",
+      "integrity": "sha512-403D4wN95Mtzt2EoQHARf5oe/jEPhzBOBNrunk+ydQGW8WmkQ/E8rViRAEB1qEt/vssfGfNVD6ujP4FVeegrLg==",
       "dev": true
     },
     "@types/jsdom": {
@@ -368,8 +368,8 @@
       "integrity": "sha512-xaHlMIzlReyciMIWGJBnkEdHngCOEpik2ojt9tJFe7rD+QiObCIcmr9/tAqxn7l1jflQ3wEIkh7+gt4ls5n1Dw==",
       "dev": true,
       "requires": {
-        "@types/jquery": "*",
-        "@types/node": "*"
+        "@types/jquery": "3.3.6",
+        "@types/node": "9.6.28"
       }
     },
     "@types/jszip": {
@@ -378,7 +378,7 @@
       "integrity": "sha512-UaVbz4buRlBEolZYrxqkrGDOypugYlbqGNrUFB4qBaexrLypTH0jyvaF5jolNy5D+5C4kKV1WJ3Yx9cn/JH8oA==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.28"
       }
     },
     "@types/lodash": {
@@ -405,13 +405,13 @@
       "integrity": "sha512-Lx4rNtGajRGtcVwJe1sKPAkAuBBWq8TOuimKJfOfK7ayY1Jc+18Lx00GjagLeIwaH2+OvFJvCv8tz+pvbt3OoA==",
       "dev": true,
       "requires": {
-        "@types/express": "*"
+        "@types/express": "4.11.1"
       }
     },
     "@types/node": {
-      "version": "9.6.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.27.tgz",
-      "integrity": "sha512-fGWGG9Wypv6JZLIrnq9jXFX/FhQzgNccTlojez9hBbQ9UiBdxtc0ONMMe4/vnB2nDgOMDpPR/7HhenUB+Bw5yQ==",
+      "version": "9.6.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.28.tgz",
+      "integrity": "sha512-LMSOxMKNJ8tGqUVs8lSIT8RGo1XGWYada/ZU2QZcbcD6AW9futXDE99tfQA0K6DK60GXcwplsGGK5KABRmI5GA==",
       "dev": true
     },
     "@types/platform": {
@@ -438,7 +438,7 @@
       "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.28"
       }
     },
     "@types/selenium-webdriver": {
@@ -453,8 +453,8 @@
       "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/express-serve-static-core": "4.16.0",
+        "@types/mime": "2.0.0"
       }
     },
     "@types/shell-quote": {
@@ -486,8 +486,8 @@
       "integrity": "sha512-tlDVFHCcJdNqYgjGNDPDCo4tNqhFMymIAdJCcykFbdhYr4X6vD7IlMxY0t3/k6Pfup68YNkMTpRfLKTRuKDmnQ==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/node": "*"
+        "@types/events": "1.2.0",
+        "@types/node": "9.6.28"
       }
     },
     "@types/yargs": {
@@ -519,7 +519,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.19",
         "negotiator": "0.6.1"
       }
     },
@@ -535,7 +535,7 @@
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.4"
+        "acorn": "4.0.13"
       }
     },
     "adm-zip": {
@@ -550,10 +550,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "align-text": {
@@ -562,9 +562,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
@@ -591,7 +591,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.2"
       }
     },
     "any-observable": {
@@ -606,8 +606,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "app-root-path": {
@@ -628,7 +628,7 @@
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^1.0.0"
+        "default-require-extensions": "1.0.0"
       }
     },
     "argparse": {
@@ -637,7 +637,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "argv": {
@@ -652,7 +652,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -697,7 +697,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -718,7 +718,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -775,9 +775,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -792,11 +792,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -813,14 +813,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -837,7 +837,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-runtime": {
@@ -846,8 +846,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
@@ -864,11 +864,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-traverse": {
@@ -877,15 +877,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
       }
     },
     "babel-types": {
@@ -894,10 +894,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -925,7 +925,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "benchmark": {
@@ -946,8 +946,8 @@
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "body-parser": {
@@ -957,15 +957,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "type-is": "1.6.16"
       }
     },
     "boolbase": {
@@ -979,7 +979,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "bootstrap": {
@@ -994,7 +994,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1004,9 +1004,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "buffer": {
@@ -1016,8 +1016,8 @@
       "dev": true,
       "requires": {
         "base64-js": "0.0.8",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "ieee754": "1.1.12",
+        "isarray": "1.0.0"
       }
     },
     "buffer-alloc": {
@@ -1026,8 +1026,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -1067,7 +1067,7 @@
       "dev": true,
       "requires": {
         "dicer": "0.2.5",
-        "readable-stream": "1.1.x"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -1082,10 +1082,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -1108,7 +1108,7 @@
       "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
       "dev": true,
       "requires": {
-        "stack-trace": "~0.0.7"
+        "stack-trace": "0.0.10"
       }
     },
     "camelcase": {
@@ -1131,8 +1131,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chai": {
@@ -1141,12 +1141,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
     },
     "chalk": {
@@ -1155,9 +1155,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       }
     },
     "charm": {
@@ -1166,7 +1166,7 @@
       "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "check-error": {
@@ -1181,15 +1181,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "chromedriver": {
@@ -1198,17 +1198,17 @@
       "integrity": "sha512-ewvRQ1HMk0vpFSWYCk5hKDoEz5QMPplx5w3C6/Me+03y1imr67l3Hxl9U0jn3mu2N7+c7BoC7JtNW6HzbRAwDQ==",
       "dev": true,
       "requires": {
-        "del": "^3.0.0",
-        "extract-zip": "^1.6.7",
-        "kew": "^0.7.0",
-        "mkdirp": "^0.5.1",
-        "request": "^2.87.0"
+        "del": "3.0.0",
+        "extract-zip": "1.6.7",
+        "kew": "0.7.0",
+        "mkdirp": "0.5.1",
+        "request": "2.88.0"
       }
     },
     "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.3.0.tgz",
+      "integrity": "sha512-mPdvoljUhH3Feai3dakD3bwYl/8I0tSo16Ge2W+tY88yfYDKGVnXV2vFxZC8VGME01CYp+DaAZnE93VHYVapnA==",
       "dev": true
     },
     "cldr-data": {
@@ -1217,8 +1217,8 @@
       "integrity": "sha1-eWCDKDbgpkp0voi1XuEF8pgKDyo=",
       "dev": true,
       "requires": {
-        "cldr-data-downloader": "0.3.x",
-        "glob": "5.x.x"
+        "cldr-data-downloader": "0.3.4",
+        "glob": "5.0.15"
       },
       "dependencies": {
         "glob": {
@@ -1227,11 +1227,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -1244,10 +1244,10 @@
       "requires": {
         "adm-zip": "0.4.11",
         "mkdirp": "0.5.0",
-        "nopt": "3.0.x",
+        "nopt": "3.0.6",
         "progress": "1.1.8",
         "q": "1.0.1",
-        "request": "~2.83.0",
+        "request": "2.83.0",
         "request-progress": "0.3.1"
       },
       "dependencies": {
@@ -1257,8 +1257,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "mkdirp": {
@@ -1282,28 +1282,28 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "stringstream": "~0.0.5",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.8.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.2",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.19",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         },
         "tough-cookie": {
@@ -1312,7 +1312,7 @@
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         }
       }
@@ -1328,7 +1328,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-spinners": {
@@ -1344,7 +1344,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
+        "string-width": "1.0.2"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -1353,7 +1353,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -1362,9 +1362,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -1376,8 +1376,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -1408,10 +1408,10 @@
       "integrity": "sha512-KJyzHdg9B8U9LxXa7hS6jnEW5b1cNckLYc2YpnJ1nEFiOW+/iSzDHp+5MYEIQd9fN3/tC6WmGZmYiwxzkuGp/A==",
       "dev": true,
       "requires": {
-        "argv": "^0.0.2",
-        "ignore-walk": "^3.0.1",
-        "request": "^2.87.0",
-        "urlgrey": "^0.4.4"
+        "argv": "0.0.2",
+        "ignore-walk": "3.0.1",
+        "request": "2.88.0",
+        "urlgrey": "0.4.4"
       }
     },
     "color-convert": {
@@ -1435,7 +1435,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "command-exists": {
@@ -1450,7 +1450,7 @@
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "dev": true,
       "requires": {
-        "graceful-readlink": ">= 1.0.0"
+        "graceful-readlink": "1.0.1"
       }
     },
     "concat-map": {
@@ -1465,10 +1465,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "content-disposition": {
@@ -1519,10 +1519,10 @@
       "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
       "dev": true,
       "requires": {
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^3.0.0",
-        "require-from-string": "^2.0.1"
+        "is-directory": "0.3.1",
+        "js-yaml": "3.12.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.2"
       }
     },
     "cpx": {
@@ -1531,17 +1531,17 @@
       "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.9.2",
-        "chokidar": "^1.6.0",
-        "duplexer": "^0.1.1",
-        "glob": "^7.0.5",
-        "glob2base": "^0.0.12",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "resolve": "^1.1.7",
-        "safe-buffer": "^5.0.1",
-        "shell-quote": "^1.6.1",
-        "subarg": "^1.0.0"
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "duplexer": "0.1.1",
+        "glob": "7.1.2",
+        "glob2base": "0.0.12",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "resolve": "1.7.1",
+        "safe-buffer": "5.1.2",
+        "shell-quote": "1.6.1",
+        "subarg": "1.0.0"
       }
     },
     "cross-spawn": {
@@ -1550,9 +1550,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "cryptiles": {
@@ -1561,7 +1561,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -1570,7 +1570,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -1580,11 +1580,11 @@
       "resolved": "https://registry.npmjs.org/css-select-umd/-/css-select-umd-1.3.0-rc0.tgz",
       "integrity": "sha512-ggouX0yWeql8nZobF5jscijHx/WIDkEuy7Iq6fU2X6ogQyIPpJ/aGn4ZYM0jpfI0LbvDaQustkj0az/hN1BqwA==",
       "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "es6-set": "^0.1.5",
-        "nth-check": "^1.0.1"
+        "es6-set": "0.1.5",
+        "nth-check": "1.0.1"
       }
     },
     "css-what": {
@@ -1604,7 +1604,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "0.3.4"
       }
     },
     "d": {
@@ -1612,7 +1612,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.46"
       }
     },
     "dashdash": {
@@ -1621,7 +1621,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "date-fns": {
@@ -1651,14 +1651,14 @@
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.0.0",
-        "decompress-tarbz2": "^4.0.0",
-        "decompress-targz": "^4.0.0",
-        "decompress-unzip": "^4.0.1",
-        "graceful-fs": "^4.1.10",
-        "make-dir": "^1.0.0",
-        "pify": "^2.3.0",
-        "strip-dirs": "^2.0.0"
+        "decompress-tar": "4.1.1",
+        "decompress-tarbz2": "4.1.1",
+        "decompress-targz": "4.1.1",
+        "decompress-unzip": "4.0.1",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "pify": "2.3.0",
+        "strip-dirs": "2.1.0"
       }
     },
     "decompress-tar": {
@@ -1667,9 +1667,9 @@
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
       "requires": {
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0",
-        "tar-stream": "^1.5.2"
+        "file-type": "5.2.0",
+        "is-stream": "1.1.0",
+        "tar-stream": "1.6.1"
       }
     },
     "decompress-tarbz2": {
@@ -1678,11 +1678,11 @@
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.1.0",
-        "file-type": "^6.1.0",
-        "is-stream": "^1.1.0",
-        "seek-bzip": "^1.0.5",
-        "unbzip2-stream": "^1.0.9"
+        "decompress-tar": "4.1.1",
+        "file-type": "6.2.0",
+        "is-stream": "1.1.0",
+        "seek-bzip": "1.0.5",
+        "unbzip2-stream": "1.2.5"
       },
       "dependencies": {
         "file-type": {
@@ -1699,9 +1699,9 @@
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.1.1",
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0"
+        "decompress-tar": "4.1.1",
+        "file-type": "5.2.0",
+        "is-stream": "1.1.0"
       }
     },
     "decompress-unzip": {
@@ -1710,10 +1710,10 @@
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
       "requires": {
-        "file-type": "^3.8.0",
-        "get-stream": "^2.2.0",
-        "pify": "^2.3.0",
-        "yauzl": "^2.4.2"
+        "file-type": "3.9.0",
+        "get-stream": "2.3.1",
+        "pify": "2.3.0",
+        "yauzl": "2.10.0"
       },
       "dependencies": {
         "file-type": {
@@ -1736,7 +1736,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.8"
       }
     },
     "deep-is": {
@@ -1751,17 +1751,16 @@
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "dev": true,
       "requires": {
-        "strip-bom": "^2.0.0"
+        "strip-bom": "2.0.0"
       }
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "object-keys": "1.0.12"
       }
     },
     "del": {
@@ -1770,12 +1769,12 @@
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "pify": {
@@ -1810,7 +1809,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "dicer": {
@@ -1819,7 +1818,7 @@
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.x",
+        "readable-stream": "1.1.14",
         "streamsearch": "0.1.2"
       },
       "dependencies": {
@@ -1835,10 +1834,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -1859,8 +1858,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -1880,8 +1879,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "duplexer": {
@@ -1897,8 +1896,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ee-first": {
@@ -1925,7 +1924,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "entities": {
@@ -1939,7 +1938,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -1948,11 +1947,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1961,19 +1960,19 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
-      "version": "0.10.45",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+      "version": "0.10.46",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -1981,9 +1980,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-promise": {
@@ -1997,11 +1996,11 @@
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -2009,8 +2008,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46"
       }
     },
     "escape-html": {
@@ -2031,11 +2030,11 @@
       "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -2075,8 +2074,8 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46"
       }
     },
     "event-stream": {
@@ -2085,13 +2084,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
       }
     },
     "execa": {
@@ -2100,13 +2099,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       },
       "dependencies": {
         "get-stream": {
@@ -2129,7 +2128,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -2138,7 +2137,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       }
     },
     "expand-tilde": {
@@ -2147,7 +2146,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "express": {
@@ -2156,36 +2155,36 @@
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "body-parser": {
@@ -2195,15 +2194,15 @@
           "dev": true,
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "debug": "2.6.9",
-            "depd": "~1.1.1",
-            "http-errors": "~1.6.2",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
             "iconv-lite": "0.4.19",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "~1.6.15"
+            "type-is": "1.6.16"
           }
         },
         "iconv-lite": {
@@ -2245,7 +2244,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": ">= 1.3.1 < 2"
+                "statuses": "1.4.0"
               }
             },
             "setprototypeof": {
@@ -2282,7 +2281,7 @@
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "requires": {
-        "is-extendable": "^0.1.0"
+        "is-extendable": "0.1.1"
       }
     },
     "extglob": {
@@ -2291,7 +2290,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extract-zip": {
@@ -2312,7 +2311,7 @@
           "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
           "dev": true,
           "requires": {
-            "pend": "~1.2.0"
+            "pend": "1.2.0"
           }
         },
         "yauzl": {
@@ -2321,7 +2320,7 @@
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "dev": true,
           "requires": {
-            "fd-slicer": "~1.0.1"
+            "fd-slicer": "1.0.1"
           }
         }
       }
@@ -2356,7 +2355,7 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -2365,8 +2364,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-type": {
@@ -2387,11 +2386,11 @@
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.1.0",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -2401,12 +2400,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -2435,7 +2434,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "for-in": {
@@ -2450,14 +2449,8 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2471,9 +2464,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.19"
       }
     },
     "formatio": {
@@ -2482,7 +2475,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.x"
+        "samsam": "1.3.0"
       }
     },
     "forwarded": {
@@ -2528,8 +2521,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2555,8 +2548,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -2569,7 +2562,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2633,7 +2626,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -2648,14 +2641,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -2664,12 +2657,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -2684,7 +2677,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -2693,7 +2686,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -2702,8 +2695,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -2722,7 +2715,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -2736,7 +2729,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -2749,8 +2742,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -2759,7 +2752,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -2782,9 +2775,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -2793,16 +2786,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -2811,8 +2804,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -2827,8 +2820,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -2837,10 +2830,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -2859,7 +2852,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -2880,8 +2873,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -2902,10 +2895,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2922,13 +2915,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -2937,7 +2930,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -2980,9 +2973,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -2991,7 +2984,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -2999,7 +2992,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -3014,13 +3007,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -3035,7 +3028,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -3080,8 +3073,8 @@
       "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
       }
     },
     "getpass": {
@@ -3090,7 +3083,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "git-config-path": {
@@ -3099,9 +3092,9 @@
       "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "fs-exists-sync": "^0.1.0",
-        "homedir-polyfill": "^1.0.0"
+        "extend-shallow": "2.0.1",
+        "fs-exists-sync": "0.1.0",
+        "homedir-polyfill": "1.0.1"
       }
     },
     "glob": {
@@ -3110,12 +3103,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -3124,8 +3117,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -3134,7 +3127,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob2base": {
@@ -3143,7 +3136,7 @@
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
-        "find-index": "^0.1.1"
+        "find-index": "0.1.1"
       }
     },
     "globalize": {
@@ -3151,7 +3144,7 @@
       "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.3.0.tgz",
       "integrity": "sha1-xWUkuKz9LOONDJfd/c6zj2RLM5I=",
       "requires": {
-        "cldrjs": "^0.4.6"
+        "cldrjs": "0.4.8"
       }
     },
     "globals": {
@@ -3166,11 +3159,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "graceful-fs": {
@@ -3191,10 +3184,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "source-map": {
@@ -3203,7 +3196,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -3220,8 +3213,8 @@
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -3230,7 +3223,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -3239,7 +3232,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -3254,10 +3247,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       }
     },
     "hoek": {
@@ -3272,7 +3265,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -3287,7 +3280,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "^1.0.1"
+        "whatwg-encoding": "1.0.4"
       }
     },
     "http-errors": {
@@ -3296,10 +3289,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.5.0"
       }
     },
     "http-signature": {
@@ -3308,9 +3301,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "husky": {
@@ -3319,9 +3312,9 @@
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "is-ci": "^1.0.10",
-        "normalize-path": "^1.0.0",
-        "strip-indent": "^2.0.0"
+        "is-ci": "1.1.0",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
       },
       "dependencies": {
         "normalize-path": {
@@ -3338,7 +3331,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ieee754": {
@@ -3353,7 +3346,7 @@
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "3.0.4"
       }
     },
     "immediate": {
@@ -3368,7 +3361,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "inflight": {
@@ -3377,8 +3370,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -3399,55 +3392,55 @@
       "integrity": "sha512-yVe+IsWXAdZaj2LX9PiZ9KUQzru67zuCcIf28ulxh9bp7dvLvmyeEH1d+DpF78+zvl7ebAOEvX3NDQSc/PEdOQ==",
       "dev": true,
       "requires": {
-        "@dojo/core": "~0.5.0",
-        "@dojo/has": "~0.1.2",
-        "@dojo/interfaces": "~0.2.1",
-        "@dojo/shim": "~0.2.7",
-        "@theintern/digdug": "~2.1.0",
-        "@theintern/leadfoot": "~2.1.0",
-        "@types/benchmark": "~1.0.30",
-        "@types/chai": "~4.1.2",
-        "@types/charm": "~1.0.0",
-        "@types/diff": "~3.5.1",
-        "@types/express": "~4.11.1",
-        "@types/http-errors": "~1.6.1",
-        "@types/istanbul-lib-coverage": "~1.1.0",
-        "@types/istanbul-lib-hook": "~1.0.0",
-        "@types/istanbul-lib-instrument": "~1.7.1",
-        "@types/istanbul-lib-report": "~1.1.0",
-        "@types/istanbul-lib-source-maps": "~1.2.1",
-        "@types/istanbul-reports": "~1.1.0",
-        "@types/lodash": "~4.14.107",
-        "@types/mime-types": "~2.1.0",
-        "@types/platform": "~1.3.0",
+        "@dojo/core": "0.5.0",
+        "@dojo/has": "0.1.2",
+        "@dojo/interfaces": "0.2.1",
+        "@dojo/shim": "0.2.7",
+        "@theintern/digdug": "2.1.2",
+        "@theintern/leadfoot": "2.1.1",
+        "@types/benchmark": "1.0.31",
+        "@types/chai": "4.1.4",
+        "@types/charm": "1.0.1",
+        "@types/diff": "3.5.1",
+        "@types/express": "4.11.1",
+        "@types/http-errors": "1.6.1",
+        "@types/istanbul-lib-coverage": "1.1.0",
+        "@types/istanbul-lib-hook": "1.0.0",
+        "@types/istanbul-lib-instrument": "1.7.2",
+        "@types/istanbul-lib-report": "1.1.0",
+        "@types/istanbul-lib-source-maps": "1.2.1",
+        "@types/istanbul-reports": "1.1.0",
+        "@types/lodash": "4.14.116",
+        "@types/mime-types": "2.1.0",
+        "@types/platform": "1.3.1",
         "@types/resolve": "0.0.7",
-        "@types/shell-quote": "~1.6.0",
-        "@types/statuses": "~1.3.0",
-        "@types/ws": "~4.0.2",
-        "benchmark": "~2.1.4",
-        "body-parser": "~1.18.2",
-        "chai": "~4.1.2",
-        "charm": "~1.0.2",
-        "diff": "~3.5.0",
-        "express": "~4.16.3",
-        "glob": "~7.1.1",
-        "http-errors": "~1.6.3",
-        "istanbul-lib-coverage": "~1.2.0",
-        "istanbul-lib-hook": "~1.1.0",
-        "istanbul-lib-instrument": "~1.10.0",
-        "istanbul-lib-report": "~1.1.3",
-        "istanbul-lib-source-maps": "~1.2.4",
-        "istanbul-reports": "~1.3.0",
-        "lodash": "~4.17.5",
-        "mime-types": "~2.1.18",
-        "minimatch": "~3.0.4",
-        "platform": "~1.3.5",
-        "resolve": "~1.7.1",
-        "shell-quote": "~1.6.1",
-        "source-map": "~0.6.1",
-        "statuses": "~1.5.0",
-        "tslib": "~1.9.0",
-        "ws": "~5.1.1"
+        "@types/shell-quote": "1.6.0",
+        "@types/statuses": "1.3.0",
+        "@types/ws": "4.0.2",
+        "benchmark": "2.1.4",
+        "body-parser": "1.18.3",
+        "chai": "4.1.2",
+        "charm": "1.0.2",
+        "diff": "3.5.0",
+        "express": "4.16.3",
+        "glob": "7.1.2",
+        "http-errors": "1.6.3",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.5",
+        "istanbul-reports": "1.3.0",
+        "lodash": "4.17.10",
+        "mime-types": "2.1.19",
+        "minimatch": "3.0.4",
+        "platform": "1.3.5",
+        "resolve": "1.7.1",
+        "shell-quote": "1.6.1",
+        "source-map": "0.6.1",
+        "statuses": "1.5.0",
+        "tslib": "1.9.3",
+        "ws": "5.1.1"
       },
       "dependencies": {
         "benchmark": {
@@ -3456,8 +3449,8 @@
           "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.4",
-            "platform": "^1.3.3"
+            "lodash": "4.17.10",
+            "platform": "1.3.5"
           }
         },
         "diff": {
@@ -3485,7 +3478,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -3512,7 +3505,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -3527,7 +3520,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -3542,7 +3535,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.3.0"
       }
     },
     "is-date-object": {
@@ -3569,7 +3562,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -3590,7 +3583,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -3605,7 +3598,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-natural-number": {
@@ -3620,7 +3613,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-obj": {
@@ -3635,7 +3628,7 @@
       "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
       "dev": true,
       "requires": {
-        "symbol-observable": "^0.2.2"
+        "symbol-observable": "0.2.4"
       },
       "dependencies": {
         "symbol-observable": {
@@ -3658,7 +3651,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -3667,7 +3660,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-posix-bracket": {
@@ -3694,7 +3687,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-regexp": {
@@ -3766,7 +3759,7 @@
       "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0"
+        "append-transform": "0.4.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -3775,13 +3768,13 @@
       "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
-        "babel-generator": "^6.18.0",
-        "babel-template": "^6.16.0",
-        "babel-traverse": "^6.18.0",
-        "babel-types": "^6.18.0",
-        "babylon": "^6.18.0",
-        "istanbul-lib-coverage": "^1.2.0",
-        "semver": "^5.3.0"
+        "babel-generator": "6.26.1",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "semver": "5.5.0"
       }
     },
     "istanbul-lib-report": {
@@ -3790,10 +3783,10 @@
       "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^1.1.2",
-        "mkdirp": "^0.5.1",
-        "path-parse": "^1.0.5",
-        "supports-color": "^3.1.2"
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "path-parse": "1.0.6",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "has-flag": {
@@ -3808,7 +3801,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -3819,11 +3812,11 @@
       "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "istanbul-lib-coverage": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.1",
-        "source-map": "^0.5.3"
+        "debug": "3.1.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -3849,7 +3842,7 @@
       "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.0.3"
+        "handlebars": "4.0.11"
       }
     },
     "jest-get-type": {
@@ -3864,10 +3857,10 @@
       "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^21.2.0",
-        "leven": "^2.1.0",
-        "pretty-format": "^21.2.1"
+        "chalk": "2.4.1",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
       }
     },
     "js-tokens": {
@@ -3882,8 +3875,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -3899,25 +3892,25 @@
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "dev": true,
       "requires": {
-        "abab": "^1.0.3",
-        "acorn": "^4.0.4",
-        "acorn-globals": "^3.1.0",
-        "array-equal": "^1.0.0",
-        "content-type-parser": "^1.0.1",
-        "cssom": ">= 0.3.2 < 0.4.0",
-        "cssstyle": ">= 0.2.37 < 0.3.0",
-        "escodegen": "^1.6.1",
-        "html-encoding-sniffer": "^1.0.1",
-        "nwmatcher": ">= 1.3.9 < 2.0.0",
-        "parse5": "^1.5.1",
-        "request": "^2.79.0",
-        "sax": "^1.2.1",
-        "symbol-tree": "^3.2.1",
-        "tough-cookie": "^2.3.2",
-        "webidl-conversions": "^4.0.0",
-        "whatwg-encoding": "^1.0.1",
-        "whatwg-url": "^4.3.0",
-        "xml-name-validator": "^2.0.1"
+        "abab": "1.0.4",
+        "acorn": "4.0.13",
+        "acorn-globals": "3.1.0",
+        "array-equal": "1.0.0",
+        "content-type-parser": "1.0.2",
+        "cssom": "0.3.4",
+        "cssstyle": "0.2.37",
+        "escodegen": "1.11.0",
+        "html-encoding-sniffer": "1.0.2",
+        "nwmatcher": "1.4.4",
+        "parse5": "1.5.1",
+        "request": "2.88.0",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.4.3",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.4",
+        "whatwg-url": "4.8.0",
+        "xml-name-validator": "2.0.1"
       }
     },
     "jsesc": {
@@ -3980,11 +3973,11 @@
       "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "dev": true,
       "requires": {
-        "core-js": "~2.3.0",
-        "es6-promise": "~3.0.2",
-        "lie": "~3.1.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.0.6"
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -3999,12 +3992,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -4033,7 +4026,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "lazy-cache": {
@@ -4049,7 +4042,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "leven": {
@@ -4064,8 +4057,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lie": {
@@ -4074,7 +4067,7 @@
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "dev": true,
       "requires": {
-        "immediate": "~3.0.5"
+        "immediate": "3.0.6"
       }
     },
     "lint-staged": {
@@ -4083,26 +4076,26 @@
       "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
       "dev": true,
       "requires": {
-        "app-root-path": "^2.0.0",
-        "chalk": "^2.1.0",
-        "commander": "^2.11.0",
-        "cosmiconfig": "^3.1.0",
-        "debug": "^3.1.0",
-        "dedent": "^0.7.0",
-        "execa": "^0.8.0",
-        "find-parent-dir": "^0.3.0",
-        "is-glob": "^4.0.0",
-        "jest-validate": "^21.1.0",
-        "listr": "^0.13.0",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "minimatch": "^3.0.0",
-        "npm-which": "^3.0.1",
-        "p-map": "^1.1.1",
-        "path-is-inside": "^1.0.2",
-        "pify": "^3.0.0",
+        "app-root-path": "2.1.0",
+        "chalk": "2.4.1",
+        "commander": "2.17.1",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.10",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
         "staged-git-files": "0.0.4",
-        "stringify-object": "^3.2.0"
+        "stringify-object": "3.2.2"
       },
       "dependencies": {
         "commander": {
@@ -4126,13 +4119,13 @@
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "get-stream": {
@@ -4153,7 +4146,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "pify": {
@@ -4170,23 +4163,23 @@
       "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "figures": "^1.7.0",
-        "indent-string": "^2.1.0",
-        "is-observable": "^0.2.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.4.0",
-        "listr-verbose-renderer": "^0.4.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^1.0.2",
-        "ora": "^0.2.3",
-        "p-map": "^1.1.1",
-        "rxjs": "^5.4.2",
-        "stream-to-observable": "^0.2.0",
-        "strip-ansi": "^3.0.1"
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.11",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4201,11 +4194,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "log-symbols": {
@@ -4214,7 +4207,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         },
         "supports-color": {
@@ -4237,14 +4230,14 @@
       "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^1.0.2",
-        "strip-ansi": "^3.0.1"
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4259,11 +4252,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "indent-string": {
@@ -4278,7 +4271,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         },
         "supports-color": {
@@ -4295,10 +4288,10 @@
       "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-cursor": "^1.0.2",
-        "date-fns": "^1.27.2",
-        "figures": "^1.7.0"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4313,11 +4306,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -4334,10 +4327,10 @@
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "parse-json": {
@@ -4346,8 +4339,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.2",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "pify": {
@@ -4370,8 +4363,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -4392,7 +4385,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.4.1"
       }
     },
     "log-update": {
@@ -4401,8 +4394,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.0.0",
-        "cli-cursor": "^1.0.2"
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
       }
     },
     "lolex": {
@@ -4423,7 +4416,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "lru-cache": {
@@ -4432,8 +4425,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "make-dir": {
@@ -4442,7 +4435,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -4477,7 +4470,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memorystream": {
@@ -4504,19 +4497,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "mime": {
@@ -4537,7 +4530,7 @@
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "1.35.0"
       }
     },
     "mimic-fn": {
@@ -4552,7 +4545,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -4576,7 +4569,7 @@
       "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
       "dev": true,
       "requires": {
-        "caller-id": "^0.1.0"
+        "caller-id": "0.1.0"
       }
     },
     "ms": {
@@ -4591,14 +4584,14 @@
       "integrity": "sha512-JHdEoxkA/5NgZRo91RNn4UT+HdcJV9XUo01DTkKC7vo1erNIngtuaw9Y0WI8RdTlyi+wMIbunflhghzVLuGJyw==",
       "dev": true,
       "requires": {
-        "append-field": "^0.1.0",
-        "busboy": "^0.2.11",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^3.0.0",
-        "on-finished": "^2.3.0",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
+        "append-field": "0.1.0",
+        "busboy": "0.2.14",
+        "concat-stream": "1.6.2",
+        "mkdirp": "0.5.1",
+        "object-assign": "3.0.0",
+        "on-finished": "2.3.0",
+        "type-is": "1.6.16",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -4634,16 +4627,16 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
-      "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.3.tgz",
+      "integrity": "sha512-cg44dkGHutAY+VmftgB1gHvLWxFl2vwYdF8WpbceYicQwylESRJiAAKgCRJntdoEbMiUzywkZEUzjoDWH0JwKA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
-        "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.7.1",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
       },
       "dependencies": {
         "isarray": {
@@ -4669,7 +4662,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -4678,10 +4671,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
@@ -4690,7 +4683,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "npm-path": {
@@ -4699,7 +4692,7 @@
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "dev": true,
       "requires": {
-        "which": "^1.2.10"
+        "which": "1.3.1"
       }
     },
     "npm-run-all": {
@@ -4708,15 +4701,15 @@
       "integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.4",
-        "memorystream": "^0.3.1",
-        "minimatch": "^3.0.4",
-        "ps-tree": "^1.1.0",
-        "read-pkg": "^3.0.0",
-        "shell-quote": "^1.6.1",
-        "string.prototype.padend": "^3.0.0"
+        "ansi-styles": "3.2.1",
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "memorystream": "0.3.1",
+        "minimatch": "3.0.4",
+        "ps-tree": "1.1.0",
+        "read-pkg": "3.0.0",
+        "shell-quote": "1.6.1",
+        "string.prototype.padend": "3.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -4725,11 +4718,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         }
       }
@@ -4740,7 +4733,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npm-which": {
@@ -4749,9 +4742,9 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "^2.9.0",
-        "npm-path": "^2.0.2",
-        "which": "^1.2.10"
+        "commander": "2.17.1",
+        "npm-path": "2.0.4",
+        "which": "1.3.1"
       },
       "dependencies": {
         "commander": {
@@ -4767,7 +4760,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "number-is-nan": {
@@ -4806,8 +4799,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "on-finished": {
@@ -4825,7 +4818,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -4840,8 +4833,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       }
     },
     "optionator": {
@@ -4850,12 +4843,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -4872,10 +4865,10 @@
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "cli-cursor": "^1.0.2",
-        "cli-spinners": "^0.1.2",
-        "object-assign": "^4.0.1"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4890,11 +4883,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -4911,9 +4904,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       }
     },
     "os-tmpdir": {
@@ -4934,7 +4927,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -4943,7 +4936,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-map": {
@@ -4970,9 +4963,9 @@
       "integrity": "sha512-ObBoF8oac1DKo78J6R+O9KwhMNL0yCmizi4/WKyB6rQXNHe4SmLMhnLrpPogWT2BbJUx1LcIzec/ftAiveSVhQ==",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "git-config-path": "^1.0.1",
-        "ini": "^1.3.5"
+        "expand-tilde": "2.0.2",
+        "git-config-path": "1.0.1",
+        "ini": "1.3.5"
       }
     },
     "parse-glob": {
@@ -4981,10 +4974,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -4993,7 +4986,7 @@
       "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1"
+        "error-ex": "1.3.2"
       }
     },
     "parse-passwd": {
@@ -5056,7 +5049,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -5079,7 +5072,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "~2.3"
+        "through": "2.3.8"
       }
     },
     "pend": {
@@ -5117,7 +5110,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "platform": {
@@ -5150,8 +5143,8 @@
       "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0",
-        "ansi-styles": "^3.2.0"
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5180,7 +5173,7 @@
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "dev": true,
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -5190,7 +5183,7 @@
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true,
       "requires": {
-        "event-stream": "~3.3.0"
+        "event-stream": "3.3.4"
       }
     },
     "pseudomap": {
@@ -5235,9 +5228,9 @@
       "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -5278,9 +5271,9 @@
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "3.0.0"
       }
     },
     "readable-stream": {
@@ -5289,13 +5282,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -5304,10 +5297,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "regenerator-runtime": {
@@ -5322,7 +5315,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "remove-trailing-separator": {
@@ -5349,7 +5342,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
@@ -5358,26 +5351,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.1.0",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.19",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "request-progress": {
@@ -5386,7 +5379,7 @@
       "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
       "dev": true,
       "requires": {
-        "throttleit": "~0.0.2"
+        "throttleit": "0.0.2"
       }
     },
     "require-directory": {
@@ -5413,7 +5406,7 @@
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "restore-cursor": {
@@ -5422,8 +5415,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "right-align": {
@@ -5433,7 +5426,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -5442,7 +5435,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "rxjs": {
@@ -5484,7 +5477,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "~2.8.1"
+        "commander": "2.8.1"
       }
     },
     "selenium-webdriver": {
@@ -5493,10 +5486,10 @@
       "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
-        "jszip": "^3.1.3",
-        "rimraf": "^2.5.4",
+        "jszip": "3.1.5",
+        "rimraf": "2.6.2",
         "tmp": "0.0.30",
-        "xml2js": "^0.4.17"
+        "xml2js": "0.4.19"
       }
     },
     "semver": {
@@ -5512,18 +5505,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "statuses": {
@@ -5540,9 +5533,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -5570,7 +5563,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -5585,10 +5578,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
       }
     },
     "signal-exit": {
@@ -5603,13 +5596,13 @@
       "integrity": "sha1-nLNGvdsYDWioBEKf/hSXjX+v1ik=",
       "dev": true,
       "requires": {
-        "diff": "^3.1.0",
+        "diff": "3.4.0",
         "formatio": "1.2.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
+        "lodash.get": "4.4.2",
+        "lolex": "2.7.1",
+        "nise": "1.4.3",
+        "supports-color": "5.4.0",
+        "type-detect": "4.0.8"
       }
     },
     "slice-ansi": {
@@ -5624,7 +5617,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "source-map": {
@@ -5639,8 +5632,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -5655,8 +5648,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -5671,7 +5664,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "sprintf-js": {
@@ -5686,15 +5679,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-trace": {
@@ -5721,7 +5714,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "stream-to-observable": {
@@ -5730,7 +5723,7 @@
       "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
       "dev": true,
       "requires": {
-        "any-observable": "^0.2.0"
+        "any-observable": "0.2.0"
       }
     },
     "streamsearch": {
@@ -5745,8 +5738,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5761,7 +5754,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -5772,9 +5765,9 @@
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -5783,7 +5776,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringify-object": {
@@ -5792,9 +5785,9 @@
       "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
       "dev": true,
       "requires": {
-        "get-own-enumerable-property-symbols": "^2.0.1",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
       }
     },
     "stringstream": {
@@ -5809,7 +5802,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -5818,7 +5811,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-dirs": {
@@ -5827,7 +5820,7 @@
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
       "requires": {
-        "is-natural-number": "^4.0.1"
+        "is-natural-number": "4.0.1"
       }
     },
     "strip-eof": {
@@ -5848,7 +5841,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "^1.1.0"
+        "minimist": "1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -5865,7 +5858,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "symbol-observable": {
@@ -5886,13 +5879,13 @@
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "dev": true,
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.1.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "buffer-alloc": "1.2.0",
+        "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "text-encoding": {
@@ -5919,7 +5912,7 @@
       "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-buffer": {
@@ -5940,8 +5933,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.29",
+        "punycode": "1.4.1"
       }
     },
     "tr46": {
@@ -5967,18 +5960,18 @@
       "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.1",
+        "commander": "2.17.1",
+        "diff": "3.4.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.12.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.7.1",
+        "semver": "5.5.0",
+        "tslib": "1.8.1",
+        "tsutils": "2.29.0"
       },
       "dependencies": {
         "commander": {
@@ -5995,7 +5988,7 @@
       "integrity": "sha1-9UbcOEg5eeb7PPpZWErYUls61No=",
       "dev": true,
       "requires": {
-        "mock-require": "^2.0.2"
+        "mock-require": "2.0.2"
       }
     },
     "tsutils": {
@@ -6004,7 +5997,7 @@
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.8.1"
       }
     },
     "tunnel-agent": {
@@ -6013,7 +6006,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -6029,7 +6022,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-detect": {
@@ -6045,7 +6038,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.19"
       }
     },
     "typedarray": {
@@ -6067,9 +6060,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -6086,9 +6079,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -6107,8 +6100,8 @@
       "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
       "dev": true,
       "requires": {
-        "buffer": "^3.0.1",
-        "through": "^2.3.6"
+        "buffer": "3.6.0",
+        "through": "2.3.8"
       }
     },
     "unpipe": {
@@ -6147,8 +6140,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vary": {
@@ -6163,9 +6156,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "web-animations-js": {
@@ -6200,8 +6193,8 @@
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
       "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "tr46": "0.0.3",
+        "webidl-conversions": "3.0.1"
       },
       "dependencies": {
         "webidl-conversions": {
@@ -6218,7 +6211,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -6246,8 +6239,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -6256,7 +6249,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -6265,9 +6258,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -6284,7 +6277,7 @@
       "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "1.0.0"
       }
     },
     "xml-name-validator": {
@@ -6299,8 +6292,8 @@
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -6333,18 +6326,18 @@
       "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^8.1.0"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "8.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6359,9 +6352,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "strip-ansi": {
@@ -6370,7 +6363,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -6381,7 +6374,7 @@
       "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -6398,8 +6391,8 @@
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.1.0"
       }
     }
   }

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -156,6 +156,7 @@ export function w<W extends WidgetBaseInterface>(
 ): WNode<W> {
 	if (isWNode(widgetConstructorOrNode)) {
 		properties = { ...(widgetConstructorOrNode.properties as any), ...(properties as any) };
+		children = children.length ? children : widgetConstructorOrNode.children;
 		widgetConstructorOrNode = widgetConstructorOrNode.widgetConstructor;
 	}
 
@@ -199,8 +200,9 @@ export function v(
 		nodeClasses = Array.isArray(nodeClasses) ? nodeClasses : [nodeClasses];
 		classes = Array.isArray(classes) ? classes : [classes];
 		styles = { ...nodeStyles, ...styles };
-		newProperties = { ...nodeProperties, ...newProperties, classes: [...nodeClasses, ...classes], styles };
-		return v(tag.tag, newProperties, children ? children : tag.children);
+		properties = { ...nodeProperties, ...newProperties, classes: [...nodeClasses, ...classes], styles };
+		children = children ? children : tag.children;
+		tag = tag.tag;
 	}
 
 	return {

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -152,16 +152,16 @@ export function w<W extends WidgetBaseInterface>(
 export function w<W extends WidgetBaseInterface>(
 	widgetConstructorOrNode: Constructor<W> | RegistryLabel | WNode<W>,
 	properties: W['properties'],
-	children: W['children'] = []
+	children?: W['children']
 ): WNode<W> {
 	if (isWNode(widgetConstructorOrNode)) {
 		properties = { ...(widgetConstructorOrNode.properties as any), ...(properties as any) };
-		children = children.length ? children : widgetConstructorOrNode.children;
+		children = children ? children : widgetConstructorOrNode.children;
 		widgetConstructorOrNode = widgetConstructorOrNode.widgetConstructor;
 	}
 
 	return {
-		children,
+		children: children || [],
 		widgetConstructor: widgetConstructorOrNode,
 		properties,
 		type: WNODE

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -155,11 +155,13 @@ export function w<W extends WidgetBaseInterface>(
 /**
  * Wrapper function for calls to create VNodes.
  */
+export function v(node: VNode, properties: VNodeProperties, children: undefined | DNode[]): VNode;
+export function v(node: VNode, properties: VNodeProperties): VNode;
 export function v(tag: string, children: undefined | DNode[]): VNode;
 export function v(tag: string, properties: DeferredVirtualProperties | VNodeProperties, children?: DNode[]): VNode;
 export function v(tag: string): VNode;
 export function v(
-	tag: string,
+	tag: string | VNode,
 	propertiesOrChildren: VNodeProperties | DeferredVirtualProperties | DNode[] = {},
 	children: undefined | DNode[] = undefined
 ): VNode {
@@ -174,6 +176,16 @@ export function v(
 	if (typeof properties === 'function') {
 		deferredPropertiesCallback = properties;
 		properties = {};
+	}
+
+	if (isVNode(tag)) {
+		let { classes = [], styles = {}, ...newProperties } = properties;
+		let { classes: nodeClasses = [], styles: nodeStyles = {}, ...nodeProperties } = tag.properties;
+		nodeClasses = Array.isArray(nodeClasses) ? nodeClasses : [nodeClasses];
+		classes = Array.isArray(classes) ? classes : [classes];
+		styles = { ...nodeStyles, ...styles };
+		newProperties = { ...nodeProperties, ...newProperties, classes: [...nodeClasses, ...classes], styles };
+		return v(tag.tag, newProperties, children ? children : tag.children);
 	}
 
 	return {

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -32,7 +32,7 @@ export const DOMVNODE = Symbol('Identifier for a VNode created using existing do
  * Helper function that returns true if the `DNode` is a `WNode` using the `type` property
  */
 export function isWNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterface>(
-	child: DNode<W>
+	child: DNode<W> | any
 ): child is WNode<W> {
 	return Boolean(child && typeof child !== 'string' && child.type === WNODE);
 }
@@ -140,13 +140,28 @@ export function decorate(
  * Wrapper function for calls to create a widget.
  */
 export function w<W extends WidgetBaseInterface>(
+	node: WNode<W>,
+	properties: Partial<W['properties']>,
+	children?: W['children']
+): WNode<W>;
+export function w<W extends WidgetBaseInterface>(
 	widgetConstructor: Constructor<W> | RegistryLabel,
+	properties: W['properties'],
+	children?: W['children']
+): WNode<W>;
+export function w<W extends WidgetBaseInterface>(
+	widgetConstructorOrNode: Constructor<W> | RegistryLabel | WNode<W>,
 	properties: W['properties'],
 	children: W['children'] = []
 ): WNode<W> {
+	if (isWNode(widgetConstructorOrNode)) {
+		properties = { ...(widgetConstructorOrNode.properties as any), ...(properties as any) };
+		widgetConstructorOrNode = widgetConstructorOrNode.widgetConstructor;
+	}
+
 	return {
 		children,
-		widgetConstructor,
+		widgetConstructor: widgetConstructorOrNode,
 		properties,
 		type: WNODE
 	};

--- a/tests/widget-core/unit/d.ts
+++ b/tests/widget-core/unit/d.ts
@@ -142,6 +142,46 @@ registerSuite('d', {
 			assert.isTrue(isVNode(vNode));
 			assert.isFalse(isWNode(vNode));
 		},
+		'should mix properties onto passed vnode properties'() {
+			const children = ['child'];
+			const vnode = v('div', { a: 'a', b: 'b' }, children);
+			const mergedVNode = v(vnode, { c: 'c', b: 'c' });
+			assert.strictEqual(mergedVNode.tag, 'div');
+			assert.deepEqual(mergedVNode.properties, { a: 'a', b: 'c', c: 'c', styles: {}, classes: [] });
+			assert.strictEqual(mergedVNode.children, children);
+		},
+		'should replace children on passed vnode'() {
+			const children = ['new child'];
+			const vnode = v('div', { a: 'a', b: 'b' }, ['child']);
+			const mergedVNode = v(vnode, { c: 'c', b: 'c' }, children);
+			assert.strictEqual(mergedVNode.tag, 'div');
+			assert.deepEqual(mergedVNode.properties, { a: 'a', b: 'c', c: 'c', styles: {}, classes: [] });
+			assert.strictEqual(mergedVNode.children, children);
+		},
+		'should merge styles onto passed vnode properties'() {
+			const vnode = v('div', { styles: { color: 'red', width: '100px' } });
+			const mergedVNode = v(vnode, { styles: { width: '200px', height: '100px' } });
+			assert.strictEqual(mergedVNode.tag, 'div');
+			assert.deepEqual(mergedVNode.properties.styles, { color: 'red', width: '200px', height: '100px' });
+		},
+		'should merge classes onto passed vnode properties with no classes'() {
+			const vnode = v('div');
+			const mergedVNode = v(vnode, { classes: 'baz' });
+			assert.strictEqual(mergedVNode.tag, 'div');
+			assert.deepEqual(mergedVNode.properties.classes, ['baz']);
+		},
+		'should merge classes onto passed vnode properties with string classes'() {
+			const vnode = v('div', { classes: 'foo' });
+			const mergedVNode = v(vnode, { classes: ['baz'] });
+			assert.strictEqual(mergedVNode.tag, 'div');
+			assert.deepEqual(mergedVNode.properties.classes, ['foo', 'baz']);
+		},
+		'should merge classes onto passed vnode properties with an array of classes'() {
+			const vnode = v('div', { classes: ['foo', 'bar'] });
+			const mergedVNode = v(vnode, { classes: ['baz'] });
+			assert.strictEqual(mergedVNode.tag, 'div');
+			assert.deepEqual(mergedVNode.properties.classes, ['foo', 'bar', 'baz']);
+		},
 		'create VNode wrapper with deferred properties'() {
 			const props = () => {
 				return { a: 'a' };

--- a/tests/widget-core/unit/d.ts
+++ b/tests/widget-core/unit/d.ts
@@ -110,6 +110,47 @@ registerSuite('d', {
 			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isVNode(dNode));
+		},
+		'should merge properties onto a WNode'() {
+			class Foo extends WidgetBase<{ foo: string; bar: number }> {}
+			const dNode = w(Foo, { foo: 'foo', bar: 1 });
+			assert.equal(dNode.type, WNODE);
+			assert.strictEqual(dNode.widgetConstructor, Foo);
+			assert.deepEqual(dNode.properties, { foo: 'foo', bar: 1 });
+			assert.lengthOf(dNode.children, 0);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isVNode(dNode));
+			const mergedNode = w(dNode, { foo: 'bar' });
+			// maintains properties typings, this errors
+			// w(dNode, { foo: 1 });
+			assert.equal(mergedNode.type, WNODE);
+			assert.strictEqual(mergedNode.widgetConstructor, Foo);
+			assert.deepEqual(mergedNode.properties, { foo: 'bar', bar: 1 });
+			assert.lengthOf(mergedNode.children, 0);
+			assert.isTrue(isWNode(mergedNode));
+			assert.isFalse(isVNode(mergedNode));
+		},
+		'should replace children on a WNode'() {
+			class Foo extends WidgetBase<any, string> {}
+			const dNode = w(Foo, {}, ['original']);
+			assert.equal(dNode.type, WNODE);
+			assert.strictEqual(dNode.widgetConstructor, Foo);
+			assert.deepEqual(dNode.properties, {});
+			assert.lengthOf(dNode.children, 1);
+			assert.strictEqual(dNode.children[0], 'original');
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isVNode(dNode));
+			const mergedNode = w(dNode, {}, ['updated', 'children']);
+			// maintains children typings, this errors
+			// w(dNode, { }, [ v('div') ]);
+			assert.equal(mergedNode.type, WNODE);
+			assert.strictEqual(mergedNode.widgetConstructor, Foo);
+			assert.deepEqual(mergedNode.properties, {});
+			assert.lengthOf(mergedNode.children, 2);
+			assert.strictEqual(mergedNode.children[0], 'updated');
+			assert.strictEqual(mergedNode.children[1], 'children');
+			assert.isTrue(isWNode(mergedNode));
+			assert.isFalse(isVNode(mergedNode));
 		}
 	},
 	v: {

--- a/tests/widget-core/unit/d.ts
+++ b/tests/widget-core/unit/d.ts
@@ -153,6 +153,24 @@ registerSuite('d', {
 			assert.strictEqual(mergedNode.children[1], 'children');
 			assert.isTrue(isWNode(mergedNode));
 			assert.isFalse(isVNode(mergedNode));
+		},
+		'should replace children with an empty array on a WNode'() {
+			class Foo extends WidgetBase<any, string> {}
+			const dNode = w(Foo, {}, ['original']);
+			assert.equal(dNode.type, WNODE);
+			assert.strictEqual(dNode.widgetConstructor, Foo);
+			assert.deepEqual(dNode.properties, {});
+			assert.lengthOf(dNode.children, 1);
+			assert.strictEqual(dNode.children[0], 'original');
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isVNode(dNode));
+			const mergedNode = w(dNode, {}, []);
+			assert.equal(mergedNode.type, WNODE);
+			assert.strictEqual(mergedNode.widgetConstructor, Foo);
+			assert.deepEqual(mergedNode.properties, {});
+			assert.lengthOf(mergedNode.children, 0);
+			assert.isTrue(isWNode(mergedNode));
+			assert.isFalse(isVNode(mergedNode));
 		}
 	},
 	v: {

--- a/tests/widget-core/unit/d.ts
+++ b/tests/widget-core/unit/d.ts
@@ -113,11 +113,12 @@ registerSuite('d', {
 		},
 		'should merge properties onto a WNode'() {
 			class Foo extends WidgetBase<{ foo: string; bar: number }> {}
-			const dNode = w(Foo, { foo: 'foo', bar: 1 });
+			const dNode = w(Foo, { foo: 'foo', bar: 1 }, ['child']);
 			assert.equal(dNode.type, WNODE);
 			assert.strictEqual(dNode.widgetConstructor, Foo);
 			assert.deepEqual(dNode.properties, { foo: 'foo', bar: 1 });
-			assert.lengthOf(dNode.children, 0);
+			assert.lengthOf(dNode.children, 1);
+			assert.strictEqual(dNode.children[0], 'child');
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isVNode(dNode));
 			const mergedNode = w(dNode, { foo: 'bar' });
@@ -126,7 +127,8 @@ registerSuite('d', {
 			assert.equal(mergedNode.type, WNODE);
 			assert.strictEqual(mergedNode.widgetConstructor, Foo);
 			assert.deepEqual(mergedNode.properties, { foo: 'bar', bar: 1 });
-			assert.lengthOf(mergedNode.children, 0);
+			assert.lengthOf(mergedNode.children, 1);
+			assert.strictEqual(dNode.children[0], 'child');
 			assert.isTrue(isWNode(mergedNode));
 			assert.isFalse(isVNode(mergedNode));
 		},


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds an overload for `v()` and `w()` that accepts an existing instead of a string tag/widget constructor that that will merge any properties onto the provided node and replace the nodes children with the provided children.

Resolves: #67 