### PR TITLE
Only run linting on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 install:
 - travis_retry npm install
 script:
+- npm run lint
 - npm run test:browserstack
 - npm run uploadCoverage
 - npm run benchmark

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "precommit": "lint-staged",
     "prettier": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
     "release": "run-s lint clean build \"dojo-release -- {@}\" --",
-    "test": "run-s lint build intern",
-    "test:local": "run-s lint build \"intern config=@local\"",
-    "test:browserstack": "run-s lint build \"intern config=@browserstack\"",
+    "test": "run-s build intern",
+    "test:local": "run-s build \"intern config=@local\"",
+    "test:browserstack": "run-s build \"intern config=@browserstack\"",
     "uploadCoverage": "codecov --file=coverage/coverage.json",
     "watch:ts": "dojo-tsc-watcher -p tsconfig.json -p tsconfig.esm.json -- dojo-package",
     "watch": "run-p watch:ts \"build:static:** -- --watch\""


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Only run linting on CI as part of the pipeline.
