### PR TITLE
Add registry tsx type that transfers a registry id from a property

### DIFF
--- a/src/widget-core/tsx.ts
+++ b/src/widget-core/tsx.ts
@@ -43,6 +43,10 @@ export function tsx(tag: any, properties = {}, ...children: any[]): DNode {
 	properties = properties === null ? {} : properties;
 	if (typeof tag === 'string') {
 		return v(tag, properties, children);
+	} else if (tag.type === 'registry' && (properties as any).__autoRegistryItem) {
+		const name = (properties as any).__autoRegistryItem;
+		delete (properties as any).__autoRegistryItem;
+		return w(name, properties, children);
 	} else if (tag.type === REGISTRY_ITEM) {
 		const registryItem = new tag();
 		return w(registryItem.name, properties, children);

--- a/tests/widget-core/unit/tsx.ts
+++ b/tests/widget-core/unit/tsx.ts
@@ -36,6 +36,14 @@ registerSuite('tsx', {
 			assert.deepEqual(node.properties, { hello: 'world' } as any);
 			assert.deepEqual(node.children, ['child']);
 		},
+		'tsx generate a WNode from a registry type'() {
+			const node: WNode = tsx({ type: 'registry' }, { hello: 'world', __autoRegistryItem: 'foo' }, [
+				'child'
+			]) as WNode;
+			assert.deepEqual(node.widgetConstructor, 'foo');
+			assert.deepEqual(node.properties, { hello: 'world' } as any);
+			assert.deepEqual(node.children, ['child']);
+		},
 		'children arrays are spread correctly'() {
 			const node: VNode = tsx('div', { hello: 'world' }, ['child', ['child-2', ['child-3']]]) as VNode;
 			assert.deepEqual(node.tag, 'div');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Adds a small registry type hack for lazy loading widgets via tsx. The companion build pr for this is here: https://github.com/dojo/webpack-contrib/pull/60

