### PR TITLE
Convert `Outlet` from a HOC to a standard component with a render prop

### DIFF
--- a/examples/routing/ambigious-matches.ts
+++ b/examples/routing/ambigious-matches.ts
@@ -1,9 +1,9 @@
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import { v, w } from '@dojo/framework/widget-core/d';
-import { MapParamsOptions } from '@dojo/framework/routing/interfaces';
 
 import { Link } from '@dojo/framework/routing/Link';
 import { Outlet } from '@dojo/framework/routing/Outlet';
+import { MatchDetails } from '@dojo/framework/routing/interfaces';
 
 export interface ChildProperties {
 	name: string;
@@ -31,14 +31,6 @@ export class User extends WidgetBase<UserProperties> {
 	}
 }
 
-export const AboutOutlet = Outlet(About, 'about-us');
-export const CompanyOutlet = Outlet(Company, 'company');
-export const UserOutlet = Outlet(User, 'user', {
-	mapParams: ({ params }: MapParamsOptions) => {
-		return { name: params.user };
-	}
-});
-
 export class App extends WidgetBase {
 	protected render() {
 		return v('div', [
@@ -48,9 +40,24 @@ export class App extends WidgetBase {
 				v('li', [w(Link, { key: '3', to: 'user', params: { user: 'kim' } }, ['Kim (dynamic)'])]),
 				v('li', [w(Link, { key: '4', to: 'user', params: { user: 'chris' } }, ['Chris (dynamic)'])])
 			]),
-			w(AboutOutlet, {}),
-			w(CompanyOutlet, {}),
-			w(UserOutlet, {})
+			w(Outlet, {
+				outlet: 'about-us',
+				renderer: () => {
+					return w(About, {});
+				}
+			}),
+			w(Outlet, {
+				outlet: 'company',
+				renderer: () => {
+					return w(Company, {});
+				}
+			}),
+			w(Outlet, {
+				outlet: 'user',
+				renderer: ({ params }: MatchDetails) => {
+					return w(User, { name: params.user });
+				}
+			})
 		]);
 	}
 }
@@ -73,5 +80,3 @@ export const AmbiguousMatchesRouteConfig = {
 		}
 	]
 };
-
-export const AmbiguousMatchesOutlet = Outlet(App, 'ambiguous-matches');

--- a/examples/routing/basic.ts
+++ b/examples/routing/basic.ts
@@ -3,7 +3,7 @@ import { v, w } from '@dojo/framework/widget-core/d';
 
 import { Outlet } from '@dojo/framework/routing/Outlet';
 import { Link } from '@dojo/framework/routing/Link';
-import { MapParamsOptions } from '@dojo/framework/routing/interfaces';
+import { MatchDetails } from '@dojo/framework/routing/interfaces';
 
 export interface ChildProperties {
 	name: string;
@@ -39,7 +39,15 @@ export class Topics extends WidgetBase<TopicsProperties> {
 				v('li', [w(Link, { key: 'props', to: 'topic', params: { topic: 'props-v-state' } }, ['Props v State'])])
 			]),
 			showHeading ? v('h3', ['Please select a topic.']) : null,
-			w(TopicOutlet, {})
+			w(Outlet, {
+				outlet: 'topic',
+				renderer({ params, type }: MatchDetails) {
+					if (type === 'error') {
+						return w(ErrorWidget, {});
+					}
+					return w(Topic, { topic: params.topic });
+				}
+			})
 		]);
 	}
 }
@@ -60,19 +68,6 @@ class ErrorWidget extends WidgetBase {
 	}
 }
 
-export const AboutOutlet = Outlet(About, 'about');
-export const HomeOutlet = Outlet({ index: Home }, 'home');
-export const TopicsOutlet = Outlet(Topics, 'topics', {
-	mapParams: ({ type }: MapParamsOptions) => {
-		return { showHeading: type === 'index' };
-	}
-});
-export const TopicOutlet = Outlet({ main: Topic, error: ErrorWidget }, 'topic', {
-	mapParams: ({ params }) => {
-		return { topic: params.topic };
-	}
-});
-
 export class App extends WidgetBase {
 	protected render() {
 		return v('div', [
@@ -81,9 +76,24 @@ export class App extends WidgetBase {
 				v('li', [w(Link, { key: 'about', to: 'about' }, ['About'])]),
 				v('li', [w(Link, { key: 'topics', to: 'topics' }, ['Topics'])])
 			]),
-			w(AboutOutlet, {}),
-			w(HomeOutlet, {}),
-			w(TopicsOutlet, {})
+			w(Outlet, {
+				outlet: 'about',
+				renderer() {
+					return w(About, {});
+				}
+			}),
+			w(Outlet, {
+				outlet: 'home',
+				renderer() {
+					return w(Home, {});
+				}
+			}),
+			w(Outlet, {
+				outlet: 'topics',
+				renderer({ type }: MatchDetails) {
+					return w(Topics, { showHeading: type === 'index' });
+				}
+			})
 		]);
 	}
 }
@@ -112,5 +122,3 @@ export const BasicAppRouteConfig = {
 		}
 	]
 };
-
-export const BasicAppOutlet = Outlet(App, 'basic');

--- a/examples/routing/main.ts
+++ b/examples/routing/main.ts
@@ -6,9 +6,10 @@ import { Registry } from '@dojo/framework/widget-core/Registry';
 import { RouteConfig } from '@dojo/framework/routing/interfaces';
 import { registerRouterInjector } from '@dojo/framework/routing/RouterInjector';
 import { Link } from '@dojo/framework/routing/Link';
-import { BasicAppOutlet, BasicAppRouteConfig } from './basic';
-import { UrlParametersAppOutlet, UrlParametersRouteConfig } from './url-parameters';
-import { AmbiguousMatchesOutlet, AmbiguousMatchesRouteConfig } from './ambigious-matches';
+import { App as BasicApp, BasicAppRouteConfig } from './basic';
+import { App as UrlParametersApp, UrlParametersRouteConfig } from './url-parameters';
+import { App as AmbiguousMatchesApp, AmbiguousMatchesRouteConfig } from './ambigious-matches';
+import { Outlet } from '@dojo/framework/routing/Outlet';
 
 const applicationRoutes: RouteConfig[] = [BasicAppRouteConfig, UrlParametersRouteConfig, AmbiguousMatchesRouteConfig];
 
@@ -76,9 +77,24 @@ class App extends WidgetBase {
 				])
 			]),
 			v('div', { styles: contentStyles }, [
-				w(BasicAppOutlet, {}),
-				w(UrlParametersAppOutlet, {}),
-				w(AmbiguousMatchesOutlet, {})
+				w(Outlet, {
+					outlet: 'ambiguous-matches',
+					renderer() {
+						return w(AmbiguousMatchesApp, {});
+					}
+				}),
+				w(Outlet, {
+					outlet: 'basic',
+					renderer() {
+						return w(BasicApp, {});
+					}
+				}),
+				w(Outlet, {
+					outlet: 'url-parameters',
+					renderer() {
+						return w(UrlParametersApp, {});
+					}
+				})
 			])
 		]);
 	}

--- a/examples/routing/url-parameters.ts
+++ b/examples/routing/url-parameters.ts
@@ -1,9 +1,9 @@
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import { v, w } from '@dojo/framework/widget-core/d';
-import { MapParamsOptions } from '@dojo/framework/routing/interfaces';
 
 import { Link } from '@dojo/framework/routing/Link';
 import { Outlet } from '@dojo/framework/routing/Outlet';
+import { MatchDetails } from '@dojo/framework/routing/interfaces';
 
 export interface ChildProperties {
 	name: string;
@@ -15,12 +15,6 @@ export class Child extends WidgetBase<ChildProperties> {
 	}
 }
 
-export const ChildOutlet = Outlet(Child, 'child', {
-	mapParams: ({ params }: MapParamsOptions) => {
-		return { name: params.id };
-	}
-});
-
 export class App extends WidgetBase {
 	protected render() {
 		return v('div', [
@@ -31,7 +25,12 @@ export class App extends WidgetBase {
 				v('li', [w(Link, { key: '3', to: 'child', params: { id: 'yahoo' } }, ['Yahoo'])]),
 				v('li', [w(Link, { key: '4', to: 'child', params: { id: 'modus-create' } }, ['Modus Create'])])
 			]),
-			w(ChildOutlet, {})
+			w(Outlet, {
+				outlet: 'child',
+				renderer: (details: MatchDetails) => {
+					return w(Child, { name: details.params.id });
+				}
+			})
 		]);
 	}
 }
@@ -46,5 +45,3 @@ export const UrlParametersRouteConfig = {
 		}
 	]
 };
-
-export const UrlParametersAppOutlet = Outlet(App, 'url-parameters');

--- a/src/routing/Outlet.ts
+++ b/src/routing/Outlet.ts
@@ -14,7 +14,7 @@ export interface OutletProperties {
 
 @alwaysRender()
 export class Outlet extends WidgetBase<OutletProperties> {
-	private _handle: Handle;
+	private _handle: Handle | undefined;
 	private _matched = false;
 	private _matchedParams: Params = {};
 	private _onExit?: OnExit;
@@ -25,6 +25,7 @@ export class Outlet extends WidgetBase<OutletProperties> {
 		const item = this.registry.getInjector<Router>(routerKey);
 		if (this._handle) {
 			this._handle.destroy();
+			this._handle = undefined;
 		}
 		if (item) {
 			this._handle = item.invalidator.on('invalidate', () => {
@@ -92,4 +93,5 @@ export class Outlet extends WidgetBase<OutletProperties> {
 		return null;
 	}
 }
+
 export default Outlet;

--- a/src/routing/Outlet.ts
+++ b/src/routing/Outlet.ts
@@ -1,100 +1,95 @@
-import { DNode, WidgetBaseInterface } from '../widget-core/interfaces';
+import { DNode } from '../widget-core/interfaces';
 import { WidgetBase } from '../widget-core/WidgetBase';
-import { w } from '../widget-core/d';
-import { inject } from '../widget-core/decorators/inject';
 import { alwaysRender } from '../widget-core/decorators/alwaysRender';
-import { OnEnter, Component, OutletOptions, OutletComponents, Outlet, Params, OutletContext } from './interfaces';
+import { MatchDetails, OnExit, OutletContext, OnEnter, Params } from './interfaces';
 import { Router } from './Router';
+import { diffProperty } from '../widget-core/decorators/diffProperty';
+import { Handle } from '../core/Destroyable';
 
-export function isComponent<W extends WidgetBaseInterface>(value: any): value is Component<W> {
-	return Boolean(value && (typeof value === 'string' || typeof value === 'function' || typeof value === 'symbol'));
+export interface OutletProperties {
+	renderer: (matchDetails: MatchDetails) => DNode;
+	outlet: string;
+	routerKey?: string;
 }
 
-export function getProperties(router: Router, properties: any) {
-	return { router };
-}
+@alwaysRender()
+export class Outlet extends WidgetBase<OutletProperties> {
+	private _handle: Handle;
+	private _matched = false;
+	private _matchedParams: Params = {};
+	private _onExit?: OnExit;
 
-export function Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterface, E extends WidgetBaseInterface>(
-	outletComponents: Component<W> | OutletComponents<W, F, E>,
-	outlet: string,
-	options: OutletOptions = {}
-): Outlet<W, F, E> {
-	const indexComponent = isComponent(outletComponents) ? undefined : outletComponents.index;
-	const mainComponent = isComponent(outletComponents) ? outletComponents : outletComponents.main;
-	const errorComponent = isComponent(outletComponents) ? undefined : outletComponents.error;
-	const { mapParams, key = 'router' } = options;
-
-	@inject({ name: key, getProperties })
-	@alwaysRender()
-	class OutletComponent extends WidgetBase<Partial<W['properties']> & { router: Router }, null> {
-		private _matched = false;
-		private _matchedParams: Params = {};
-		private _onExit?: () => void;
-
-		private _hasRouteChanged(params: Params): boolean {
-			if (!this._matched) {
-				return true;
-			}
-			const newParamKeys = Object.keys(params);
-			for (let i = 0; i < newParamKeys.length; i++) {
-				const key = newParamKeys[i];
-				if (this._matchedParams[key] !== params[key]) {
-					return true;
-				}
-			}
-			return false;
+	@diffProperty('routerKey')
+	protected onRouterKeyChange(current: OutletProperties, next: OutletProperties) {
+		const { routerKey = 'router' } = next;
+		const item = this.registry.getInjector<Router>(routerKey);
+		if (this._handle) {
+			this._handle.destroy();
 		}
-
-		private _onEnter(outletContext: OutletContext, onEnterCallback?: OnEnter) {
-			const { params, type } = outletContext;
-			if (this._hasRouteChanged(params)) {
-				onEnterCallback && onEnterCallback(params, type);
-				this._matched = true;
-				this._matchedParams = params;
-			}
-		}
-
-		protected onDetach() {
-			if (this._matched) {
-				this._onExit && this._onExit();
-				this._matched = false;
-			}
-		}
-
-		protected render(): DNode {
-			let { router, ...properties } = this.properties;
-
-			const outletContext = router.getOutlet(outlet);
-			if (outletContext) {
-				const { queryParams, params, type, onEnter, onExit } = outletContext;
-				this._onExit = onExit;
-				if (mapParams) {
-					properties = { ...properties, ...mapParams({ queryParams, params, type, router }) };
-				}
-
-				if (type === 'index' && indexComponent) {
-					this._onEnter(outletContext, onEnter);
-					return w(indexComponent, properties, this.children);
-				} else if (type === 'error' && errorComponent) {
-					this._onEnter(outletContext, onEnter);
-					return w(errorComponent, properties, this.children);
-				} else if (type === 'error' && indexComponent) {
-					this._onEnter(outletContext, onEnter);
-					return w(indexComponent, properties, this.children);
-				} else if (type !== 'error' && mainComponent) {
-					this._onEnter(outletContext, onEnter);
-					return w(mainComponent, properties, this.children);
-				}
-			}
-
-			if (this._matched) {
-				this._onExit && this._onExit();
-				this._matched = false;
-			}
-			return null;
+		if (item) {
+			this._handle = item.invalidator.on('invalidate', () => {
+				this.invalidate();
+			});
+			this.own(this._handle);
 		}
 	}
-	return OutletComponent;
-}
 
+	protected onDetach() {
+		this._onExit && this._onExit();
+	}
+
+	protected onAttach() {
+		if (!this._handle) {
+			this.onRouterKeyChange(this.properties, this.properties);
+		}
+	}
+
+	private _hasRouteChanged(params: Params): boolean {
+		if (!this._matched) {
+			return true;
+		}
+		const newParamKeys = Object.keys(params);
+		for (let i = 0; i < newParamKeys.length; i++) {
+			const key = newParamKeys[i];
+			if (this._matchedParams[key] !== params[key]) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private _onEnter(outletContext: OutletContext, onEnterCallback?: OnEnter) {
+		const { params, type } = outletContext;
+		if (this._hasRouteChanged(params)) {
+			onEnterCallback && onEnterCallback(params, type);
+			this._matched = true;
+			this._matchedParams = params;
+		}
+	}
+
+	protected render(): DNode {
+		const { renderer, outlet, routerKey = 'router' } = this.properties;
+		const item = this.registry.getInjector<Router>(routerKey);
+
+		if (item) {
+			const router = item.injector();
+			const outletContext = router.getOutlet(outlet);
+			if (outletContext) {
+				const { queryParams, params, type, onEnter, onExit, isError, isExact } = outletContext;
+				this._onExit = onExit;
+				const result = renderer({ queryParams, params, type, isError, isExact, router });
+				if (result) {
+					this._onEnter(outletContext, onEnter);
+					return result;
+				}
+			}
+		}
+		if (this._matched) {
+			this._onExit && this._onExit();
+			this._onExit = undefined;
+			this._matched = false;
+		}
+		return null;
+	}
+}
 export default Outlet;

--- a/src/routing/Outlet.ts
+++ b/src/routing/Outlet.ts
@@ -7,8 +7,8 @@ import { diffProperty } from '../widget-core/decorators/diffProperty';
 import { Handle } from '../core/Destroyable';
 
 export interface OutletProperties {
-	renderer: (matchDetails: MatchDetails) => DNode;
-	outlet: string;
+	renderer: (matchDetails: MatchDetails) => DNode | DNode[];
+	id: string;
 	routerKey?: string;
 }
 
@@ -68,13 +68,13 @@ export class Outlet extends WidgetBase<OutletProperties> {
 		}
 	}
 
-	protected render(): DNode {
-		const { renderer, outlet, routerKey = 'router' } = this.properties;
+	protected render(): DNode | DNode[] {
+		const { renderer, id, routerKey = 'router' } = this.properties;
 		const item = this.registry.getInjector<Router>(routerKey);
 
 		if (item) {
 			const router = item.injector();
-			const outletContext = router.getOutlet(outlet);
+			const outletContext = router.getOutlet(id);
 			if (outletContext) {
 				const { queryParams, params, type, onEnter, onExit, isError, isExact } = outletContext;
 				this._onExit = onExit;

--- a/src/routing/README.md
+++ b/src/routing/README.md
@@ -10,8 +10,6 @@ Routing for Dojo applications.
      - [History Managers](#history-managers)
    - [Router Context Injection](#router-context-injection)
    - [Outlets](#outlets)
-     - [Outlet Component Types](#outlet-component-types)
-     - [Outlet Options](#outlet-options)
      - [Global Error Outlet](#global-error-outlet)
    - [Link](#link)
 
@@ -225,7 +223,7 @@ const router = registerRouterInjector(config, registry, { history, key: 'custom-
 
 The primary concept for the routing integration is an `outlet`, a unique identifier associated with the registered application route. The `Outlet` is a standard dojo widget and can be used anywhere within an application. The `Outlet` widget has a small API:
 
- * `outlet`: The name of the outlet to execute the `renderer` when matched.
+ * `id`: The id of the outlet to execute the `renderer` when matched.
  * `renderer`: A render function that is called when the outlet is matched.
  * `routerKey` (Optional): The `key` used when the router was defined in the registry - defaults to `router`.
 
@@ -234,7 +232,7 @@ The primary concept for the routing integration is an `outlet`, a unique identif
 ```ts
 render() {
 	return v('div', [
-		w(Outlet, { name: 'my-outlet', renderer: () => {
+		w(Outlet, { id: 'my-outlet', renderer: () => {
 			return w(MyWidget, {});
 		}})
 	])
@@ -280,7 +278,7 @@ interface MatchDetails {
 ```ts
 render() {
 	return v('div', [
-		w(Outlet, { name: 'my-outlet', renderer: (matchDetails: MatchDetails) => {
+		w(Outlet, { id: 'my-outlet', renderer: (matchDetails: MatchDetails) => {
 			if (matchDetails.isError()) {
 				return w(ErrorWidget, {});
 			}
@@ -298,7 +296,14 @@ render() {
 Whenever a match type of `error` is registered a global outlet is automatically added to the matched outlets called `errorOutlet`. This outlet can be used to render a widget for any unknown routes.
 
 ```ts
-const ErrorOutlet = Outlet((properties) => w(ErrorWidget, properties), { outlet: 'errorOutlet' });
+render() {
+	return w(Outlet, {
+		id: 'errorOutlet',
+		renderer: (matchDetails: MatchDetails) => {
+			return w(ErrorWidget, properties);
+		}
+	});
+}
 ```
 
 ### Link

--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -249,6 +249,8 @@ export class Router extends QueuingEvented<{ nav: NavEvent }> implements RouterI
 					queryParams: this._currentQueryParams,
 					params: { ...this._currentParams },
 					type,
+					isError: () => type === 'error',
+					isExact: () => type === 'index',
 					onEnter,
 					onExit
 				};
@@ -269,6 +271,8 @@ export class Router extends QueuingEvented<{ nav: NavEvent }> implements RouterI
 			this._matchedOutlets.errorOutlet = {
 				queryParams: this._currentQueryParams,
 				params: { ...this._currentParams },
+				isError: () => true,
+				isExact: () => false,
 				type: 'error'
 			};
 		}

--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -263,6 +263,7 @@ export class Router extends QueuingEvented<{ nav: NavEvent }> implements RouterI
 			} else {
 				if (previousOutlet !== undefined && routes.length === 0) {
 					this._matchedOutlets[previousOutlet].type = 'error';
+					this._matchedOutlets[previousOutlet].isError = () => true;
 				}
 				segments = [...segmentsForRoute];
 			}

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -123,18 +123,6 @@ export interface OnExit {
 	(): void;
 }
 
-export interface OutletRender<O> {
-	(properties: O & WidgetProperties, outletProperties: MatchDetails): DNode;
-}
-
-/**
- * Outlet options that can be configured
- */
-export interface OutletOptions {
-	key?: RegistryLabel;
-	outlet: string;
-}
-
 export interface MatchDetails {
 	/**
 	 * Query params from the matching route for the outlet
@@ -166,29 +154,6 @@ export interface MatchDetails {
 	 */
 	isExact(): boolean;
 }
-
-/**
- * Component type
- */
-export type Component<W extends WidgetBaseInterface = WidgetBaseInterface> = Constructor<W> | RegistryLabel;
-
-/**
- * Outlet component options
- */
-export interface OutletComponents<
-	W extends WidgetBaseInterface,
-	I extends WidgetBaseInterface,
-	E extends WidgetBaseInterface
-> {
-	main?: Component<W>;
-	index?: Component<I>;
-	error?: Component<E>;
-}
-
-/**
- * Type for Outlet
- */
-export type Outlet<O extends WidgetProperties> = Constructor<WidgetBase<O, null>>;
 
 /**
  * Properties for the Link widget

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -3,7 +3,8 @@ import {
 	RegistryLabel,
 	VNodeProperties,
 	WidgetBaseInterface,
-	WidgetProperties
+	WidgetProperties,
+	DNode
 } from '../widget-core/interfaces';
 import { WidgetBase } from '../widget-core/WidgetBase';
 
@@ -45,16 +46,6 @@ export interface Params {
 }
 
 /**
- * Options passed to the mapParams callback
- */
-export interface MapParamsOptions {
-	queryParams: Params;
-	params: Params;
-	type: MatchType;
-	router: RouterInterface;
-}
-
-/**
  * Type of outlet matches
  */
 export type MatchType = 'error' | 'index' | 'partial';
@@ -77,6 +68,16 @@ export interface OutletContext {
 	 * The query params for the route
 	 */
 	queryParams: Params;
+
+	/**
+	 * Returns `true` when the route is an error match
+	 */
+	isError(): boolean;
+
+	/**
+	 * Returns `true` when the route is an exact match
+	 */
+	isExact(): boolean;
 
 	/**
 	 * On enter for the route
@@ -114,13 +115,6 @@ export interface RouterInterface {
 	readonly currentParams: Params;
 }
 
-/**
- * Function for mapping params to properties
- */
-export interface MapParams {
-	(options: MapParamsOptions): any;
-}
-
 export interface OnEnter {
 	(params: Params, type: MatchType): void;
 }
@@ -129,12 +123,48 @@ export interface OnExit {
 	(): void;
 }
 
+export interface OutletRender<O> {
+	(properties: O & WidgetProperties, outletProperties: MatchDetails): DNode;
+}
+
 /**
  * Outlet options that can be configured
  */
 export interface OutletOptions {
 	key?: RegistryLabel;
-	mapParams?: MapParams;
+	outlet: string;
+}
+
+export interface MatchDetails {
+	/**
+	 * Query params from the matching route for the outlet
+	 */
+	queryParams: Params;
+
+	/**
+	 * Params from the matching route for the outlet
+	 */
+	params: Params;
+
+	/**
+	 * Match type of the route for the outlet, either `index`, `partial` or `error`
+	 */
+	type: MatchType;
+
+	/**
+	 * The router instance
+	 */
+	router: RouterInterface;
+
+	/**
+	 * Function returns true if the outlet match was an `error` type
+	 */
+	isError(): boolean;
+
+	/**
+	 * Function returns true if the outlet match was an `index` type
+	 */
+	isExact(): boolean;
 }
 
 /**
@@ -158,13 +188,7 @@ export interface OutletComponents<
 /**
  * Type for Outlet
  */
-export type Outlet<
-	W extends WidgetBaseInterface,
-	F extends WidgetBaseInterface,
-	E extends WidgetBaseInterface
-> = Constructor<
-	WidgetBase<Partial<E['properties']> & Partial<W['properties']> & Partial<F['properties']> & WidgetProperties, null>
->;
+export type Outlet<O extends WidgetProperties> = Constructor<WidgetBase<O, null>>;
 
 /**
  * Properties for the Link widget

--- a/tests/routing/unit/Outlet.ts
+++ b/tests/routing/unit/Outlet.ts
@@ -381,7 +381,7 @@ describe('Outlet', () => {
 			}
 		});
 
-		assert.isNull(outlet.__render__());
+		assert.isUndefined(outlet.__render__());
 	});
 
 	it('Should change the invalidator if the router key changes', () => {

--- a/tests/routing/unit/Outlet.ts
+++ b/tests/routing/unit/Outlet.ts
@@ -5,9 +5,10 @@ import { stub } from 'sinon';
 import { WidgetBase } from '../../../src/widget-core/WidgetBase';
 import { w } from '../../../src/widget-core/d';
 import { WNode } from '../../../src/widget-core/interfaces';
-import { Router } from '../../../src/routing/Router';
 import { MemoryHistory as HistoryManager } from '../../../src/routing/history/MemoryHistory';
-import { Outlet, getProperties } from '../../../src/routing/Outlet';
+import { Outlet } from '../../../src/routing/Outlet';
+import { Registry } from '../../../src/widget-core/Registry';
+import { registerRouterInjector } from '../../../src/routing/RouterInjector';
 
 class Widget extends WidgetBase {
 	render() {
@@ -17,6 +18,7 @@ class Widget extends WidgetBase {
 
 const configOnEnter = stub();
 const configOnExit = stub();
+let registry: Registry;
 
 const routeConfig = [
 	{
@@ -37,93 +39,61 @@ const routeConfig = [
 
 describe('Outlet', () => {
 	beforeEach(() => {
+		registry = new Registry();
 		configOnEnter.reset();
+		configOnExit.reset();
 	});
 
-	it('Should render the main component for index matches when no index component is set', () => {
-		const router = new Router(routeConfig, { HistoryManager });
+	it('Should render the result of the renderer when the outlet matches', () => {
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
+
 		router.setPath('/foo');
-		const TestOutlet = Outlet(Widget, 'foo');
-		const outlet = new TestOutlet();
-		outlet.__setProperties__({ router } as any);
+		const outlet = new Outlet();
+		outlet.__setProperties__({
+			outlet: 'foo',
+			renderer() {
+				return w(Widget, {});
+			}
+		});
+		outlet.registry.base = registry;
 		const renderResult = outlet.__render__() as WNode;
 		assert.strictEqual(renderResult.widgetConstructor, Widget);
 		assert.deepEqual(renderResult.children, []);
 		assert.deepEqual(renderResult.properties, {});
 	});
 
-	it('Should render the main component for partial matches', () => {
-		const router = new Router(routeConfig, { HistoryManager });
-		router.setPath('/foo/bar');
-		const TestOutlet = Outlet(Widget, 'foo');
-		const outlet = new TestOutlet();
-		outlet.__setProperties__({ router } as any);
-		const renderResult = outlet.__render__() as WNode;
-		assert.strictEqual(renderResult.widgetConstructor, Widget);
-		assert.deepEqual(renderResult.children, []);
-		assert.deepEqual(renderResult.properties, {});
-	});
-
-	it('Should render the index component only for index matches', () => {
-		const router = new Router(routeConfig, { HistoryManager });
+	it('Should set the type as index for exact matches', () => {
+		let matchType: string | undefined;
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo');
-		const TestOutlet = Outlet({ index: Widget }, 'foo');
-		const outlet = new TestOutlet();
-		outlet.__setProperties__({ router } as any);
-		let renderResult = outlet.__render__() as WNode;
-		assert.strictEqual(renderResult.widgetConstructor, Widget);
-		assert.deepEqual(renderResult.children, []);
-		assert.deepEqual(renderResult.properties, {});
-		router.setPath('/foo/bar');
-		renderResult = outlet.__render__() as WNode;
-		assert.isUndefined(renderResult);
+		const outlet = new Outlet();
+		outlet.__setProperties__({
+			outlet: 'foo',
+			renderer(details) {
+				matchType = details.type;
+				return null;
+			}
+		});
+		outlet.registry.base = registry;
+		outlet.__render__() as WNode;
+		assert.strictEqual(matchType, 'index');
 	});
 
-	it('Should render the error component only for error matches', () => {
-		const router = new Router(routeConfig, { HistoryManager });
+	it('Should set the type as error for error matches', () => {
+		let matchType: string | undefined;
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo/other');
-		const TestOutlet = Outlet({ error: Widget }, 'foo');
-		const outlet = new TestOutlet();
-		outlet.__setProperties__({ router } as any);
-		let renderResult = outlet.__render__() as WNode;
-		assert.strictEqual(renderResult.widgetConstructor, Widget);
-		assert.deepEqual(renderResult.children, []);
-		assert.deepEqual(renderResult.properties, {});
-	});
-
-	it('Should render the index component only for error matches when there is no error component', () => {
-		const router = new Router(routeConfig, { HistoryManager });
-		router.setPath('/foo/other');
-		const TestOutlet = Outlet({ index: Widget }, 'foo');
-		const outlet = new TestOutlet();
-		outlet.__setProperties__({ router } as any);
-		let renderResult = outlet.__render__() as WNode;
-		assert.strictEqual(renderResult.widgetConstructor, Widget);
-		assert.deepEqual(renderResult.children, []);
-		assert.deepEqual(renderResult.properties, {});
-	});
-
-	it('Map params is called with params, queryParams, match type and router', () => {
-		const router = new Router(routeConfig, { HistoryManager });
-		router.setPath('/baz/bazParam?bazQuery=true');
-		const mapParams = stub();
-		const TestOutlet = Outlet({ index: Widget }, 'baz', { mapParams });
-		const outlet = new TestOutlet();
-		outlet.__setProperties__({ router } as any);
-		outlet.__render__();
-		assert.isTrue(mapParams.calledOnce);
-		assert.isTrue(
-			mapParams.calledWith({
-				params: {
-					baz: 'bazParam'
-				},
-				queryParams: {
-					bazQuery: 'true'
-				},
-				router,
-				type: 'index'
-			})
-		);
+		const outlet = new Outlet();
+		outlet.__setProperties__({
+			outlet: 'foo',
+			renderer(details) {
+				matchType = details.type;
+				return null;
+			}
+		});
+		outlet.registry.base = registry;
+		outlet.__render__() as WNode;
+		assert.strictEqual(matchType, 'error');
 	});
 
 	it('configuration onEnter called when the outlet is rendered', () => {
@@ -146,12 +116,17 @@ describe('Outlet', () => {
 			}
 		];
 
-		const router = new Router(routeConfig, { HistoryManager });
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/baz/param');
-		const TestOutlet = Outlet({ index: Widget }, 'baz');
-		const outlet = new TestOutlet();
-		outlet.__setProperties__({ router } as any);
-		outlet.__render__();
+		const outlet = new Outlet();
+		outlet.__setProperties__({
+			outlet: 'baz',
+			renderer(details) {
+				return w(Widget, {});
+			}
+		});
+		outlet.registry.base = registry;
+		outlet.__render__() as WNode;
 		assert.isTrue(configOnEnter.calledOnce);
 		router.setPath('/baz/bar');
 		outlet.__render__();
@@ -167,10 +142,15 @@ describe('Outlet', () => {
 				return 'inner';
 			}
 		}
-		const InnerOutlet = Outlet({ index: InnerWidget }, 'qux');
+
 		class OuterWidget extends WidgetBase {
 			render() {
-				return w(InnerOutlet, {});
+				return w(Outlet, {
+					outlet: 'quz',
+					renderer() {
+						return w(InnerWidget, {});
+					}
+				});
 			}
 		}
 		const routeConfig = [
@@ -198,12 +178,17 @@ describe('Outlet', () => {
 			}
 		];
 
-		const router = new Router(routeConfig, { HistoryManager });
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/baz/param');
-		const TestOutlet = Outlet(OuterWidget, 'baz');
-		const outlet = new TestOutlet();
-		outlet.__setProperties__({ router } as any);
-		outlet.__render__();
+		const outlet = new Outlet();
+		outlet.__setProperties__({
+			outlet: 'baz',
+			renderer() {
+				return w(OuterWidget, {});
+			}
+		});
+		outlet.registry.base = registry;
+		outlet.__render__() as WNode;
 		assert.isTrue(configOnEnter.calledOnce);
 		router.setPath('/baz/bar');
 		outlet.__render__();
@@ -236,12 +221,19 @@ describe('Outlet', () => {
 			}
 		];
 
-		const router = new Router(routeConfig, { HistoryManager });
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo');
-		const TestOutlet = Outlet({ index: Widget }, 'foo');
-		const outlet = new TestOutlet();
-		outlet.__setProperties__({ router } as any);
-		outlet.__render__();
+		const outlet = new Outlet();
+		outlet.__setProperties__({
+			outlet: 'foo',
+			renderer(details) {
+				if (details.type === 'index') {
+					return w(Widget, {});
+				}
+			}
+		});
+		outlet.registry.base = registry;
+		outlet.__render__() as WNode;
 		assert.isTrue(configOnExit.notCalled);
 		router.setPath('/foo/bar');
 		outlet.__render__();
@@ -254,8 +246,5 @@ describe('Outlet', () => {
 		assert.isTrue(configOnExit.calledOnce);
 	});
 
-	it('getProperties returns the payload as router', () => {
-		const router = new Router(routeConfig, { HistoryManager });
-		assert.deepEqual(getProperties(router, {}), { router });
-	});
+	it('Should render nothing when if no router is available', () => {});
 });

--- a/tests/routing/unit/Outlet.ts
+++ b/tests/routing/unit/Outlet.ts
@@ -50,7 +50,7 @@ describe('Outlet', () => {
 		router.setPath('/foo');
 		const outlet = new Outlet();
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			renderer() {
 				return w(Widget, {});
 			}
@@ -68,7 +68,7 @@ describe('Outlet', () => {
 		router.setPath('/foo');
 		const outlet = new Outlet();
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			renderer(details) {
 				matchType = details.type;
 				return null;
@@ -85,7 +85,7 @@ describe('Outlet', () => {
 		router.setPath('/foo/other');
 		const outlet = new Outlet();
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			renderer(details) {
 				matchType = details.type;
 				return null;
@@ -120,7 +120,7 @@ describe('Outlet', () => {
 		router.setPath('/baz/param');
 		const outlet = new Outlet();
 		outlet.__setProperties__({
-			outlet: 'baz',
+			id: 'baz',
 			renderer(details) {
 				return w(Widget, {});
 			}
@@ -146,7 +146,7 @@ describe('Outlet', () => {
 		class OuterWidget extends WidgetBase {
 			render() {
 				return w(Outlet, {
-					outlet: 'quz',
+					id: 'quz',
 					renderer() {
 						return w(InnerWidget, {});
 					}
@@ -182,7 +182,7 @@ describe('Outlet', () => {
 		router.setPath('/baz/param');
 		const outlet = new Outlet();
 		outlet.__setProperties__({
-			outlet: 'baz',
+			id: 'baz',
 			renderer() {
 				return w(OuterWidget, {});
 			}
@@ -225,7 +225,7 @@ describe('Outlet', () => {
 		router.setPath('/foo');
 		const outlet = new Outlet();
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			renderer(details) {
 				if (details.type === 'index') {
 					return w(Widget, {});
@@ -272,7 +272,7 @@ describe('Outlet', () => {
 		const outlet = new TestOutlet();
 		outlet.__setCoreProperties__({ baseRegistry: registry, bind: outlet });
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			renderer(details) {
 				if (details.type === 'index') {
 					return w(Widget, {});
@@ -306,7 +306,7 @@ describe('Outlet', () => {
 		const outlet = new TestOutlet();
 		outlet.__setCoreProperties__({ baseRegistry: registry, bind: outlet });
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			renderer(details) {
 				if (details.type === 'index') {
 					return w(Widget, {});
@@ -340,7 +340,7 @@ describe('Outlet', () => {
 		const outlet = new TestOutlet();
 		outlet.__setCoreProperties__({ baseRegistry: registry, bind: outlet });
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			renderer(details) {
 				if (details.type === 'index') {
 					return w(Widget, {});
@@ -373,7 +373,7 @@ describe('Outlet', () => {
 		router.setPath('/other');
 		const outlet = new TestOutlet();
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			renderer(details) {
 				if (details.type === 'index') {
 					return w(Widget, {});
@@ -407,7 +407,7 @@ describe('Outlet', () => {
 		const outlet = new TestOutlet();
 		outlet.__setCoreProperties__({ baseRegistry: registry, bind: outlet });
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			routerKey: 'my-router',
 			renderer(details) {
 				if (details.type === 'index') {
@@ -421,7 +421,7 @@ describe('Outlet', () => {
 		routerTwo.setPath('/foo');
 		assert.strictEqual(invalidateCount, 1);
 		outlet.__setProperties__({
-			outlet: 'foo',
+			id: 'foo',
 			renderer(details) {
 				if (details.type === 'index') {
 					return w(Widget, {});

--- a/tests/routing/unit/Outlet.ts
+++ b/tests/routing/unit/Outlet.ts
@@ -270,7 +270,7 @@ describe('Outlet', () => {
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo');
 		const outlet = new TestOutlet();
-		outlet.__setCoreProperties__({ baseRegistry: registry, bind: outlet });
+		outlet.registry.base = registry;
 		outlet.__setProperties__({
 			id: 'foo',
 			renderer(details) {
@@ -304,7 +304,7 @@ describe('Outlet', () => {
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo');
 		const outlet = new TestOutlet();
-		outlet.__setCoreProperties__({ baseRegistry: registry, bind: outlet });
+		outlet.registry.base = registry;
 		outlet.__setProperties__({
 			id: 'foo',
 			renderer(details) {
@@ -338,7 +338,7 @@ describe('Outlet', () => {
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/other');
 		const outlet = new TestOutlet();
-		outlet.__setCoreProperties__({ baseRegistry: registry, bind: outlet });
+		outlet.registry.base = registry;
 		outlet.__setProperties__({
 			id: 'foo',
 			renderer(details) {
@@ -405,7 +405,7 @@ describe('Outlet', () => {
 		const routerTwo = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		routerOne.setPath('/foo');
 		const outlet = new TestOutlet();
-		outlet.__setCoreProperties__({ baseRegistry: registry, bind: outlet });
+		outlet.registry.base = registry;
 		outlet.__setProperties__({
 			id: 'foo',
 			routerKey: 'my-router',

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -321,13 +321,13 @@ describe('Router', () => {
 		router.on('nav', (event) => {
 			assert.strictEqual(event.type, 'nav');
 			assert.strictEqual(event.outlet, 'foo');
-			assert.deepEqual(event.context, {
-				queryParams: {},
-				params: { bar: 'defaultBar' },
-				type: 'index',
-				onEnter: undefined,
-				onExit: undefined
-			});
+			assert.deepEqual(event.context.queryParams, {});
+			assert.deepEqual(event.context.params, { bar: 'defaultBar' });
+			assert.deepEqual(event.context.type, 'index');
+			assert.isUndefined(event.context.onEnter);
+			assert.isUndefined(event.context.onExit);
+			assert.isTrue(event.context.isExact());
+			assert.isFalse(event.context.isError());
 			initialNavEvent = true;
 		});
 		assert.isTrue(initialNavEvent);

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -125,7 +125,9 @@ describe('Router', () => {
 		assert.isOk(context);
 		assert.deepEqual(context!.params, {});
 		assert.deepEqual(context!.queryParams, {});
-		assert.deepEqual(context!.type, 'error');
+		assert.strictEqual(context!.type, 'error');
+		assert.strictEqual(context!.isError(), true);
+		assert.strictEqual(context!.isExact(), false);
 	});
 
 	it('Should navigates to global "errorOutlet" if default route requires params but none have been provided', () => {
@@ -136,7 +138,9 @@ describe('Router', () => {
 		assert.isOk(errorContext);
 		assert.deepEqual(errorContext!.params, {});
 		assert.deepEqual(errorContext!.queryParams, {});
-		assert.deepEqual(errorContext!.type, 'error');
+		assert.strictEqual(errorContext!.type, 'error');
+		assert.strictEqual(errorContext!.isError(), true);
+		assert.strictEqual(errorContext!.isExact(), false);
 	});
 
 	it('Should register as an index match for an outlet that index matches the route', () => {
@@ -146,7 +150,8 @@ describe('Router', () => {
 		assert.isOk(context);
 		assert.deepEqual(context!.params, {});
 		assert.deepEqual(context!.queryParams, {});
-		assert.deepEqual(context!.type, 'index');
+		assert.strictEqual(context!.type, 'index');
+		assert.strictEqual(context!.isExact(), true);
 	});
 
 	it('Should register as a partial match for an outlet that matches a section of the route', () => {
@@ -157,11 +162,13 @@ describe('Router', () => {
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, {});
 		assert.deepEqual(fooContext!.type, 'partial');
+		assert.strictEqual(fooContext!.isExact(), false);
 		const barContext = router.getOutlet('bar');
 		assert.isOk(barContext);
 		assert.deepEqual(barContext!.params, {});
 		assert.deepEqual(barContext!.queryParams, {});
 		assert.deepEqual(barContext!.type, 'index');
+		assert.strictEqual(barContext!.isExact(), true);
 	});
 
 	it('Should register as a error match for an outlet that matches a section of the route with no further matching registered outlets', () => {
@@ -172,6 +179,7 @@ describe('Router', () => {
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, {});
 		assert.deepEqual(fooContext!.type, 'error');
+		assert.strictEqual(fooContext!.isError(), true);
 		const barContext = router.getOutlet('bar');
 		assert.isNotOk(barContext);
 	});
@@ -184,11 +192,15 @@ describe('Router', () => {
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, {});
 		assert.deepEqual(fooContext!.type, 'partial');
+		assert.strictEqual(fooContext!.isExact(), false);
+		assert.strictEqual(fooContext!.isError(), false);
 		const context = router.getOutlet('baz');
 		assert.isOk(context);
 		assert.deepEqual(context!.params, { baz: 'baz' });
 		assert.deepEqual(context!.queryParams, {});
 		assert.deepEqual(context!.type, 'index');
+		assert.strictEqual(context!.isExact(), true);
+		assert.strictEqual(context!.isError(), false);
 	});
 
 	it('Should return params from all matching outlets', () => {
@@ -199,16 +211,22 @@ describe('Router', () => {
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, { hello: 'world' });
 		assert.deepEqual(fooContext!.type, 'partial');
+		assert.strictEqual(fooContext!.isExact(), false);
+		assert.strictEqual(fooContext!.isError(), false);
 		const bazContext = router.getOutlet('baz');
 		assert.isOk(bazContext);
 		assert.deepEqual(bazContext!.params, { baz: 'baz' });
 		assert.deepEqual(bazContext!.queryParams, { hello: 'world' });
 		assert.deepEqual(bazContext!.type, 'partial');
+		assert.strictEqual(bazContext!.isExact(), false);
+		assert.strictEqual(bazContext!.isError(), false);
 		const quxContext = router.getOutlet('qux');
 		assert.isOk(quxContext);
 		assert.deepEqual(quxContext!.params, { baz: 'baz', qux: 'qux' });
 		assert.deepEqual(quxContext!.queryParams, { hello: 'world' });
 		assert.deepEqual(quxContext!.type, 'index');
+		assert.strictEqual(quxContext!.isExact(), true);
+		assert.strictEqual(quxContext!.isError(), false);
 	});
 
 	it('Should pass query params to all matched outlets', () => {
@@ -218,10 +236,14 @@ describe('Router', () => {
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, { query: 'true' });
 		assert.deepEqual(fooContext!.type, 'partial');
+		assert.strictEqual(fooContext!.isExact(), false);
+		assert.strictEqual(fooContext!.isError(), false);
 		const barContext = router.getOutlet('bar');
 		assert.deepEqual(barContext!.params, {});
 		assert.deepEqual(barContext!.queryParams, { query: 'true' });
 		assert.deepEqual(barContext!.type, 'index');
+		assert.strictEqual(barContext!.isExact(), true);
+		assert.strictEqual(barContext!.isError(), false);
 	});
 
 	it('Should pass params and query params to all matched outlets', () => {
@@ -237,6 +259,8 @@ describe('Router', () => {
 		assert.deepEqual(fooContext!.params, { view: 'bar' });
 		assert.deepEqual(fooContext!.queryParams, { filter: 'true' });
 		assert.deepEqual(fooContext!.type, 'index');
+		assert.strictEqual(fooContext!.isExact(), true);
+		assert.strictEqual(fooContext!.isError(), false);
 	});
 
 	it('Should return all params for a route', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

This changes the `Outlet` from a higher order component to a standard component with a render property. The render property is used to display content when a route matches providing more control over the nodes to render when an Outlet's route has been matched.

Having an `Outlet` as a HOC implies that it would be shared across the application (which generally they are not), adds complexity in it's usage by having to specify another interface for the properties that the `Outlet` can accept and has more boilerplate and indirection that if the `Outlet` is a standard widget.

```ts
render() {
    return v('div', [
        w(Outlet, { 
            id: 'outlet-name', 
            renderer: (matchDetails: MatchDetails) => {
                // match details contains the `matchType`, `params` and `queryParams`
                return v(MyWidget, { foo: 'bar', id: matchDetails.id });
            }
        })
    ]);
}
```

Resolves #60 

Alternative to #24 
