### PR TITLE
Forwards compatibility for TS2.7 through to TS3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6056,9 +6056,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,14 @@
         "tslint-language-service": "~0.9.9",
         "typescript": "~2.6.2",
         "yargs": "~10.1.2"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+          "dev": true
+        }
       }
     },
     "@dojo/shim": {
@@ -6048,9 +6056,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
+      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -357,9 +357,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.5.tgz",
-      "integrity": "sha512-18OnkBZ+9pOx8grC2w4i256VS+9j/Ya/N0DcWkZRgPrg7V2oolgk8n7790goBlnChL6nIXAXy1lBTrz/r4lJTg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.6.tgz",
+      "integrity": "sha512-403D4wN95Mtzt2EoQHARf5oe/jEPhzBOBNrunk+ydQGW8WmkQ/E8rViRAEB1qEt/vssfGfNVD6ujP4FVeegrLg==",
       "dev": true
     },
     "@types/jsdom": {
@@ -409,9 +409,9 @@
       }
     },
     "@types/node": {
-      "version": "9.6.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.27.tgz",
-      "integrity": "sha512-fGWGG9Wypv6JZLIrnq9jXFX/FhQzgNccTlojez9hBbQ9UiBdxtc0ONMMe4/vnB2nDgOMDpPR/7HhenUB+Bw5yQ==",
+      "version": "9.6.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.28.tgz",
+      "integrity": "sha512-LMSOxMKNJ8tGqUVs8lSIT8RGo1XGWYada/ZU2QZcbcD6AW9futXDE99tfQA0K6DK60GXcwplsGGK5KABRmI5GA==",
       "dev": true
     },
     "@types/platform": {
@@ -1201,9 +1201,9 @@
       }
     },
     "ci-info": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.2.0.tgz",
-      "integrity": "sha512-U4aoLsSz44FhOyZ2E7bCufaBr2IUzNYujBd+b9vHiFH7SUzIhKcD94PQP5QSFn7ngPof6OF2yPk4/hygqwMJhA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.3.1.tgz",
+      "integrity": "sha512-l4wK/SFEN8VVTQ9RO1I5yzIL2vw1w6My29qA6Gwaec80QeHxfXbruuUWqn1knyMoJn/X5kav3zVY1TlRHSKeIA==",
       "dev": true
     },
     "cldr-data": {
@@ -1750,13 +1750,12 @@
       }
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "object-keys": "^1.0.12"
       }
     },
     "del": {
@@ -2447,12 +2446,6 @@
       "requires": {
         "for-in": "^1.0.1"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -3532,12 +3525,12 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
+      "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "^1.3.0"
       }
     },
     "is-date-object": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,11 +483,6 @@
       "integrity": "sha512-E0QjLIX1q+ThpQ7HLh5SjMtUtPl0tQjxoLMPwJtFDFtH7C0qdXmCgNcBplZ9m24+sOoQBpc0PT/aMW4jlm3K6g==",
       "dev": true
     },
-    "@types/web-animations-js": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@types/web-animations-js/-/web-animations-js-2.2.5.tgz",
-      "integrity": "sha512-3kjO6yvLt1e673wtcKEz0lgLKqPkBiuwxQj0DQ1jj+48HB03emIlTQYcqKAvB9UwOXq09QrWy/Dm6ZU8xMZVTw=="
-    },
     "@types/ws": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-4.0.2.tgz",
@@ -6056,9 +6051,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,14 +49,6 @@
         "tslint-language-service": "~0.9.9",
         "typescript": "~2.6.2",
         "yargs": "~10.1.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
-          "dev": true
-        }
       }
     },
     "@dojo/shim": {
@@ -365,9 +357,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.6.tgz",
-      "integrity": "sha512-403D4wN95Mtzt2EoQHARf5oe/jEPhzBOBNrunk+ydQGW8WmkQ/E8rViRAEB1qEt/vssfGfNVD6ujP4FVeegrLg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.5.tgz",
+      "integrity": "sha512-18OnkBZ+9pOx8grC2w4i256VS+9j/Ya/N0DcWkZRgPrg7V2oolgk8n7790goBlnChL6nIXAXy1lBTrz/r4lJTg==",
       "dev": true
     },
     "@types/jsdom": {
@@ -417,9 +409,9 @@
       }
     },
     "@types/node": {
-      "version": "9.6.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.28.tgz",
-      "integrity": "sha512-LMSOxMKNJ8tGqUVs8lSIT8RGo1XGWYada/ZU2QZcbcD6AW9futXDE99tfQA0K6DK60GXcwplsGGK5KABRmI5GA==",
+      "version": "9.6.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.27.tgz",
+      "integrity": "sha512-fGWGG9Wypv6JZLIrnq9jXFX/FhQzgNccTlojez9hBbQ9UiBdxtc0ONMMe4/vnB2nDgOMDpPR/7HhenUB+Bw5yQ==",
       "dev": true
     },
     "@types/platform": {
@@ -1209,9 +1201,9 @@
       }
     },
     "ci-info": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.3.1.tgz",
-      "integrity": "sha512-l4wK/SFEN8VVTQ9RO1I5yzIL2vw1w6My29qA6Gwaec80QeHxfXbruuUWqn1knyMoJn/X5kav3zVY1TlRHSKeIA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.2.0.tgz",
+      "integrity": "sha512-U4aoLsSz44FhOyZ2E7bCufaBr2IUzNYujBd+b9vHiFH7SUzIhKcD94PQP5QSFn7ngPof6OF2yPk4/hygqwMJhA==",
       "dev": true
     },
     "cldr-data": {
@@ -1758,12 +1750,13 @@
       }
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "del": {
@@ -2454,6 +2447,12 @@
       "requires": {
         "for-in": "^1.0.1"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -3533,12 +3532,12 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
-      "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.3.0"
+        "ci-info": "^1.0.0"
       }
     },
     "is-date-object": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6056,9 +6056,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
+      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@types/cldrjs": "0.4.20",
     "@types/globalize": "0.0.34",
-    "@types/web-animations-js": "2.2.5",
     "@webcomponents/webcomponentsjs": "1.1.0",
     "cldrjs": "0.4.8",
     "css-select-umd": "1.3.0-rc0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "rimraf": "~2.6.2",
     "selenium-webdriver": "3.6.0",
     "sinon": "~4.1.3",
-    "typescript": "~3.0.0",
+    "typescript": "^2.5.3",
     "whatwg-fetch": "^2.0.4"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "rimraf": "~2.6.2",
     "selenium-webdriver": "3.6.0",
     "sinon": "~4.1.3",
-    "typescript": "^2.5.3",
+	"typescript": "~2.6.2",
     "whatwg-fetch": "^2.0.4"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "rimraf": "~2.6.2",
     "selenium-webdriver": "3.6.0",
     "sinon": "~4.1.3",
-	"typescript": "~2.6.2",
+    "typescript": "~2.6.2",
     "whatwg-fetch": "^2.0.4"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "rimraf": "~2.6.2",
     "selenium-webdriver": "3.6.0",
     "sinon": "~4.1.3",
-    "typescript": "~2.6.2",
+    "typescript": "~3.0.0",
     "whatwg-fetch": "^2.0.4"
   },
   "lint-staged": {

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -2,7 +2,7 @@
 import global from '../shim/global';
 import { isArrayLike, isIterable } from '../shim/iterator';
 import Map from '../shim/Map';
-import Evented from '../core/Evented';
+import Evented, { EventObject } from '../core/Evented';
 import has from '../has/preset';
 import { uuid } from '../core/util';
 import * as Globalize from 'globalize/dist/globalize/message';
@@ -98,10 +98,14 @@ export interface Messages {
 	[key: string]: string;
 }
 
+export interface I18nEventObject extends EventObject<string> {
+	target: any;
+}
+
 const TOKEN_PATTERN = /\{([a-z0-9_]+)\}/gi;
 const bundleMap = new Map<string, Map<string, Messages>>();
 const formatterMap = new Map<string, MessageFormatter>();
-const localeProducer = new Evented();
+const localeProducer = new Evented<{}, string, I18nEventObject>();
 let rootLocale: string;
 
 /**
@@ -282,7 +286,7 @@ export function formatMessage<T extends Messages>(
  *
  * @return The cached messages object, if it exists.
  */
-export function getCachedMessages<T extends Messages>(bundle: Bundle<T>, locale: string): T | void {
+export function getCachedMessages<T extends Messages>(bundle: Bundle<T>, locale: string): T | undefined {
 	const { id = getBundleId(bundle), locales, messages } = bundle;
 	const cached = bundleMap.get(id);
 

--- a/src/shim/AbortController.ts
+++ b/src/shim/AbortController.ts
@@ -4,7 +4,7 @@ import { findIndex } from './array';
 
 export interface AbortSignal extends EventTarget {
 	aborted: boolean;
-	onabort: (ev: Event) => any;
+	onabort: undefined | ((ev: Event) => any);
 }
 
 export interface AbortSignalConstructor {
@@ -18,7 +18,7 @@ export let ShimAbortSignal: AbortSignalConstructor = global.AbortSignal;
 if (!has('abort-signal')) {
 	global.AbortSignal = ShimAbortSignal = class implements AbortSignal {
 		private _aborted = false;
-		onabort: (ev: Event) => any;
+		onabort: undefined | ((ev: Event) => any);
 
 		listeners: { [type: string]: ((event: Event) => void)[] } = {};
 

--- a/src/shim/object.ts
+++ b/src/shim/object.ts
@@ -149,10 +149,7 @@ if (has('es6-object')) {
 		return to;
 	};
 
-	getOwnPropertyDescriptor = function getOwnPropertyDescriptor(
-		o: any,
-		prop: string | symbol
-	): PropertyDescriptor | undefined {
+	getOwnPropertyDescriptor = function<T, K extends keyof T>(o: T, prop: K): PropertyDescriptor | undefined {
 		if (isSymbol(prop)) {
 			return (<any>Object).getOwnPropertyDescriptor(o, prop);
 		} else {

--- a/src/widget-core/Registry.ts
+++ b/src/widget-core/Registry.ts
@@ -28,7 +28,7 @@ export const WIDGET_BASE_TYPE = Symbol('Widget Base');
 
 export interface RegistryEventObject extends EventObject<RegistryLabel> {
 	action: string;
-	item: WidgetBaseConstructor | InjectorFactory;
+	item: WidgetBaseConstructor | InjectorItem;
 }
 /**
  * Widget Registry Interface

--- a/src/widget-core/meta/WebAnimation.ts
+++ b/src/widget-core/meta/WebAnimation.ts
@@ -32,7 +32,7 @@ export interface AnimationTimingProperties {
 	iterationStart?: number;
 }
 
-interface AnimationKeyFrame {
+export interface AnimationKeyFrame {
 	easing?: string | string[];
 	offset?: number | Array<number | null> | null;
 	opacity?: number | number[];
@@ -62,7 +62,7 @@ export interface AnimationInfo {
 }
 
 export interface AnimationPlayer {
-	player: Animation;
+	player: any;
 	used: boolean;
 }
 
@@ -74,12 +74,12 @@ export class WebAnimations extends Base {
 
 		const fx = typeof effects === 'function' ? effects() : effects;
 
-		const keyframeEffect = new KeyframeEffect(node, fx as any, timing);
+		const keyframeEffect = new global.KeyframeEffect(node, fx, timing);
 
-		return new Animation(keyframeEffect, global.document.timeline);
+		return new global.Animation(keyframeEffect, global.document.timeline);
 	}
 
-	private _updatePlayer(player: Animation, controls: AnimationControls) {
+	private _updatePlayer(player: any, controls: AnimationControls) {
 		const { play, reverse, cancel, finish, onFinish, onCancel, playbackRate, startTime, currentTime } = controls;
 
 		if (playbackRate !== undefined) {

--- a/src/widget-core/meta/WebAnimation.ts
+++ b/src/widget-core/meta/WebAnimation.ts
@@ -32,6 +32,13 @@ export interface AnimationTimingProperties {
 	iterationStart?: number;
 }
 
+interface AnimationKeyFrame {
+	easing?: string | string[];
+	offset?: number | Array<number | null> | null;
+	opacity?: number | number[];
+	transform?: string | string[];
+}
+
 /**
  * Animation propertiues that can be passed as vdom property `animate`
  */
@@ -62,12 +69,12 @@ export interface AnimationPlayer {
 export class WebAnimations extends Base {
 	private _animationMap = new Map<string, AnimationPlayer>();
 
-	private _createPlayer(node: HTMLElement, properties: AnimationProperties): Animation {
+	private _createPlayer(node: HTMLElement, properties: AnimationProperties): any {
 		const { effects, timing = {} } = properties;
 
 		const fx = typeof effects === 'function' ? effects() : effects;
 
-		const keyframeEffect = new KeyframeEffect(node, fx, timing as AnimationEffectTiming);
+		const keyframeEffect = new KeyframeEffect(node, fx as any, timing);
 
 		return new Animation(keyframeEffect, global.document.timeline);
 	}
@@ -161,10 +168,10 @@ export class WebAnimations extends Base {
 			const { currentTime, playState, playbackRate, startTime } = animation.player;
 
 			return {
-				currentTime,
+				currentTime: currentTime || 0,
 				playState,
 				playbackRate,
-				startTime
+				startTime: startTime || 0
 			};
 		}
 	}

--- a/tests/core/unit/Evented.ts
+++ b/tests/core/unit/Evented.ts
@@ -39,8 +39,8 @@ registerSuite('Evented', {
 		'on() with Symbol type'() {
 			const foo = Symbol();
 			const bar = Symbol();
-			const eventStack: symbol[] = [];
-			const evented = new Evented<{}, symbol>();
+			const eventStack: (symbol | string)[] = [];
+			const evented = new Evented<{}, symbol | string>();
 			const handle = evented.on(foo, (event) => {
 				eventStack.push(event.type);
 			});
@@ -173,10 +173,10 @@ registerSuite('Evented', {
 			const eventStack: string[] = [];
 			const evented = new Evented();
 			evented.on('foo', (event) => {
-				eventStack.push(`foo->${event.type}`);
+				eventStack.push(`foo->${event.type.toString()}`);
 			});
 			evented.on('*foo', (event) => {
-				eventStack.push(`*foo->${event.type}`);
+				eventStack.push(`*foo->${event.type.toString()}`);
 			});
 
 			evented.emit({ type: 'foo' });

--- a/tests/core/unit/QueuingEvented.ts
+++ b/tests/core/unit/QueuingEvented.ts
@@ -6,7 +6,7 @@ import { EventObject } from '../../../src/core/Evented';
 
 interface CustomEvent extends EventObject {
 	type: 'test';
-	target: any;
+	target?: any;
 	value: number;
 }
 
@@ -16,7 +16,7 @@ function isCustomEvent(object: any): object is CustomEvent {
 
 registerSuite('QueuingEvented', {
 	'events are queued for the first subscriber': function() {
-		const evented = new QueuingEvented();
+		const evented = new QueuingEvented<{}, string, CustomEvent>();
 		let listenerCallCount = 0;
 
 		evented.emit({
@@ -32,7 +32,7 @@ registerSuite('QueuingEvented', {
 	},
 
 	'events do not get queued over maximum'() {
-		const evented = new QueuingEvented();
+		const evented = new QueuingEvented<{}, string, CustomEvent>();
 		evented.maxEvents = 5;
 		let expectedValues: number[] = [];
 

--- a/tests/i18n/unit/i18n.ts
+++ b/tests/i18n/unit/i18n.ts
@@ -409,7 +409,7 @@ registerSuite('i18n', {
 					const cached = getCachedMessages(bundle, 'ar-JO');
 
 					assert.throws(() => {
-						cached!['hello'] = 'Hello';
+						cached!.hello = 'Hello';
 					});
 				});
 			}

--- a/tests/routing/unit/history/StateHistory.ts
+++ b/tests/routing/unit/history/StateHistory.ts
@@ -26,8 +26,8 @@ describe('StateHistory', () => {
 	});
 
 	it('initializes current path to current location', () => {
-		sandbox.contentWindow.history.pushState({}, '', '/foo?bar');
-		assert.equal(new StateHistory({ onChange, window: sandbox.contentWindow }).current, '/foo?bar');
+		sandbox.contentWindow!.history.pushState({}, '', '/foo?bar');
+		assert.equal(new StateHistory({ onChange, window: sandbox.contentWindow! }).current, '/foo?bar');
 	});
 
 	it('location defers to the global object', () => {
@@ -35,34 +35,34 @@ describe('StateHistory', () => {
 	});
 
 	it('prefixes path with leading slash if necessary', () => {
-		const history = new StateHistory({ onChange, window: sandbox.contentWindow });
+		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		assert.equal(history.prefix('/foo'), '/foo');
 		assert.equal(history.prefix('foo'), '/foo');
 	});
 
 	it('update path', () => {
-		const history = new StateHistory({ onChange, window: sandbox.contentWindow });
+		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		history.set('/foo');
 		assert.equal(history.current, '/foo');
-		assert.equal(sandbox.contentWindow.location.pathname, '/foo');
+		assert.equal(sandbox.contentWindow!.location.pathname, '/foo');
 	});
 
 	it('update path, adds leading slash if necessary', () => {
-		const history = new StateHistory({ onChange, window: sandbox.contentWindow });
+		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		history.set('foo');
 		assert.equal(history.current, '/foo');
-		assert.equal(sandbox.contentWindow.location.pathname, '/foo');
+		assert.equal(sandbox.contentWindow!.location.pathname, '/foo');
 	});
 
 	it('emits change when path is updated', () => {
-		const history = new StateHistory({ onChange, window: sandbox.contentWindow });
+		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		history.set('/foo');
 		assert.deepEqual(onChange.firstCall.args, ['/foo']);
 	});
 
 	it('does not emit change if path is set to the current value', () => {
-		sandbox.contentWindow.history.pushState({}, '', '/foo');
-		const history = new StateHistory({ onChange, window: sandbox.contentWindow });
+		sandbox.contentWindow!.history.pushState({}, '', '/foo');
+		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		history.set('/foo');
 		assert.isTrue(onChange.notCalled);
 	});
@@ -89,58 +89,58 @@ describe('StateHistory', () => {
 		});
 
 		it('initializes current path, taking out the base, with trailing slash', () => {
-			sandbox.contentWindow.history.pushState({}, '', '/foo/bar?baz');
+			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar?baz');
 			assert.equal(
-				new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow }).current,
+				new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! }).current,
 				'/bar?baz'
 			);
 		});
 
 		it('initializes current path, taking out the base, without trailing slash', () => {
-			sandbox.contentWindow.history.pushState({}, '', '/foo/bar?baz');
+			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar?baz');
 			assert.equal(
-				new StateHistory({ onChange, base: '/foo', window: sandbox.contentWindow }).current,
+				new StateHistory({ onChange, base: '/foo', window: sandbox.contentWindow! }).current,
 				'/bar?baz'
 			);
 		});
 
 		it("initializes current path to / if it's not a base suffix", () => {
-			sandbox.contentWindow.history.pushState({}, '', '/foo/bar?baz');
-			assert.equal(new StateHistory({ onChange, base: '/thud/', window: sandbox.contentWindow }).current, '/');
+			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar?baz');
+			assert.equal(new StateHistory({ onChange, base: '/thud/', window: sandbox.contentWindow! }).current, '/');
 		});
 
 		it('#prefix prefixes path with the base (with trailing slash)', () => {
-			const history = new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow });
+			const history = new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
 			assert.equal(history.prefix('/bar'), '/foo/bar');
 			assert.equal(history.prefix('bar'), '/foo/bar');
 		});
 
 		it('#prefix prefixes path with the base (without trailing slash)', () => {
-			const history = new StateHistory({ onChange, base: '/foo', window: sandbox.contentWindow });
+			const history = new StateHistory({ onChange, base: '/foo', window: sandbox.contentWindow! });
 			assert.equal(history.prefix('/bar'), '/foo/bar');
 			assert.equal(history.prefix('bar'), '/foo/bar');
 		});
 
 		it('#set expands the path with the base when pushing state, with trailing slash', () => {
-			const history = new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow });
+			const history = new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
 			history.set('/bar');
 			assert.equal(history.current, '/bar');
-			assert.equal(sandbox.contentWindow.location.pathname, '/foo/bar');
+			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/bar');
 
 			history.set('baz');
 			assert.equal(history.current, '/baz');
-			assert.equal(sandbox.contentWindow.location.pathname, '/foo/baz');
+			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/baz');
 		});
 
 		it('#set expands the path with the base when pushing state, without trailing slash', () => {
-			const history = new StateHistory({ onChange, base: '/foo', window: sandbox.contentWindow });
+			const history = new StateHistory({ onChange, base: '/foo', window: sandbox.contentWindow! });
 			history.set('/bar');
 			assert.equal(history.current, '/bar');
-			assert.equal(sandbox.contentWindow.location.pathname, '/foo/bar');
+			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/bar');
 
 			history.set('baz');
 			assert.equal(history.current, '/baz');
-			assert.equal(sandbox.contentWindow.location.pathname, '/foo/baz');
+			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/baz');
 		});
 	});
 });

--- a/tests/widget-core/unit/RegistryHandler.ts
+++ b/tests/widget-core/unit/RegistryHandler.ts
@@ -3,6 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import RegistryHandler from '../../../src/widget-core/RegistryHandler';
 import Registry from '../../../src/widget-core/Registry';
 import { WidgetBase } from '../../../src/widget-core/WidgetBase';
+import { Evented } from '../../../src/core/Evented';
 
 const foo = Symbol();
 const bar = Symbol();
@@ -118,7 +119,7 @@ registerSuite('RegistryHandler', {
 				registryHandler.get('global');
 				registryHandler.define('global', LocalWidget);
 				assert.strictEqual(invalidateCount, 1);
-				registry.emit({ type: 'global', action: 'other' });
+				registry.emit({ type: 'global', action: 'other', item: LocalWidget });
 				assert.strictEqual(invalidateCount, 1);
 			},
 			'no `invalidate` events emitted once the with registry with the highest precedence has loaded'() {
@@ -160,10 +161,10 @@ registerSuite('RegistryHandler', {
 				registryHandler.get('global');
 				registryHandler.base = registry;
 				registryHandler.get('global');
-				registry.emit({ type: 'global', action: 'other' });
+				registry.emit({ type: 'global', action: 'other', item: WidgetBase });
 				assert.strictEqual(invalidateCount, 0);
 				registryHandler.get('global', true);
-				registry.emit({ type: 'global', action: 'other' });
+				registry.emit({ type: 'global', action: 'other', item: WidgetBase });
 				assert.strictEqual(invalidateCount, 0);
 			}
 		}
@@ -257,7 +258,14 @@ registerSuite('RegistryHandler', {
 				registryHandler.getInjector('global');
 				registryHandler.defineInjector('global', localInjector);
 				assert.strictEqual(invalidateCount, 1);
-				registry.emit({ type: 'global', action: 'other' });
+				registry.emit({
+					type: 'global',
+					action: 'other',
+					item: {
+						injector: () => ({}),
+						invalidator: new Evented()
+					}
+				});
 				assert.strictEqual(invalidateCount, 1);
 			},
 			'no `invalidate` events emitted once the with registry with the highest precedence has loaded'() {
@@ -300,10 +308,24 @@ registerSuite('RegistryHandler', {
 				});
 
 				registryHandler.getInjector('global');
-				registry.emit({ type: 'global', action: 'other' });
+				registry.emit({
+					type: 'global',
+					action: 'other',
+					item: {
+						injector: () => ({}),
+						invalidator: new Evented()
+					}
+				});
 				assert.strictEqual(invalidateCount, 0);
 				registryHandler.getInjector('global', true);
-				registry.emit({ type: 'global', action: 'other' });
+				registry.emit({
+					type: 'global',
+					action: 'other',
+					item: {
+						injector: () => ({}),
+						invalidator: new Evented()
+					}
+				});
 				assert.strictEqual(invalidateCount, 0);
 			}
 		}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"jsx": "react",
 		"jsxFactory": "tsx",
-		"types": [ "intern", "web-animations-js" ]
+		"types": [ "intern" ]
 	},
 	"include": [
 		"./src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"jsx": "react",
 		"jsxFactory": "tsx",
-		"types": [ "intern", "web-animations-js" ]
+		"types": [ "intern" ]
 	},
 	"include": [
 		"./src/**/*.ts",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Provide updates for forwards compatibility with TypeScript from 2.6 to 3.0.

**Note:** This does not upgrade the TypeScript dependency, it is intended to enable consumers to use @dojo/framework on these TypeScript versions.

Related to #55 
