### PR TITLE
Remove symbol use in widget-core

### DIFF
--- a/src/widget-core/Registry.ts
+++ b/src/widget-core/Registry.ts
@@ -1,6 +1,5 @@
 import Promise from '../shim/Promise';
 import Map from '../shim/Map';
-import Symbol from '../shim/Symbol';
 import { Evented, EventObject } from '../core/Evented';
 import {
 	Constructor,
@@ -22,9 +21,9 @@ export type RegistryItem =
 	| ESMDefaultWidgetBaseFunction;
 
 /**
- * Widget base symbol type
+ * Widget base type
  */
-export const WIDGET_BASE_TYPE = Symbol('Widget Base');
+export const WIDGET_BASE_TYPE = '__widget_base_type';
 
 export interface RegistryEventObject extends EventObject<RegistryLabel> {
 	action: string;

--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -1,6 +1,5 @@
 import Map from '../shim/Map';
 import WeakMap from '../shim/WeakMap';
-import Symbol from '../shim/Symbol';
 import { v, VNODE, isVNode, isWNode } from './d';
 import { auto } from './diff';
 import {
@@ -33,7 +32,7 @@ export type BoundFunctionData = { boundFunc: (...args: any[]) => any; scope: any
 const decoratorMap = new Map<Function, Map<string, any[]>>();
 const boundAuto = auto.bind(null);
 
-export const noBind = Symbol.for('dojoNoBind');
+export const noBind = '__dojo_no_bind';
 
 function toTextVNode(data: any): VNode {
 	return {
@@ -52,7 +51,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	/**
 	 * static identifier
 	 */
-	static _type: symbol = WIDGET_BASE_TYPE;
+	static _type = WIDGET_BASE_TYPE;
 
 	/**
 	 * children array

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -1,4 +1,3 @@
-import Symbol from '../shim/Symbol';
 import {
 	Constructor,
 	DefaultWidgetBaseInterface,
@@ -15,19 +14,19 @@ import {
 } from './interfaces';
 
 /**
- * The symbol identifier for a WNode type
+ * The identifier for a WNode type
  */
-export const WNODE = Symbol('Identifier for a WNode.');
+export const WNODE = '__WNODE_TYPE';
 
 /**
- * The symbol identifier for a VNode type
+ * The identifier for a VNode type
  */
-export const VNODE = Symbol('Identifier for a VNode.');
+export const VNODE = '__VNODE_TYPE';
 
 /**
- * The symbol identifier for a VNode type created using dom()
+ * The identifier for a VNode type created using dom()
  */
-export const DOMVNODE = Symbol('Identifier for a VNode created using existing dom.');
+export const DOMVNODE = '__DOMVNODE_TYPE';
 
 /**
  * Helper function that returns true if the `DNode` is a `WNode` using the `type` property

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -331,7 +331,7 @@ export interface VNode {
 	/**
 	 * The type of node
 	 */
-	type: symbol;
+	type: string;
 
 	/**
 	 * Text node string
@@ -375,8 +375,11 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 	/**
 	 * The type of node
 	 */
-	type: symbol;
+	type: string;
 
+	/**
+	 * The instance that created the node
+	 */
 	bind?: WidgetBaseInterface & { registry: RegistryHandler };
 }
 

--- a/src/widget-core/mixins/I18n.ts
+++ b/src/widget-core/mixins/I18n.ts
@@ -9,7 +9,7 @@ import { Injector } from './../Injector';
 import { Registry } from './../Registry';
 import { WidgetBase } from './../WidgetBase';
 
-export const INJECTOR_KEY = Symbol('i18n');
+export const INJECTOR_KEY = '__i18n_injector';
 
 export interface LocaleData {
 	/**

--- a/src/widget-core/mixins/Themed.ts
+++ b/src/widget-core/mixins/Themed.ts
@@ -32,7 +32,7 @@ export interface ThemedProperties<T = ClassNames> extends WidgetProperties {
 
 const THEME_KEY = ' _key';
 
-export const INJECTED_THEME_KEY = Symbol('theme');
+export const INJECTED_THEME_KEY = '__theme_injector';
 
 /**
  * Interface for the ThemedMixin

--- a/src/widget-core/tsx.ts
+++ b/src/widget-core/tsx.ts
@@ -14,7 +14,7 @@ declare global {
 	}
 }
 
-export const REGISTRY_ITEM = Symbol('Identifier for an item from the Widget Registry.');
+export const REGISTRY_ITEM = '__registry_item';
 
 export class FromRegistry<P> {
 	static type = REGISTRY_ITEM;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Symbol usage causes issues as they are unique for a specific version, this change swaps references out for the using double underscore prefixed strings.
