### PR TITLE
Support lazy widgets with a function that returns a promise in w()

### DIFF
--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -9,6 +9,7 @@ import {
 	BeforeRender,
 	DiffPropertyReaction,
 	DNode,
+	LazyWidget,
 	Render,
 	WidgetMetaBase,
 	WidgetMetaConstructor,
@@ -30,6 +31,8 @@ interface ReactionFunctionConfig {
 
 export type BoundFunctionData = { boundFunc: (...args: any[]) => any; scope: any };
 
+let lazyWidgetId = 0;
+const lazyWidgetIdMap = new WeakMap<LazyWidget, string>();
 const decoratorMap = new Map<Function, Map<string, any[]>>();
 const boundAuto = auto.bind(null);
 
@@ -278,6 +281,16 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 				node.properties = { ...properties, ...node.properties };
 			}
 			if (isWNode(node) && !isWidgetBaseConstructor(node.widgetConstructor)) {
+				if (typeof node.widgetConstructor === 'function') {
+					let id = lazyWidgetIdMap.get(node.widgetConstructor);
+					if (!id) {
+						id = `__lazy_widget_${lazyWidgetId++}`;
+						lazyWidgetIdMap.set(node.widgetConstructor, id);
+						this.registry.define(id, node.widgetConstructor());
+					}
+					node.widgetConstructor = id;
+				}
+
 				node.widgetConstructor =
 					this.registry.get<WidgetBase>(node.widgetConstructor) || node.widgetConstructor;
 			}

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -5,6 +5,7 @@ import {
 	DeferredVirtualProperties,
 	DNode,
 	VNode,
+	LazyWidget,
 	RegistryLabel,
 	VNodeProperties,
 	WidgetBaseInterface,
@@ -146,12 +147,12 @@ export function w<W extends WidgetBaseInterface>(
 	children?: W['children']
 ): WNode<W>;
 export function w<W extends WidgetBaseInterface>(
-	widgetConstructor: Constructor<W> | RegistryLabel,
+	widgetConstructor: Constructor<W> | RegistryLabel | LazyWidget<W>,
 	properties: W['properties'],
 	children?: W['children']
 ): WNode<W>;
 export function w<W extends WidgetBaseInterface>(
-	widgetConstructorOrNode: Constructor<W> | RegistryLabel | WNode<W>,
+	widgetConstructorOrNode: Constructor<W> | RegistryLabel | WNode<W> | LazyWidget<W>,
 	properties: W['properties'],
 	children?: W['children']
 ): WNode<W> {

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -353,6 +353,8 @@ export interface DomVNode extends VNode {
 	domNode: Text | Element;
 }
 
+export type LazyWidget<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> = () => Promise<Constructor<W>>;
+
 /**
  * Wrapper for `w`
  */
@@ -360,7 +362,7 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 	/**
 	 * Constructor to create a widget or string constructor label
 	 */
-	widgetConstructor: Constructor<W> | RegistryLabel;
+	widgetConstructor: Constructor<W> | RegistryLabel | LazyWidget<W>;
 
 	/**
 	 * Properties to set against a widget instance

--- a/tests/widget-core/unit/d.ts
+++ b/tests/widget-core/unit/d.ts
@@ -110,6 +110,18 @@ registerSuite('d', {
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isVNode(dNode));
 		},
+		'create WNode with lazy function'() {
+			const properties: any = { id: 'id', classes: ['world'] };
+			const promise = new Promise<any>(() => {});
+			const lazyFunction = () => promise;
+			const dNode = w(lazyFunction, properties, [w(WidgetBase, properties)]);
+			assert.equal(dNode.type, WNODE);
+			assert.strictEqual(dNode.widgetConstructor, lazyFunction);
+			assert.deepEqual(dNode.properties, { id: 'id', classes: ['world'] } as any);
+			assert.lengthOf(dNode.children, 1);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isVNode(dNode));
+		},
 		'should merge properties onto a WNode'() {
 			class Foo extends WidgetBase<{ foo: string; bar: number }> {}
 			const dNode = w(Foo, { foo: 'foo', bar: 1 }, ['child']);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Supports lazy widgets directly in `w()` using a function that returns a Promise that resolves to a widget constructor.

```ts
class MyWidget extends WidgetBase {
    private _loadWidget = () => {
        return import('./lazy');
    }

    render() {
        return w(this._loadWidget, {});
    }
}
```

**Note:** The function cannot change across renders as it cannot be tracked.

Resolves #57 
