### PR TITLE
StoreProvider for injecting store state into a widget tree

### DIFF
--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -334,7 +334,7 @@ Store data can be connected to widgets within your application using the `StoreP
 
 Container Property API:
 
- * `renderer`: A render function that has the store injected in order to access state and pass process to child widgets.
+ * `renderer`: A render function that has the store injected in order to access state and pass processes to child widgets.
  * `stateKey`: The key of the state in the registry.
  * `paths` (optional): A function to connect the `Container` to sections of the state.
 
@@ -359,7 +359,7 @@ class MyApp extends WidgetBase {
 	protected render() {
 		return w(StoreProvider, { stateKey: 'state', (store: Store<State>) => {
 			return v('div', [ store.get(store.path('foo')) ]);
-		}})
+		}});
 	}
 }
 ```

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -357,7 +357,7 @@ interface State {
 
 class MyApp extends WidgetBase {
 	protected render() {
-		return w(StoreProvider, { stateKey: 'state', (store: Store<State>) => {
+		return w(StoreProvider, { stateKey: 'state', renderer: (store: Store<State>) => {
 			return v('div', [ store.get(store.path('foo')) ]);
 		}});
 	}

--- a/src/stores/StoreInjector.ts
+++ b/src/stores/StoreInjector.ts
@@ -5,8 +5,10 @@ import { handleDecorator } from '../widget-core/decorators/handleDecorator';
 import { beforeProperties } from '../widget-core/decorators/beforeProperties';
 import { alwaysRender } from '../widget-core/decorators/alwaysRender';
 import { InjectorItem, RegistryLabel, Constructor, DNode } from '../widget-core/interfaces';
-import { Store, StatePaths, Path } from './Store';
+import { Store, Path } from './Store';
 import { Registry } from '../widget-core/Registry';
+import { GetPaths } from './StoreProvider';
+export { GetPaths } from './StoreProvider';
 const registeredInjectorsMap: WeakMap<WidgetBase, InjectorItem<Store>[]> = new WeakMap();
 
 export interface GetProperties<S extends Store, W extends WidgetBase<any, any> = WidgetBase<any, any>> {
@@ -25,10 +27,6 @@ export type StoreContainerPath<
 export interface StoreContainerOptions<S, W extends WidgetBase> {
 	paths?: GetPaths<S> | StoreContainerPath<S>[];
 	getProperties: GetProperties<Store<S>, W>;
-}
-
-export interface GetPaths<S = any> {
-	(path: StatePaths<S>): Path<S, any>[];
 }
 
 export interface StoreInjectConfig<S = any> {

--- a/src/stores/StoreProvider.ts
+++ b/src/stores/StoreProvider.ts
@@ -1,0 +1,77 @@
+import WidgetBase from '../widget-core/WidgetBase';
+import { DNode } from '../widget-core/interfaces';
+import { Store, StatePaths, Path } from './Store';
+import { diffProperty } from '../widget-core/decorators/diffProperty';
+import { Handle } from '../core/Destroyable';
+import { shallow } from '../widget-core/diff';
+
+export interface GetPaths<S = any> {
+	(path: StatePaths<S>): Path<S, any>[];
+}
+
+export interface StoreProviderProperties<S = any> {
+	renderer: (store: Store<S>) => DNode | DNode[];
+	stateKey: string;
+	paths?: GetPaths<S>;
+}
+
+function mockPath(...paths: string[]): string {
+	return paths.join(',');
+}
+
+function pathDiff(previousProperty: Function, newProperty: Function) {
+	const previousPaths = previousProperty ? previousProperty(mockPath) : [];
+	const currentPaths = newProperty ? newProperty(mockPath) : [];
+	const result = shallow(previousPaths, currentPaths);
+	return {
+		changed: result.changed,
+		value: newProperty
+	};
+}
+
+export class StoreProvider<S = any> extends WidgetBase<StoreProviderProperties<S>, never> {
+	private _handle: Handle | undefined;
+
+	private _getStore(key: string): Store<S> | undefined {
+		const item = this.registry.getInjector<Store<S>>(key);
+		if (item) {
+			return item.injector();
+		}
+	}
+
+	@diffProperty('stateKey')
+	@diffProperty('paths', pathDiff)
+	protected onChange(previousProperties: StoreProviderProperties, currentProperties: StoreProviderProperties) {
+		const { stateKey, paths } = currentProperties;
+		if (this._handle) {
+			this._handle.destroy();
+			this._handle = undefined;
+		}
+		const store = this._getStore(stateKey);
+		if (store) {
+			if (paths) {
+				const handle = store.onChange(paths(store.path), () => this.invalidate());
+				this._handle = {
+					destroy: () => {
+						handle.remove();
+					}
+				};
+			} else {
+				this._handle = store.on('invalidate', () => {
+					this.invalidate();
+				});
+			}
+			this.own(this._handle);
+		}
+	}
+
+	protected render(): DNode | DNode[] {
+		const { stateKey, renderer } = this.properties;
+		const store = this._getStore(stateKey);
+		if (store) {
+			return renderer(store);
+		}
+	}
+}
+
+export default StoreProvider;

--- a/src/stores/middleware/localStorage.ts
+++ b/src/stores/middleware/localStorage.ts
@@ -1,7 +1,7 @@
 import global from '../../shim/global';
 import { ProcessError, ProcessResult, ProcessCallback, processExecutor } from '../process';
 import { Store } from '../Store';
-import { GetPaths } from '../StoreInjector';
+import { GetPaths } from '../StoreProvider';
 import { add } from '../state/operations';
 
 export function collector<T = any>(id: string, getPaths: GetPaths<T>, callback?: ProcessCallback): ProcessCallback {

--- a/tests/stores/unit/StoreProvider.ts
+++ b/tests/stores/unit/StoreProvider.ts
@@ -1,0 +1,284 @@
+const { beforeEach, describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { v } from '../../../src/widget-core/d';
+import { Registry } from '../../../src/widget-core/Registry';
+
+import { StoreProvider } from '../../../src/stores/StoreProvider';
+import { createCommandFactory, createProcess, Process } from '../../../src/stores/process';
+import { replace } from '../../../src/stores/state/operations';
+import { Store } from '../../../src/stores/Store';
+import { VNode } from '../../../src/widget-core/interfaces';
+
+interface State {
+	foo: string;
+	bar: string;
+	qux: {
+		baz: number;
+		foobar: number;
+		bar: {
+			foo: {
+				foobar: {
+					baz: {
+						barbaz: {
+							res: number;
+						};
+					};
+				};
+			};
+		};
+	};
+}
+
+const commandFactory = createCommandFactory<State>();
+const fooCommand = commandFactory(({ get, path }) => {
+	const currentFoo = get(path('foo')) || '';
+	return [replace(path('foo'), `${currentFoo}foo`)];
+});
+const barCommand = commandFactory(({ get, path }) => {
+	const currentFoo = get(path('bar'));
+	return [replace(path('bar'), `${currentFoo}bar`)];
+});
+const bazCommand = commandFactory(({ get, path }) => {
+	const currentBaz = get(path('qux', 'baz')) || 0;
+	return [replace(path('qux', 'baz'), currentBaz + 1)];
+});
+const quxCommand = commandFactory(({ get, path }) => {
+	return [replace(path('qux'), { baz: 100 })];
+});
+const fooBarCommand = commandFactory(({ get, path }) => {
+	const currentFooBar = get(path('qux', 'foobar')) || 0;
+	return [replace(path('qux', 'foobar'), currentFooBar)];
+});
+const deepCommand = commandFactory(({ get, path }) => {
+	return [replace(path(path('qux', 'bar', 'foo', 'foobar', 'baz'), 'barbaz', 'res'), 0)];
+});
+
+describe('StoreProvider', () => {
+	let store: Store<State>;
+	let registry: Registry;
+	let fooProcess: Process;
+	let barProcess: Process;
+	let bazProcess: Process;
+	let quxProcess: Process;
+	let fooBarProcess: Process;
+	let deepProcess: Process;
+
+	beforeEach(() => {
+		registry = new Registry();
+		store = new Store<State>();
+		registry.defineInjector('state', () => () => store);
+		fooProcess = createProcess('foo', [fooCommand]);
+		barProcess = createProcess('bar', [barCommand]);
+		bazProcess = createProcess('baz', [bazCommand]);
+		quxProcess = createProcess('qux', [quxCommand]);
+		fooBarProcess = createProcess('foobar', [fooBarCommand]);
+		deepProcess = createProcess('deep', [deepCommand]);
+	});
+
+	it('should connect to the stores generally invalidate', () => {
+		let invalidateCount = 0;
+		class TestContainer extends StoreProvider<State> {
+			invalidate() {
+				invalidateCount++;
+			}
+		}
+		const container = new TestContainer();
+		container.registry.base = registry;
+		container.__setProperties__({
+			stateKey: 'state',
+			renderer(injectedStore) {
+				assert.strictEqual<any>(injectedStore, store);
+				return v('div');
+			}
+		});
+		invalidateCount = 0;
+		fooProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		barProcess(store)({});
+		assert.strictEqual(invalidateCount, 2);
+		bazProcess(store)({});
+		assert.strictEqual(invalidateCount, 3);
+		quxProcess(store)({});
+		assert.strictEqual(invalidateCount, 4);
+		fooBarProcess(store)({});
+		assert.strictEqual(invalidateCount, 5);
+		deepProcess(store)({});
+		assert.strictEqual(invalidateCount, 6);
+	});
+
+	it('should connect to the stores for paths', () => {
+		let invalidateCount = 0;
+		class TestContainer extends StoreProvider<State> {
+			invalidate() {
+				invalidateCount++;
+			}
+		}
+		const container = new TestContainer();
+		container.registry.base = registry;
+		container.__setProperties__({
+			paths: (path) => {
+				return [path(path('qux', 'bar', 'foo', 'foobar', 'baz'), 'barbaz', 'res')];
+			},
+			stateKey: 'state',
+			renderer(injectedStore) {
+				assert.strictEqual<any>(injectedStore, store);
+				return v('div');
+			}
+		});
+		invalidateCount = 0;
+		deepProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		fooProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		barProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		bazProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		quxProcess(store)({});
+		assert.strictEqual(invalidateCount, 2);
+		fooBarProcess(store)({});
+		assert.strictEqual(invalidateCount, 2);
+	});
+
+	it('should re-connect to the store when paths change', () => {
+		let invalidateCount = 0;
+		class TestContainer extends StoreProvider<State> {
+			invalidate() {
+				invalidateCount++;
+			}
+		}
+		const container = new TestContainer();
+		container.registry.base = registry;
+		container.__setProperties__({
+			paths: (path) => {
+				return [path(path('qux', 'bar', 'foo', 'foobar', 'baz'), 'barbaz', 'res')];
+			},
+			stateKey: 'state',
+			renderer(injectedStore) {
+				assert.strictEqual<any>(injectedStore, store);
+				return v('div');
+			}
+		});
+		invalidateCount = 0;
+		deepProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		fooProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		barProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		bazProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		quxProcess(store)({});
+		assert.strictEqual(invalidateCount, 2);
+		fooBarProcess(store)({});
+		assert.strictEqual(invalidateCount, 2);
+		container.__setProperties__({
+			paths: (path) => {
+				return [path('foo')];
+			},
+			stateKey: 'state',
+			renderer(injectedStore) {
+				assert.strictEqual<any>(injectedStore, store);
+				return v('div');
+			}
+		});
+		invalidateCount = 0;
+		deepProcess(store)({});
+		assert.strictEqual(invalidateCount, 0);
+		fooProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		barProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		bazProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		quxProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		fooBarProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+	});
+
+	it('should re-connect to the entire store paths are not passed', () => {
+		let invalidateCount = 0;
+		class TestContainer extends StoreProvider<State> {
+			invalidate() {
+				invalidateCount++;
+			}
+		}
+		const container = new TestContainer();
+		container.registry.base = registry;
+		container.__setProperties__({
+			paths: (path) => {
+				return [path(path('qux', 'bar', 'foo', 'foobar', 'baz'), 'barbaz', 'res')];
+			},
+			stateKey: 'state',
+			renderer(injectedStore) {
+				assert.strictEqual<any>(injectedStore, store);
+				return v('div');
+			}
+		});
+		invalidateCount = 0;
+		deepProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		fooProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		barProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		bazProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		quxProcess(store)({});
+		assert.strictEqual(invalidateCount, 2);
+		fooBarProcess(store)({});
+		assert.strictEqual(invalidateCount, 2);
+		container.__setProperties__({
+			stateKey: 'state',
+			renderer(injectedStore) {
+				assert.strictEqual<any>(injectedStore, store);
+				return v('div');
+			}
+		});
+		invalidateCount = 0;
+		deepProcess(store)({});
+		assert.strictEqual(invalidateCount, 1);
+		fooProcess(store)({});
+		assert.strictEqual(invalidateCount, 2);
+		barProcess(store)({});
+		assert.strictEqual(invalidateCount, 3);
+		bazProcess(store)({});
+		assert.strictEqual(invalidateCount, 4);
+		quxProcess(store)({});
+		assert.strictEqual(invalidateCount, 5);
+		fooBarProcess(store)({});
+		assert.strictEqual(invalidateCount, 6);
+	});
+
+	it('should return the result of the renderer', () => {
+		const container = new StoreProvider();
+		container.registry.base = registry;
+		container.__setProperties__({
+			stateKey: 'state',
+			renderer(injectedStore) {
+				assert.strictEqual<any>(injectedStore, store);
+				return v('div');
+			}
+		});
+		const result = container.__render__() as VNode;
+		assert.strictEqual(result.bind, container);
+		assert.deepEqual(result.properties, {});
+		assert.isUndefined(result.children);
+		assert.strictEqual(result.tag, 'div');
+	});
+
+	it('should return undefined is the store is not available in the registry', () => {
+		const container = new StoreProvider();
+		container.registry.base = registry;
+		container.__setProperties__({
+			stateKey: 'other-state',
+			renderer(injectedStore) {
+				assert.strictEqual<any>(injectedStore, store);
+				return v('div');
+			}
+		});
+		const result = container.__render__() as VNode;
+		assert.isUndefined(result);
+	});
+});

--- a/tests/stores/unit/all.ts
+++ b/tests/stores/unit/all.ts
@@ -4,4 +4,5 @@ import './Store';
 import './process';
 import './state/all';
 import './StoreInjector';
+import './StoreProvider';
 import './StoreContainer';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Introduces `StoreProvider` to be used as any widget to inject the store into the vdom tree using a render property.

**Note:** This leaves the existing `StoreContainer` for backwards compatibility and graceful consumer upgrade, it will be removed in a future major release post v4.0.0. All references have been updated on the READM.md

See #76 for code snippets.

Resolves #76 
