### PR TITLE
Add generics for inferring types when using the process factory

### DIFF
--- a/src/stores/process.ts
+++ b/src/stores/process.ts
@@ -228,8 +228,12 @@ export function createProcess<T = any, P extends object = DefaultPayload>(
  * Creates a process factory that will create processes with the specified callback decorators applied.
  * @param callbackDecorators array of process callback decorators to be used by the return factory.
  */
-export function createProcessFactoryWith(callbackDecorators: ProcessCallbackDecorator[]): CreateProcess {
-	return (id: string, commands: (Command[] | Command)[], callback?: ProcessCallback): Process => {
+export function createProcessFactoryWith(callbackDecorators: ProcessCallbackDecorator[]) {
+	return <S, P extends object>(
+		id: string,
+		commands: (Command<S, P>[] | Command<S, P>)[],
+		callback?: ProcessCallback<S>
+	): Process<S, P> => {
 		const decoratedCallback = callbackDecorators.reduce((callback, callbackDecorator) => {
 			return callbackDecorator(callback);
 		}, callback);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fixes `createProcessFactoryWith` so that the returned factory correctly infer typings when used to create a process.

Resolves #80
