### PR TITLE
Ensure to match against the most specific route

### DIFF
--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -25,6 +25,9 @@ export interface OutletEvent extends EventObject<string> {
 	action: 'enter' | 'exit';
 }
 
+const ROUTE_SEGMENT_SCORE = 7;
+const DYNAMIC_SEGMENT_PENALTY = 2;
+
 export class Router extends QueuingEvented<{ nav: NavEvent; outlet: OutletEvent }> implements RouterInterface {
 	private _routes: Route[] = [];
 	private _outletMap: { [index: string]: Route } = Object.create(null);
@@ -160,9 +163,9 @@ export class Router extends QueuingEvented<{ nav: NavEvent; outlet: OutletEvent 
 			}
 			for (let i = 0; i < segments.length; i++) {
 				const segment = segments[i];
-				route.score += 7;
+				route.score += ROUTE_SEGMENT_SCORE;
 				if (paramRegExp.test(segment)) {
-					route.score -= 2;
+					route.score -= DYNAMIC_SEGMENT_PENALTY;
 					route.params.push(segment.replace('{', '').replace('}', ''));
 					segments[i] = PARAM;
 				}

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -15,12 +15,13 @@ export interface Route {
 	path: string;
 	outlet: string;
 	params: string[];
-	segments: (symbol | string)[];
+	segments: string[];
 	children: Route[];
 	fullPath: string;
 	fullParams: string[];
 	fullQueryParams: string[];
 	defaultParams: Params;
+	score: number;
 	onEnter?: OnEnter;
 	onExit?: OnExit;
 }

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -106,6 +106,31 @@ const routeConfigWithParamsAndQueryParams = [
 	}
 ];
 
+const orderIndependentRouteConfig = [
+	{
+		path: '{foo}',
+		outlet: 'partial',
+		children: [
+			{
+				path: 'bar/{bar}',
+				outlet: 'bar-with-param'
+			},
+			{
+				path: 'bar/bar',
+				outlet: 'bar'
+			}
+		]
+	},
+	{
+		path: 'foo',
+		outlet: 'foo'
+	},
+	{
+		path: '/',
+		outlet: 'home'
+	}
+];
+
 describe('Router', () => {
 	it('Navigates to current route if matches against a registered outlet', () => {
 		const router = new Router(routeConfig, { HistoryManager });
@@ -152,6 +177,30 @@ describe('Router', () => {
 		assert.deepEqual(context!.queryParams, {});
 		assert.strictEqual(context!.type, 'index');
 		assert.strictEqual(context!.isExact(), true);
+	});
+
+	it('should find the most specific match from the routing configuration', () => {
+		const router = new Router(orderIndependentRouteConfig, { HistoryManager });
+		router.setPath('/foo');
+		const fooContext = router.getOutlet('foo');
+		assert.isOk(fooContext);
+		assert.deepEqual(fooContext!.params, {});
+		assert.deepEqual(fooContext!.queryParams, {});
+		assert.deepEqual(fooContext!.type, 'index');
+		assert.strictEqual(fooContext!.isExact(), true);
+		router.setPath('/foo/bar/bar');
+		const barContext = router.getOutlet('bar');
+		assert.isOk(barContext);
+		assert.deepEqual(barContext!.params, { foo: 'foo' });
+		assert.deepEqual(barContext!.queryParams, {});
+		assert.deepEqual(barContext!.type, 'index');
+		assert.strictEqual(barContext!.isExact(), true);
+		const partialContext = router.getOutlet('partial');
+		assert.isOk(partialContext);
+		assert.deepEqual(partialContext!.params, { foo: 'foo' });
+		assert.deepEqual(partialContext!.queryParams, {});
+		assert.deepEqual(partialContext!.type, 'partial');
+		assert.strictEqual(partialContext!.isExact(), false);
 	});
 
 	it('Should register as a partial match for an outlet that matches a section of the route', () => {

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -131,6 +131,31 @@ const orderIndependentRouteConfig = [
 	}
 ];
 
+const config = [
+	{
+		path: 'foo',
+		outlet: 'foo-one'
+	},
+	{
+		path: 'foo',
+		outlet: 'foo-two',
+		children: [
+			{
+				path: 'baz',
+				outlet: 'baz'
+			}
+		]
+	},
+	{
+		path: '{bar}',
+		outlet: 'param'
+	},
+	{
+		path: 'bar',
+		outlet: 'bar'
+	}
+];
+
 describe('Router', () => {
 	it('Navigates to current route if matches against a registered outlet', () => {
 		const router = new Router(routeConfig, { HistoryManager });
@@ -142,6 +167,14 @@ describe('Router', () => {
 		const router = new Router(routeConfigDefaultRoute, { HistoryManager });
 		const context = router.getOutlet('foo');
 		assert.isOk(context);
+	});
+
+	it('should match against the most exact outlet specified in the configuration based on the outlets score', () => {
+		const router = new Router(config, { HistoryManager });
+		router.setPath('/bar');
+		assert.isOk(router.getOutlet('bar'));
+		router.setPath('/foo/baz');
+		assert.isOk(router.getOutlet('baz'));
 	});
 
 	it('Navigates to global "errorOutlet" if current route does not match a registered outlet and no default route is configured', () => {

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -173,8 +173,11 @@ describe('Router', () => {
 		const router = new Router(config, { HistoryManager });
 		router.setPath('/bar');
 		assert.isOk(router.getOutlet('bar'));
+		assert.isUndefined(router.getOutlet('param'));
 		router.setPath('/foo/baz');
 		assert.isOk(router.getOutlet('baz'));
+		assert.isOk(router.getOutlet('foo-two'));
+		assert.isUndefined(router.getOutlet('foo-one'));
 	});
 
 	it('Navigates to global "errorOutlet" if current route does not match a registered outlet and no default route is configured', () => {


### PR DESCRIPTION
**Type:** feature/bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

For routing the first match route specified in the configuration will be considered "the one", even if there is a more exact match in a later route within the configuration.

Assuming a routing configuration:

```ts
const config = [
    {
        path: 'foo',
        outlet: 'foo-one'
    },
    {
        path: 'foo',
        outlet: 'foo-two',
        children: [
            {
                path: 'baz',
                outlet: 'baz'
            }
        ]
    },
    {
        path: '{bar}',
        outlet: 'param'
    },
    {
        path: 'bar',
        outlet: 'bar'
    }
];
```

### Current Behaviour

Routing to `/bar`, should match against the `bar` outlet as it's more specific (a string literal match) but currently would match against the `param` outlet because it is registered first.

Routing to `/foo/baz` would currently match against the outlet, `foo-one` with a type of partial, rather then correctly matching against the more exact outlet match `baz`.

### Updated Bahaviour

Routing to `/bar`, will match against the `bar` outlet as it's more specific (a string literal match).

Routing to `/foo/baz` will match against outlet `baz`.

Resolves #83 
