### PR TITLE
Fixing string shims

### DIFF
--- a/src/shim/string.ts
+++ b/src/shim/string.ts
@@ -261,8 +261,14 @@ if (has('es6-string') && has('es6-string-raw')) {
 	};
 
 	endsWith = function endsWith(text: string, search: string, endPosition?: number): boolean {
-		if (endPosition == null) {
+		if (search === '') {
+			return true;
+		}
+
+		if (typeof endPosition === 'undefined') {
 			endPosition = text.length;
+		} else if (endPosition === null || isNaN(endPosition)) {
+			return false;
 		}
 
 		[text, search, endPosition] = normalizeSubstringArgs('endsWith', text, search, endPosition, true);

--- a/src/shim/support/has.ts
+++ b/src/shim/support/has.ts
@@ -181,7 +181,7 @@ add(
 			let callSite = getCallSite`a\n${b}`;
 
 			(callSite as any).raw = ['a\\n'];
-			const supportsTrunc = global.String.raw(callSite, 42) === 'a:\\n';
+			const supportsTrunc = global.String.raw(callSite, 42) === 'a\\n';
 
 			return supportsTrunc;
 		}

--- a/tests/shim/unit/string.ts
+++ b/tests/shim/unit/string.ts
@@ -66,16 +66,37 @@ registerSuite('shim - string functions', {
 		},
 
 		'position is Infinity, not included, or NaN'() {
-			const counts = [Infinity, undefined as any, null, NaN];
-			for (let count of counts) {
-				assert.isTrue(stringUtil.endsWith('abc', '', count));
-				assert.isFalse(stringUtil.endsWith('abc', '\0', count));
-				assert.isTrue(stringUtil.endsWith('abc', 'c', count));
-				assert.isFalse(stringUtil.endsWith('abc', 'b', count));
-				assert.isTrue(stringUtil.endsWith('abc', 'bc', count));
-				assert.isTrue(stringUtil.endsWith('abc', 'abc', count));
-				assert.isFalse(stringUtil.endsWith('abc', 'abcd', count));
-			}
+			assert.isTrue(stringUtil.endsWith('abc', '', Infinity));
+			assert.isFalse(stringUtil.endsWith('abc', '\0', Infinity));
+			assert.isTrue(stringUtil.endsWith('abc', 'c', Infinity));
+			assert.isFalse(stringUtil.endsWith('abc', 'b', Infinity));
+			assert.isTrue(stringUtil.endsWith('abc', 'bc', Infinity));
+			assert.isTrue(stringUtil.endsWith('abc', 'abc', Infinity));
+			assert.isFalse(stringUtil.endsWith('abc', 'abcd', Infinity));
+
+			assert.isTrue(stringUtil.endsWith('abc', '', undefined));
+			assert.isFalse(stringUtil.endsWith('abc', '\0', undefined));
+			assert.isTrue(stringUtil.endsWith('abc', 'c', undefined));
+			assert.isFalse(stringUtil.endsWith('abc', 'b', undefined));
+			assert.isTrue(stringUtil.endsWith('abc', 'bc', undefined));
+			assert.isTrue(stringUtil.endsWith('abc', 'abc', undefined));
+			assert.isFalse(stringUtil.endsWith('abc', 'abcd', undefined));
+
+			assert.isTrue(stringUtil.endsWith('abc', '', null as any));
+			assert.isFalse(stringUtil.endsWith('abc', '\0', null as any));
+			assert.isFalse(stringUtil.endsWith('abc', 'c', null as any));
+			assert.isFalse(stringUtil.endsWith('abc', 'b', null as any));
+			assert.isFalse(stringUtil.endsWith('abc', 'bc', null as any));
+			assert.isFalse(stringUtil.endsWith('abc', 'abc', null as any));
+			assert.isFalse(stringUtil.endsWith('abc', 'abcd', null as any));
+
+			assert.isTrue(stringUtil.endsWith('abc', '', NaN));
+			assert.isFalse(stringUtil.endsWith('abc', '\0', NaN));
+			assert.isFalse(stringUtil.endsWith('abc', 'c', NaN));
+			assert.isFalse(stringUtil.endsWith('abc', 'b', NaN));
+			assert.isFalse(stringUtil.endsWith('abc', 'bc', NaN));
+			assert.isFalse(stringUtil.endsWith('abc', 'abc', NaN));
+			assert.isFalse(stringUtil.endsWith('abc', 'abcd', NaN));
 		},
 
 		'position is 0 or negative'() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

A bug in the `es6-string-raw` check was causing it to always be false. When this flag is false, the shims for `endsWith`, `startsWith`, etc where always used.

Once this was fixed, the tests revealed some inconsistencies in how `endsWith` works natively and how our shim works.

Resolves #78 
