### PR TITLE
Add .finally() to Promise shim

### DIFF
--- a/src/shim/Promise.ts
+++ b/src/shim/Promise.ts
@@ -240,17 +240,6 @@ if (!has('es6-promise')) {
 			return this.then(undefined, onRejected);
 		}
 
-		finally(onFinally: (() => any) | undefined | null): Promise<T> {
-			return this.then(
-				onFinally && ((value: T) => Promise.resolve(onFinally()).then(() => value)),
-				onFinally &&
-					((reason: any) =>
-						Promise.resolve(onFinally()).then(() => {
-							throw reason;
-						}))
-			);
-		}
-
 		/**
 		 * The current state of this promise.
 		 */
@@ -269,6 +258,24 @@ if (!has('es6-promise')) {
 		) => Promise<TResult1 | TResult2>;
 
 		[Symbol.toStringTag]: 'Promise' = 'Promise';
+	} as any;
+	// this cast is needed in order to omit finally in the class declaration; this was done so the finally code
+	// is not duplicated and always added in the conditional below
+}
+
+if (!has('es2018-promise-finally')) {
+	global.Promise.prototype.finally = function<T>(
+		this: Promise<T>,
+		onFinally: (() => any) | undefined | null
+	): Promise<any> {
+		return this.then(
+			onFinally && ((value: T) => Promise.resolve(onFinally()).then(() => value)),
+			onFinally &&
+				((reason: any) =>
+					Promise.resolve(onFinally()).then(() => {
+						throw reason;
+					}))
+		);
 	};
 }
 

--- a/src/shim/main.ts
+++ b/src/shim/main.ts
@@ -11,7 +11,7 @@ import * as string from './string';
 import Symbol from './Symbol';
 import WeakMap from './WeakMap';
 
-`!has('es6-promise')`;
+`!has('es6-promise') || !has('es2018-promise-finallly')`;
 import './Promise';
 
 `!has('es6-symbol')`;

--- a/src/shim/support/has.ts
+++ b/src/shim/support/has.ts
@@ -128,12 +128,11 @@ add(
 add('es-observable', () => typeof global.Observable !== 'undefined', true);
 
 /* Promise */
+add('es6-promise', () => typeof global.Promise !== 'undefined' && has('es6-symbol'), true);
+
 add(
-	'es6-promise',
-	() =>
-		typeof global.Promise !== 'undefined' &&
-		has('es6-symbol') &&
-		typeof global.Promise.prototype.finally !== 'undefined',
+	'es2018-promise-finally',
+	() => has('es6-promise') && typeof global.Promise.prototype.finally !== 'undefined',
 	true
 );
 

--- a/src/shim/support/has.ts
+++ b/src/shim/support/has.ts
@@ -128,7 +128,14 @@ add(
 add('es-observable', () => typeof global.Observable !== 'undefined', true);
 
 /* Promise */
-add('es6-promise', () => typeof global.Promise !== 'undefined' && has('es6-symbol'), true);
+add(
+	'es6-promise',
+	() =>
+		typeof global.Promise !== 'undefined' &&
+		has('es6-symbol') &&
+		typeof global.Promise.prototype.finally !== 'undefined',
+	true
+);
 
 /* Set */
 add(

--- a/tests/shim/unit/Promise.ts
+++ b/tests/shim/unit/Promise.ts
@@ -438,6 +438,78 @@ export function addPromiseTests(suite: { [key: string]: Tests }, Promise: TypeUn
 		}
 	};
 
+	suite['#finally'] = {
+		'does not change the resolve value'() {
+			const dfd = this.async();
+			Promise.resolve('test')
+				.finally(() => 'changed')
+				.then(
+					dfd.callback((value: string) => {
+						assert.strictEqual(value, 'test');
+					})
+				);
+		},
+
+		'rejects if handler rejects'() {
+			const dfd = this.async();
+			Promise.resolve('test')
+				.finally(() => Promise.reject('changed'))
+				.catch(
+					dfd.callback((value: string) => {
+						assert.strictEqual(value, 'changed');
+					})
+				);
+		},
+
+		'rejects if handler throws'() {
+			const dfd = this.async();
+			Promise.resolve('test')
+				.finally(() => {
+					throw 'changed';
+				})
+				.catch(
+					dfd.callback((value: string) => {
+						assert.strictEqual(value, 'changed');
+					})
+				);
+		},
+
+		'does not change the reject value'() {
+			const dfd = this.async();
+			Promise.reject('test')
+				.finally(() => 'changed')
+				.catch(
+					dfd.callback((value: string) => {
+						assert.strictEqual(value, 'test');
+					})
+				);
+		},
+
+		'changes the reject value if handler rejects'() {
+			const dfd = this.async();
+			Promise.reject('test')
+				.finally(() => Promise.reject('changed'))
+				.catch(
+					dfd.callback((value: string) => {
+						assert.strictEqual(value, 'changed');
+					})
+				);
+		},
+
+		'changes the reject value if handler throws'() {
+			const dfd = this.async();
+			Promise.reject('test')
+				.finally(() => {
+					throw 'changed';
+				})
+				.catch(
+					dfd.callback((value: string) => {
+						assert.strictEqual(value, 'changed');
+					})
+				);
+		}
+	};
+
 	suite['#then'] = {
 		fulfillment: function() {
 			let dfd = this.async();

--- a/tests/shim/unit/support/has.ts
+++ b/tests/shim/unit/support/has.ts
@@ -10,6 +10,7 @@ registerSuite('support/has', {
 			'es-observable',
 			'es2017-object',
 			'es2017-string',
+			'es2018-promise-finally',
 			'es6-array',
 			'es6-array-fill',
 			'es6-map',

--- a/tests/widget-core/support/jsdom-plugin.ts
+++ b/tests/widget-core/support/jsdom-plugin.ts
@@ -112,7 +112,7 @@ intern.registerPlugin('jsdom', async () => {
 						const oldBefore = descriptor['before'];
 						descriptor['before'] = (suite) => {
 							initialize();
-							oldBefore!.call(suite, suite);
+							return oldBefore!.call(suite, suite);
 						};
 					} else {
 						descriptor['before'] = initialize;
@@ -121,7 +121,7 @@ intern.registerPlugin('jsdom', async () => {
 						const oldAfter = descriptor['after'];
 						descriptor['after'] = (suite) => {
 							uninitialize();
-							oldAfter!.call(suite, suite);
+							return oldAfter!.call(suite, suite);
 						};
 					} else {
 						descriptor['after'] = uninitialize;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds `.finally()` method to Promise shim as defined in the [`Promise.prototype.finally` proposal](https://tc39.github.io/proposal-promise-finally/).

Resolves #45