### PR TITLE
Static routing configuration

### DIFF
--- a/src/routing/ActiveLink.ts
+++ b/src/routing/ActiveLink.ts
@@ -39,7 +39,7 @@ export class ActiveLink extends WidgetBase<ActiveLinkProperties> {
 		if (item) {
 			const router = item.injector();
 			this._outletHandle = router.on('outlet', ({ outlet }) => {
-				if (outlet === to) {
+				if (outlet.id === to) {
 					this.invalidate();
 				}
 			});

--- a/src/routing/README.md
+++ b/src/routing/README.md
@@ -8,6 +8,7 @@ Routing for Dojo applications.
     -   [Route Configuration](#route-configuration)
     -   [Router](#router)
         -   [History Managers](#history-managers)
+        -   [Outlet Event](#outlet-event)
     -   [Router Context Injection](#router-context-injection)
     -   [Outlets](#outlets)
         -   [Global Error Outlet](#global-error-outlet)
@@ -107,23 +108,6 @@ const config = [
 ];
 ```
 
-Callbacks for `onEnter` and `onExit` can be set on the route configuration, these callbacks get called when an outlet is entered and exited.
-
-```ts
-const config = [
-	{
-		path: 'foo/{foo}',
-		outlet: 'foo',
-		onEnter: () => {
-			console.log('outlet foo entered');
-		},
-		onExit: () => {
-			console.log('outlet foo exited');
-		}
-	}
-];
-```
-
 ### Router
 
 A `Router` registers a [route configuration](#route-configuration) which is passed to the router on construction:
@@ -193,6 +177,20 @@ import { Router } from '@dojo/framework/routing/Router';
 import { MemoryHistory } from '@dojo/framework/routing/history/MemoryHistory';
 
 const router = new Router(config, MemoryHistory);
+```
+
+#### Outlet Event
+
+The `outlet` event is emitted from the `router` instance each time an outlet is entered or exited. The outlet context is provided with the event payload along with the `enter` or `exit` action.
+
+```ts
+router.on('outlet', ({ outlet, action }) => {
+	if (action === 'enter') {
+		if (outlet.id === 'my-outlet') {
+			// do something, perhaps fetch data or set state
+		}
+	}
+});
 ```
 
 ### Router Context Injection

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -22,8 +22,6 @@ export interface Route {
 	fullQueryParams: string[];
 	defaultParams: Params;
 	score: number;
-	onEnter?: OnEnter;
-	onExit?: OnExit;
 }
 
 /**
@@ -35,8 +33,6 @@ export interface RouteConfig {
 	children?: RouteConfig[];
 	defaultParams?: Params;
 	defaultRoute?: boolean;
-	onEnter?: OnEnter;
-	onExit?: OnExit;
 }
 
 /**
@@ -55,6 +51,10 @@ export type MatchType = 'error' | 'index' | 'partial';
  * Context stored for matched outlets
  */
 export interface OutletContext {
+	/**
+	 * Outlet id
+	 */
+	id: string;
 	/**
 	 * The type of match for the outlet
 	 */
@@ -79,16 +79,6 @@ export interface OutletContext {
 	 * Returns `true` when the route is an exact match
 	 */
 	isExact(): boolean;
-
-	/**
-	 * On enter for the route
-	 */
-	onEnter?: OnEnter;
-
-	/**
-	 * On exit for the route
-	 */
-	onExit?: OnExit;
 }
 
 /**
@@ -114,14 +104,6 @@ export interface RouterInterface {
 	 * The current params for matched routes
 	 */
 	readonly currentParams: Params;
-}
-
-export interface OnEnter {
-	(params: Params, type: MatchType): void;
-}
-
-export interface OnExit {
-	(): void;
 }
 
 export interface MatchDetails {

--- a/tests/routing/unit/Outlet.ts
+++ b/tests/routing/unit/Outlet.ts
@@ -1,6 +1,5 @@
 const { beforeEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
-import { stub } from 'sinon';
 
 import { WidgetBase } from '../../../src/widget-core/WidgetBase';
 import { w } from '../../../src/widget-core/d';
@@ -16,8 +15,6 @@ class Widget extends WidgetBase {
 	}
 }
 
-const configOnEnter = stub();
-const configOnExit = stub();
 let registry: Registry;
 
 const routeConfig = [
@@ -40,8 +37,6 @@ const routeConfig = [
 describe('Outlet', () => {
 	beforeEach(() => {
 		registry = new Registry();
-		configOnEnter.reset();
-		configOnExit.reset();
 	});
 
 	it('Should render the result of the renderer when the outlet matches', () => {
@@ -96,163 +91,11 @@ describe('Outlet', () => {
 		assert.strictEqual(matchType, 'error');
 	});
 
-	it('configuration onEnter called when the outlet is rendered', () => {
-		const routeConfig = [
-			{
-				path: '/foo',
-				outlet: 'foo',
-				children: [
-					{
-						path: '/bar',
-						outlet: 'bar'
-					}
-				]
-			},
-			{
-				path: 'baz/{baz}',
-				outlet: 'baz',
-				onEnter: configOnEnter,
-				onExit: configOnExit
-			}
-		];
-
-		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
-		router.setPath('/baz/param');
-		const outlet = new Outlet();
-		outlet.__setProperties__({
-			id: 'baz',
-			renderer(details) {
-				return w(Widget, {});
-			}
-		});
-		outlet.registry.base = registry;
-		outlet.__render__() as WNode;
-		assert.isTrue(configOnEnter.calledOnce);
-		router.setPath('/baz/bar');
-		outlet.__render__();
-		assert.isTrue(configOnEnter.calledTwice);
-		router.setPath('/baz/baz');
-		outlet.__render__();
-		assert.isTrue(configOnEnter.calledThrice);
-	});
-
-	it('configuration onEnter called when the outlet if params change', () => {
-		class InnerWidget extends WidgetBase {
-			render() {
-				return 'inner';
-			}
-		}
-
-		class OuterWidget extends WidgetBase {
-			render() {
-				return w(Outlet, {
-					id: 'quz',
-					renderer() {
-						return w(InnerWidget, {});
-					}
-				});
-			}
-		}
-		const routeConfig = [
-			{
-				path: '/foo',
-				outlet: 'foo',
-				children: [
-					{
-						path: '/bar',
-						outlet: 'bar'
-					}
-				]
-			},
-			{
-				path: 'baz/{baz}',
-				outlet: 'baz',
-				onEnter: configOnEnter,
-				onExit: configOnExit,
-				children: [
-					{
-						path: 'qux',
-						outlet: 'qux'
-					}
-				]
-			}
-		];
-
-		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
-		router.setPath('/baz/param');
-		const outlet = new Outlet();
-		outlet.__setProperties__({
-			id: 'baz',
-			renderer() {
-				return w(OuterWidget, {});
-			}
-		});
-		outlet.registry.base = registry;
-		outlet.__render__() as WNode;
-		assert.isTrue(configOnEnter.calledOnce);
-		router.setPath('/baz/bar');
-		outlet.__render__();
-		assert.isTrue(configOnEnter.calledTwice);
-		router.setPath('/baz/bar/qux');
-		outlet.__render__();
-		assert.isTrue(configOnEnter.calledTwice);
-		router.setPath('/baz/foo/qux');
-		outlet.__render__();
-		assert.isTrue(configOnEnter.calledThrice);
-	});
-
-	it('configuration onExit called when the outlet is rendered', () => {
-		const routeConfig = [
-			{
-				path: '/foo',
-				outlet: 'foo',
-				onEnter: configOnEnter,
-				onExit: configOnExit,
-				children: [
-					{
-						path: '/bar',
-						outlet: 'bar'
-					}
-				]
-			},
-			{
-				path: 'baz/{baz}',
-				outlet: 'baz'
-			}
-		];
-
-		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
-		router.setPath('/foo');
-		const outlet = new Outlet();
-		outlet.__setProperties__({
-			id: 'foo',
-			renderer(details) {
-				if (details.type === 'index') {
-					return w(Widget, {});
-				}
-			}
-		});
-		outlet.registry.base = registry;
-		outlet.__render__() as WNode;
-		assert.isTrue(configOnExit.notCalled);
-		router.setPath('/foo/bar');
-		outlet.__render__();
-		assert.isTrue(configOnExit.calledOnce);
-		router.setPath('/baz');
-		outlet.__render__();
-		assert.isTrue(configOnExit.calledOnce);
-		router.setPath('/foo');
-		outlet.__render__();
-		assert.isTrue(configOnExit.calledOnce);
-	});
-
 	it('Should connect the outlet on attach', () => {
 		const routeConfig = [
 			{
 				path: '/foo',
-				outlet: 'foo',
-				onEnter: configOnEnter,
-				onExit: configOnExit
+				outlet: 'foo'
 			}
 		];
 
@@ -285,81 +128,11 @@ describe('Outlet', () => {
 		assert.strictEqual(invalidateCount, 1);
 	});
 
-	it('Should call onExit if matched when onDetach is called', () => {
-		const routeConfig = [
-			{
-				path: '/foo',
-				outlet: 'foo',
-				onEnter: configOnEnter,
-				onExit: configOnExit
-			}
-		];
-
-		class TestOutlet extends Outlet {
-			onDetach() {
-				super.onDetach();
-			}
-		}
-
-		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
-		router.setPath('/foo');
-		const outlet = new TestOutlet();
-		outlet.registry.base = registry;
-		outlet.__setProperties__({
-			id: 'foo',
-			renderer(details) {
-				if (details.type === 'index') {
-					return w(Widget, {});
-				}
-			}
-		});
-
-		outlet.__render__() as WNode;
-		outlet.onDetach();
-		assert.isTrue(configOnExit.calledOnce);
-	});
-
-	it('Should not call onExit if not matched when onDetach is called', () => {
-		const routeConfig = [
-			{
-				path: '/foo',
-				outlet: 'foo',
-				onEnter: configOnEnter,
-				onExit: configOnExit
-			}
-		];
-
-		class TestOutlet extends Outlet {
-			onDetach() {
-				super.onDetach();
-			}
-		}
-
-		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
-		router.setPath('/other');
-		const outlet = new TestOutlet();
-		outlet.registry.base = registry;
-		outlet.__setProperties__({
-			id: 'foo',
-			renderer(details) {
-				if (details.type === 'index') {
-					return w(Widget, {});
-				}
-			}
-		});
-
-		outlet.__render__() as WNode;
-		outlet.onDetach();
-		assert.isTrue(configOnExit.notCalled);
-	});
-
 	it('Should render nothing when if no router is available', () => {
 		const routeConfig = [
 			{
 				path: '/foo',
-				outlet: 'foo',
-				onEnter: configOnEnter,
-				onExit: configOnExit
+				outlet: 'foo'
 			}
 		];
 
@@ -388,9 +161,7 @@ describe('Outlet', () => {
 		const routeConfig = [
 			{
 				path: '/foo',
-				outlet: 'foo',
-				onEnter: configOnEnter,
-				onExit: configOnExit
+				outlet: 'foo'
 			}
 		];
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

In order to evaluate routing at build time we need to ensure that it is static, these changes remove support for `onEnter` and `onExit` functions in the routing configuration. 

The same behaviour is supported by using the `outlet` event from the `router` instance:

```ts
router.on('outlet', ({ outlet, action }) => {
	if (action === 'enter') {
		if (outlet.id === 'my-outlet') {
			// do something, perhaps fetch data or set state
		}
	}
});
```
