### PR TITLE
Add default export for renderer from vdom

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -1156,3 +1156,5 @@ export function renderer(renderer: () => WNode): Renderer {
 		invalidate
 	};
 }
+
+export default renderer;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds a default export for `renderer` from vdom.
