### PR TITLE
Support setting properties & children after appending in ProjectorMixin Shim

### DIFF
--- a/tests/widget-core/unit/mixins/Projector.ts
+++ b/tests/widget-core/unit/mixins/Projector.ts
@@ -71,4 +71,28 @@ jsdomDescribe('Projector', () => {
 		projector.append();
 		assert.strictEqual((div.childNodes[0].childNodes[0] as Text).data, 'widget');
 	});
+
+	it('should invalidate when properties are set after mounting', () => {
+		const div = document.createElement('div');
+		const Projector = ProjectorMixin(App);
+		const projector = new Projector();
+		projector.async = false;
+		projector.root = div;
+		projector.append();
+		assert.strictEqual((div.childNodes[0].childNodes[0] as Text).data, 'widget');
+		projector.setProperties({ child: 'property' });
+		assert.strictEqual((div.childNodes[0].childNodes[0] as Text).data, 'property');
+	});
+
+	it('should invalidate when children are set after mounting', () => {
+		const div = document.createElement('div');
+		const Projector = ProjectorMixin(App);
+		const projector = new Projector();
+		projector.async = false;
+		projector.root = div;
+		projector.append();
+		assert.strictEqual((div.childNodes[0].childNodes[0] as Text).data, 'widget');
+		projector.setChildren(['child']);
+		assert.strictEqual((div.childNodes[0].childNodes[0] as Text).data, 'child');
+	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The `Projector` mixin has been shimmed to ease the transition moving to the new vdom, however previously users could set properties and children after the projector had been appended. 

This wasn't possible with the existing implementation, so these changes add that capability to ensure that users who are setting properties and children on the projector after mounting will not break. This is not a common use case.
