### PR TITLE
Fix error when setting classes on SVG elements

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -5,7 +5,6 @@ import {
 	VNode,
 	DNode,
 	VNodeProperties,
-	SupportedClassName,
 	WidgetBaseConstructor,
 	TransitionStrategy,
 	WidgetProperties,
@@ -264,13 +263,9 @@ function findIndexOfChild(children: DNodeWrapper[], sameAs: DNodeWrapper, start:
 	return -1;
 }
 
-function applyClasses(domNode: any, classes: SupportedClassName, op: string) {
-	if (classes) {
-		const classNames = classes.split(' ');
-		for (let i = 0; i < classNames.length; i++) {
-			domNode.classList[op](classNames[i]);
-		}
-	}
+function createClassPropValue(classes: string | string[] = []) {
+	classes = Array.isArray(classes) ? classes : [classes];
+	return classes.join(' ').trim();
 }
 
 function updateAttribute(domNode: Element, attrName: string, attrValue: string | undefined, namespace?: string) {
@@ -515,12 +510,7 @@ export function renderer(renderer: () => WNode): Renderer {
 		const propNames = Object.keys(nextWrapper.node.properties);
 		const propCount = propNames.length;
 		if (propNames.indexOf('classes') === -1 && currentProperties.classes) {
-			const classes = Array.isArray(currentProperties.classes)
-				? currentProperties.classes
-				: [currentProperties.classes];
-			for (let i = 0; i < classes.length; i++) {
-				applyClasses(domNode, classes[i], 'remove');
-			}
+			domNode.removeAttribute('class');
 		}
 
 		includesEventsAndAttributes && removeOrphanedEvents(domNode, currentProperties, nextWrapper.node.properties);
@@ -530,38 +520,21 @@ export function renderer(renderer: () => WNode): Renderer {
 			let propValue = nextWrapper.node.properties[propName];
 			const previousValue = currentProperties[propName];
 			if (propName === 'classes') {
-				const previousClasses = Array.isArray(previousValue)
-					? previousValue
-					: previousValue
-						? [previousValue]
-						: [];
-				const currentClasses = Array.isArray(propValue) ? propValue : [propValue];
-				const prevClassesLength = previousClasses.length;
-				if (previousClasses && prevClassesLength > 0) {
-					if (!propValue || propValue.length === 0) {
-						for (let i = 0; i < prevClassesLength; i++) {
-							applyClasses(domNode, previousClasses[i], 'remove');
-						}
-					} else {
-						const newClasses: (null | undefined | string)[] = [...currentClasses];
-						for (let i = 0; i < prevClassesLength; i++) {
-							const previousClassName = previousClasses[i];
-							if (previousClassName) {
-								const classIndex = newClasses.indexOf(previousClassName);
-								if (classIndex === -1) {
-									applyClasses(domNode, previousClassName, 'remove');
-									continue;
+				const previousClassString = createClassPropValue(previousValue);
+				let currentClassString = createClassPropValue(propValue);
+				if (previousClassString !== currentClassString) {
+					if (currentClassString) {
+						if (nextWrapper.merged) {
+							const domClasses = (domNode.getAttribute('class') || '').split(' ');
+							for (let i = 0; i < domClasses.length; i++) {
+								if (currentClassString.indexOf(domClasses[i]) === -1) {
+									currentClassString = `${domClasses[i]} ${currentClassString}`;
 								}
-								newClasses.splice(classIndex, 1);
 							}
 						}
-						for (let i = 0; i < newClasses.length; i++) {
-							applyClasses(domNode, newClasses[i], 'add');
-						}
-					}
-				} else {
-					for (let i = 0; i < currentClasses.length; i++) {
-						applyClasses(domNode, currentClasses[i], 'add');
+						domNode.setAttribute('class', currentClassString);
+					} else {
+						domNode.removeAttribute('class');
 					}
 				}
 			} else if (nodeOperations.indexOf(propName) !== -1) {

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -560,12 +560,8 @@ export function renderer(renderer: () => WNode): Renderer {
 						}
 					}
 				} else {
-					if (nextWrapper.merged) {
-						for (let i = 0; i < currentClasses.length; i++) {
-							applyClasses(domNode, currentClasses[i], 'add');
-						}
-					} else {
-						domNode.className = currentClasses.join(' ').trim();
+					for (let i = 0; i < currentClasses.length; i++) {
+						applyClasses(domNode, currentClasses[i], 'add');
 					}
 				}
 			} else if (nodeOperations.indexOf(propName) !== -1) {

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -3800,43 +3800,59 @@ jsdomDescribe('vdom', () => {
 
 			assert.strictEqual(root.innerHTML, 'changed <i>value</i>');
 		});
+	});
 
-		describe('svg', () => {
-			it('creates and updates svg dom nodes with the right namespace', () => {
-				const [Widget, meta] = getWidget(
-					v('div', [
-						v('svg', [
-							v('circle', { cx: '2cm', cy: '2cm', r: '1cm', fill: 'red' }),
-							v('image', { href: '/image.jpeg' })
-						]),
-						v('span')
-					])
-				);
-				const r = renderer(() => w(Widget, {}));
-				const div = document.createElement('div');
-				r.mount({ domNode: div, sync: true });
-				const svg = (div.childNodes[0] as Element).childNodes[0];
-				assert.strictEqual(svg.namespaceURI, 'http://www.w3.org/2000/svg');
-				const circle = svg.childNodes[0];
-				assert.strictEqual(circle.namespaceURI, 'http://www.w3.org/2000/svg');
-				const image = svg.childNodes[1];
-				assert.strictEqual(image.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
-				const span = (div.childNodes[0] as Element).childNodes[1];
-				assert.strictEqual(span.namespaceURI, 'http://www.w3.org/1999/xhtml');
+	describe('svg', () => {
+		it('creates and updates svg dom nodes with the right namespace', () => {
+			const [Widget, meta] = getWidget(
+				v('div', [
+					v('svg', [
+						v('circle', { cx: '2cm', cy: '2cm', r: '1cm', fill: 'red' }),
+						v('image', { href: '/image.jpeg' })
+					]),
+					v('span')
+				])
+			);
+			const r = renderer(() => w(Widget, {}));
+			const div = document.createElement('div');
+			r.mount({ domNode: div, sync: true });
+			const svg = (div.childNodes[0] as Element).childNodes[0];
+			assert.strictEqual(svg.namespaceURI, 'http://www.w3.org/2000/svg');
+			const circle = svg.childNodes[0];
+			assert.strictEqual(circle.namespaceURI, 'http://www.w3.org/2000/svg');
+			const image = svg.childNodes[1];
+			assert.strictEqual(image.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
+			const span = (div.childNodes[0] as Element).childNodes[1];
+			assert.strictEqual(span.namespaceURI, 'http://www.w3.org/1999/xhtml');
 
-				meta.setRenderResult(
-					v('div', [
-						v('svg', [
-							v('circle', { key: 'blue', cx: '2cm', cy: '2cm', r: '1cm', fill: 'blue' }),
-							v('image', { href: '/image2.jpeg' })
-						]),
-						v('span')
-					])
-				);
+			meta.setRenderResult(
+				v('div', [
+					v('svg', [
+						v('circle', { key: 'blue', cx: '2cm', cy: '2cm', r: '1cm', fill: 'blue' }),
+						v('image', { href: '/image2.jpeg' })
+					]),
+					v('span')
+				])
+			);
 
-				const blueCircle = svg.childNodes[0];
-				assert.strictEqual(blueCircle.namespaceURI, 'http://www.w3.org/2000/svg');
-			});
+			const blueCircle = svg.childNodes[0];
+			assert.strictEqual(blueCircle.namespaceURI, 'http://www.w3.org/2000/svg');
+		});
+
+		it('should support adding and removing classes on svg dom', () => {
+			const [Widget, meta] = getWidget(v('svg', { classes: ['foo'] }));
+			const r = renderer(() => w(Widget, {}));
+			const div = document.createElement('div');
+			r.mount({ domNode: div, sync: true });
+			const svg = div.childNodes[0] as SVGElement;
+			assert.strictEqual(svg.namespaceURI, 'http://www.w3.org/2000/svg');
+			assert.strictEqual(svg.getAttribute('class'), 'foo');
+			meta.setRenderResult(v('svg', { classes: ['foo', 'bar'] }));
+			assert.strictEqual(svg.getAttribute('class'), 'foo bar');
+			meta.setRenderResult(v('svg', { classes: [] }));
+			assert.strictEqual(svg.getAttribute('class'), '');
+			meta.setRenderResult(v('svg', { classes: ['bar'] }));
+			assert.strictEqual(svg.getAttribute('class'), 'bar');
 		});
 	});
 

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -2394,13 +2394,13 @@ jsdomDescribe('vdom', () => {
 				const [Widget, meta] = getWidget(v('div', { classes: ['a'] }));
 				const r = renderer(() => w(Widget, {}));
 				r.mount({ domNode: root, sync: true });
-				assert.strictEqual(div.className, 'c b a');
+				assert.strictEqual(div.className, 'b c a');
 				meta.setRenderResult(v('div', { classes: ['a', 'b'] }));
-				assert.strictEqual(div.className, 'c b a');
+				assert.strictEqual(div.className, 'a b');
 				meta.setRenderResult(v('div', { classes: ['b'] }));
-				assert.strictEqual(div.className, 'c b');
+				assert.strictEqual(div.className, 'b');
 				meta.setRenderResult(v('div'));
-				assert.strictEqual(div.className, 'c');
+				assert.strictEqual(div.className, '');
 			});
 
 			it('supports null, undefined and zero length strings in classes', () => {
@@ -3850,7 +3850,7 @@ jsdomDescribe('vdom', () => {
 			meta.setRenderResult(v('svg', { classes: ['foo', 'bar'] }));
 			assert.strictEqual(svg.getAttribute('class'), 'foo bar');
 			meta.setRenderResult(v('svg', { classes: [] }));
-			assert.strictEqual(svg.getAttribute('class'), '');
+			assert.strictEqual(svg.getAttribute('class'), null);
 			meta.setRenderResult(v('svg', { classes: ['bar'] }));
 			assert.strictEqual(svg.getAttribute('class'), 'bar');
 		});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Removes the shortcut of setting `className` directly for any DOM elements with all operations going through `classList.add`. 

Could have kept a shortcut using `domNode.setAttribute('class', 'myclasses');` but honestly would need to workout if that is actually worth it.

Resolves #104
