### PR TITLE
Correct the typings for processProperties in vdom

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -146,6 +146,12 @@ interface UpdateDomApplication {
 	next: VNodeWrapper;
 }
 
+interface PreviousProperties {
+	properties: any;
+	attributes?: any;
+	events?: any;
+}
+
 type ApplicationInstruction = CreateDomApplication | UpdateDomApplication | DeleteDomApplication | AttachApplication;
 
 export const widgetInstanceMap = new WeakMap<
@@ -472,7 +478,7 @@ export function renderer(renderer: () => WNode): Renderer {
 			const properties = next.node.properties;
 			next.node.properties = { ...next.node.deferredPropertiesCallback(true), ...next.node.originalProperties };
 			_afterRenderCallbacks.push(() => {
-				processProperties(next, properties);
+				processProperties(next, { properties });
 			});
 		}
 	}
@@ -657,7 +663,7 @@ export function renderer(renderer: () => WNode): Renderer {
 		}
 	}
 
-	function processProperties(next: VNodeWrapper, previousProperties: any) {
+	function processProperties(next: VNodeWrapper, previousProperties: PreviousProperties) {
 		if (next.node.attributes && next.node.events) {
 			updateAttributes(
 				next.domNode as HTMLElement,
@@ -795,7 +801,7 @@ export function renderer(renderer: () => WNode): Renderer {
 					}
 				} = item;
 
-				processProperties(next, {});
+				processProperties(next, { properties: {} });
 				runDeferredProperties(next);
 				if (!merged) {
 					let insertBefore: any;

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -1848,38 +1848,6 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual(deferredPropertyCallCount, 12);
 		});
 
-		describe('deferred properties', () => {
-			let createElementStub: any;
-
-			afterEach(() => {
-				if (createElementStub) {
-					createElementStub.restore();
-				}
-			});
-
-			it('should only set properties and attributes that have changed for deferred properties', () => {
-				class Foo extends WidgetBase {
-					render() {
-						return v('div', () => {
-							return {
-								foo: 'foo'
-							};
-						});
-					}
-				}
-				const divSpy = document.createElement('div');
-				const setAttributeSpy = spy(divSpy, 'setAttribute');
-				const div = document.createElement('div');
-				const r = renderer(() => w(Foo, {}));
-				createElementStub = stub(document, 'createElement');
-				createElementStub.returns(divSpy);
-				r.mount({ domNode: div });
-				assert.isTrue(setAttributeSpy.calledOnce);
-				resolvers.resolve();
-				assert.isTrue(setAttributeSpy.calledOnce);
-			});
-		});
-
 		describe('supports merging with a widget returned a the top level', () => {
 			it('Supports merging DNodes onto existing HTML', () => {
 				const iframe = document.createElement('iframe');
@@ -2950,6 +2918,40 @@ jsdomDescribe('vdom', () => {
 	});
 
 	describe('deferred properties', () => {
+		let createElementStub: any;
+
+		afterEach(() => {
+			if (createElementStub) {
+				createElementStub.restore();
+			}
+		});
+
+		it('should only set properties and attributes that have changed for deferred properties', () => {
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', () => {
+						return {
+							foo: 'foo'
+						};
+					});
+				}
+			}
+			let setAttributeSpy: SinonSpy;
+			const div = document.createElement('div');
+			const r = renderer(() => w(Foo, {}));
+			const originalCreateElement = document.createElement.bind(document);
+			createElementStub = stub(document, 'createElement');
+			createElementStub.callsFake((name: string) => {
+				const element = originalCreateElement(name);
+				setAttributeSpy = spy(element, 'setAttribute');
+				return element;
+			});
+			r.mount({ domNode: div });
+			assert.isTrue(setAttributeSpy!.calledOnce);
+			resolvers.resolve();
+			assert.isTrue(setAttributeSpy!.calledOnce);
+		});
+
 		it('can call a callback on render and on the next rAF for vnode properties', () => {
 			let deferredCallbackCount = 0;
 			let renderCount = 0;

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -1848,6 +1848,38 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual(deferredPropertyCallCount, 12);
 		});
 
+		describe('deferred properties', () => {
+			let createElementStub: any;
+
+			afterEach(() => {
+				if (createElementStub) {
+					createElementStub.restore();
+				}
+			});
+
+			it('should only set properties and attributes that have changed for deferred properties', () => {
+				class Foo extends WidgetBase {
+					render() {
+						return v('div', () => {
+							return {
+								foo: 'foo'
+							};
+						});
+					}
+				}
+				const divSpy = document.createElement('div');
+				const setAttributeSpy = spy(divSpy, 'setAttribute');
+				const div = document.createElement('div');
+				const r = renderer(() => w(Foo, {}));
+				createElementStub = stub(document, 'createElement');
+				createElementStub.returns(divSpy);
+				r.mount({ domNode: div });
+				assert.isTrue(setAttributeSpy.calledOnce);
+				resolvers.resolve();
+				assert.isTrue(setAttributeSpy.calledOnce);
+			});
+		});
+
 		describe('supports merging with a widget returned a the top level', () => {
 			it('Supports merging DNodes onto existing HTML', () => {
 				const iframe = document.createElement('iframe');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The typings for `processProperties` in `vdom` used an `any` but should have been typed correctly.
