### PR TITLE
Add key warning to vdom behind dojo-debug flag

### DIFF
--- a/src/has/has.ts
+++ b/src/has/has.ts
@@ -247,6 +247,9 @@ export default function has(feature: string): FeatureTestResult {
 /* Used as a value to provide a debug only code path */
 add('debug', true);
 
+/* flag for dojo debug, default to false */
+add('dojo-debug', false);
+
 /* Detects if the environment is "browser like" */
 add('host-browser', typeof document !== 'undefined' && typeof location !== 'undefined');
 

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -1,4 +1,5 @@
 import global from '../shim/global';
+import has from '../has/has';
 import { WeakMap } from '../shim/WeakMap';
 import {
 	WNode,
@@ -224,6 +225,42 @@ function buildPreviousProperties(domNode: any, current: VNodeWrapper, next: VNod
 		{} as any
 	);
 	return newProperties;
+}
+
+function checkDistinguishable(wrappers: DNodeWrapper[], index: number, parentWNodeWrapper?: WNodeWrapper) {
+	const wrapperToCheck = wrappers[index];
+	if (isVNodeWrapper(wrapperToCheck) && !wrapperToCheck.node.tag) {
+		return;
+	}
+	const { key } = wrapperToCheck.node.properties;
+	let parentName = 'unknown';
+	if (parentWNodeWrapper) {
+		const {
+			node: { widgetConstructor }
+		} = parentWNodeWrapper;
+		parentName = (widgetConstructor as any).name || 'unknown';
+	}
+
+	if (key === undefined || key === null) {
+		for (let i = 0; i < wrappers.length; i++) {
+			if (i !== index) {
+				const wrapper = wrappers[i];
+				if (same(wrapper, wrapperToCheck)) {
+					let nodeIdentifier: string;
+					if (isWNodeWrapper(wrapper)) {
+						nodeIdentifier = (wrapper.node.widgetConstructor as any).name || 'unknown';
+					} else {
+						nodeIdentifier = wrapper.node.tag;
+					}
+
+					console.warn(
+						`A widget (${parentName}) has had a child added or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${nodeIdentifier}) multiple times as siblings`
+					);
+					break;
+				}
+			}
+		}
+	}
 }
 
 function same(dnode1: DNodeWrapper, dnode2: DNodeWrapper): boolean {
@@ -874,6 +911,13 @@ export function renderer(renderer: () => WNode): Renderer {
 		}
 	}
 
+	function registerDistinguishableCallback(childNodes: DNodeWrapper[], index: number) {
+		_afterRenderCallbacks.push(() => {
+			const parentWNodeWrapper = findParentWNodeWrapper(childNodes[index]);
+			checkDistinguishable(childNodes, index, parentWNodeWrapper);
+		});
+	}
+
 	function _process(current: DNodeWrapper[], next: DNodeWrapper[], meta: ProcessMeta = {}): void {
 		let { mergeNodes = [], oldIndex = 0, newIndex = 0 } = meta;
 		const currentLength = current.length;
@@ -895,12 +939,16 @@ export function renderer(renderer: () => WNode): Renderer {
 				}
 				instructions.push({ current: currentWrapper, next: nextWrapper });
 			} else if (!currentWrapper || findIndexOfChild(current, nextWrapper, oldIndex + 1) === -1) {
-				newIndex++;
+				has('dojo-debug') && current.length && registerDistinguishableCallback(next, newIndex);
 				instructions.push({ current: undefined, next: nextWrapper });
+				newIndex++;
 			} else if (findIndexOfChild(next, currentWrapper, newIndex + 1) === -1) {
+				has('dojo-debug') && registerDistinguishableCallback(current, oldIndex);
 				instructions.push({ current: currentWrapper, next: undefined });
 				oldIndex++;
 			} else {
+				has('dojo-debug') && registerDistinguishableCallback(next, newIndex);
+				has('dojo-debug') && registerDistinguishableCallback(current, oldIndex);
 				instructions.push({ current: currentWrapper, next: undefined });
 				instructions.push({ current: undefined, next: nextWrapper });
 				oldIndex++;
@@ -914,6 +962,7 @@ export function renderer(renderer: () => WNode): Renderer {
 
 		if (currentLength > oldIndex && newIndex >= nextLength) {
 			for (let i = oldIndex; i < currentLength; i++) {
+				has('dojo-debug') && registerDistinguishableCallback(current, i);
 				instructions.push({ current: current[i], next: undefined });
 			}
 		}

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -1,7 +1,8 @@
 const { afterEach, beforeEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 const { describe: jsdomDescribe } = intern.getPlugin('jsdom');
-import { match, spy, stub, SinonSpy } from 'sinon';
+import { match, spy, stub, SinonSpy, SinonStub } from 'sinon';
+import { add } from '../../../src/has/has';
 import { createResolvers } from './../support/util';
 import sendEvent from '../support/sendEvent';
 
@@ -101,11 +102,15 @@ class TestWidget extends WidgetBase<any> {
 	}
 }
 
+let consoleWarnStub: SinonStub;
+
 jsdomDescribe('vdom', () => {
 	const spys: SinonSpy[] = [];
 
 	beforeEach(() => {
 		resolvers.stub();
+		add('dojo-debug', true, true);
+		consoleWarnStub = stub(console, 'warn');
 	});
 
 	afterEach(() => {
@@ -114,6 +119,7 @@ jsdomDescribe('vdom', () => {
 			spy.restore();
 		}
 		spys.length = 0;
+		consoleWarnStub.restore();
 	});
 
 	describe('widgets', () => {
@@ -403,6 +409,250 @@ jsdomDescribe('vdom', () => {
 				assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'Registry, world!');
 				assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'Hello, world!');
 			});
+		});
+
+		it('Should warn when removing nodes that are not distinguishable', () => {
+			let invalidate: any;
+			class Foo extends WidgetBase {
+				constructor() {
+					super();
+					invalidate = this.invalidate.bind(this);
+				}
+
+				renderResult = v('div', [v('div'), v('div')]);
+
+				renderTwo = v('div', [v('div')]);
+
+				invalidate() {
+					this.renderResult = this.renderTwo;
+					super.invalidate();
+				}
+
+				render() {
+					return this.renderResult;
+				}
+			}
+
+			const r = renderer(() => w(Foo, {}));
+			const root = document.createElement('div');
+			r.mount({ domNode: root, sync: true });
+			assert.isTrue(consoleWarnStub.notCalled);
+			invalidate();
+			assert.isTrue(consoleWarnStub.calledOnce);
+		});
+
+		it('Should warn when removing widgets that are not distinguishable', () => {
+			class Bar extends WidgetBase {}
+			let invalidate: any;
+			class Foo extends WidgetBase {
+				constructor() {
+					super();
+					invalidate = this.invalidate.bind(this);
+				}
+
+				renderResult = v('div', [w(Bar, {}), w(Bar, {})]);
+
+				renderTwo = v('div', [w(Bar, {})]);
+
+				invalidate() {
+					this.renderResult = this.renderTwo;
+					super.invalidate();
+				}
+
+				render() {
+					return this.renderResult;
+				}
+			}
+
+			const r = renderer(() => w(Foo, {}));
+			const root = document.createElement('div');
+			r.mount({ domNode: root, sync: true });
+			assert.isTrue(consoleWarnStub.notCalled);
+			invalidate();
+			assert.isTrue(consoleWarnStub.calledOnce);
+		});
+
+		it('Should warn when adding nodes that are not distinguishable', () => {
+			let invalidate: any;
+			class Foo extends WidgetBase {
+				constructor() {
+					super();
+					invalidate = this.invalidate.bind(this);
+				}
+
+				renderTwo = v('div', [v('div'), v('div')]);
+
+				renderResult = v('div', [v('div')]);
+
+				invalidate() {
+					this.renderResult = this.renderTwo;
+					super.invalidate();
+				}
+
+				render() {
+					return this.renderResult;
+				}
+			}
+
+			const r = renderer(() => w(Foo, {}));
+			const root = document.createElement('div');
+			r.mount({ domNode: root, sync: true });
+			assert.isTrue(consoleWarnStub.notCalled);
+			invalidate();
+			assert.isTrue(consoleWarnStub.calledOnce);
+		});
+
+		it('Should warn when adding widgets that are not distinguishable', () => {
+			class Bar extends WidgetBase {}
+			let invalidate: any;
+			class Foo extends WidgetBase {
+				constructor() {
+					super();
+					invalidate = this.invalidate.bind(this);
+				}
+
+				renderTwo = v('div', [w(Bar, {}), w(Bar, {})]);
+
+				renderResult = v('div', [w(Bar, {})]);
+
+				invalidate() {
+					this.renderResult = this.renderTwo;
+					super.invalidate();
+				}
+
+				render() {
+					return this.renderResult;
+				}
+			}
+
+			const r = renderer(() => w(Foo, {}));
+			const root = document.createElement('div');
+			r.mount({ domNode: root, sync: true });
+			assert.isTrue(consoleWarnStub.notCalled);
+			invalidate();
+			assert.isTrue(consoleWarnStub.calledOnce);
+		});
+
+		it('Should not warn when removing nodes that are distinguishable', () => {
+			let invalidate: any;
+			class Foo extends WidgetBase {
+				constructor() {
+					super();
+					invalidate = this.invalidate.bind(this);
+				}
+
+				renderResult = v('div', [v('div', { key: '1' }), v('div', { key: '2' })]);
+
+				renderTwo = v('div', [v('div', { key: '1' })]);
+
+				invalidate() {
+					this.renderResult = this.renderTwo;
+					super.invalidate();
+				}
+
+				render() {
+					return this.renderResult;
+				}
+			}
+
+			const r = renderer(() => w(Foo, {}));
+			const root = document.createElement('div');
+			r.mount({ domNode: root, sync: true });
+			assert.isTrue(consoleWarnStub.notCalled);
+			invalidate();
+			assert.isTrue(consoleWarnStub.notCalled);
+		});
+
+		it('Should not warn when removing widgets that are distinguishable', () => {
+			class Bar extends WidgetBase {}
+			let invalidate: any;
+			class Foo extends WidgetBase {
+				constructor() {
+					super();
+					invalidate = this.invalidate.bind(this);
+				}
+
+				renderResult = v('div', [w(Bar, { key: '1' }), w(Bar, { key: '2' })]);
+
+				renderTwo = v('div', [w(Bar, { key: '1' })]);
+
+				invalidate() {
+					this.renderResult = this.renderTwo;
+					super.invalidate();
+				}
+
+				render() {
+					return this.renderResult;
+				}
+			}
+
+			const r = renderer(() => w(Foo, {}));
+			const root = document.createElement('div');
+			r.mount({ domNode: root, sync: true });
+			assert.isTrue(consoleWarnStub.notCalled);
+			invalidate();
+			assert.isTrue(consoleWarnStub.notCalled);
+		});
+
+		it('Should not warn when adding nodes that are distinguishable', () => {
+			let invalidate: any;
+			class Foo extends WidgetBase {
+				constructor() {
+					super();
+					invalidate = this.invalidate.bind(this);
+				}
+
+				renderTwo = v('div', [v('div', { key: '1' }), v('div', { key: '2' })]);
+
+				renderResult = v('div', [v('div', { key: '1' })]);
+
+				invalidate() {
+					this.renderResult = this.renderTwo;
+					super.invalidate();
+				}
+
+				render() {
+					return this.renderResult;
+				}
+			}
+
+			const r = renderer(() => w(Foo, {}));
+			const root = document.createElement('div');
+			r.mount({ domNode: root, sync: true });
+			assert.isTrue(consoleWarnStub.notCalled);
+			invalidate();
+			assert.isTrue(consoleWarnStub.notCalled);
+		});
+
+		it('Should not warn when adding widgets that are distinguishable', () => {
+			class Bar extends WidgetBase {}
+			let invalidate: any;
+			class Foo extends WidgetBase {
+				constructor() {
+					super();
+					invalidate = this.invalidate.bind(this);
+				}
+
+				renderTwo = v('div', [w(Bar, { key: '1' }), w(Bar, { key: '2' })]);
+
+				renderResult = v('div', [w(Bar, { key: '1' })]);
+
+				invalidate() {
+					this.renderResult = this.renderTwo;
+					super.invalidate();
+				}
+
+				render() {
+					return this.renderResult;
+				}
+			}
+
+			const r = renderer(() => w(Foo, {}));
+			const root = document.createElement('div');
+			r.mount({ domNode: root, sync: true });
+			assert.isTrue(consoleWarnStub.notCalled);
+			invalidate();
+			assert.isTrue(consoleWarnStub.notCalled);
 		});
 
 		it('should invalidate when a registry items is loaded', () => {
@@ -1537,7 +1787,7 @@ jsdomDescribe('vdom', () => {
 				}
 
 				render() {
-					return [w(Qux, {}), v('div', [w(Qux, {})])];
+					return [w(Qux, { key: '1' }), v('div', [w(Qux, { key: '2' })])];
 				}
 			}
 
@@ -1574,9 +1824,9 @@ jsdomDescribe('vdom', () => {
 					this._foo = !this._foo;
 					return v('div', [
 						w(FooBar, {}),
-						this._foo ? w(Foo, {}) : null,
+						this._foo ? w(Foo, { key: '1' }) : null,
 						w(FooBar, {}),
-						this._foo ? w(Foo, {}) : w(Bar, {})
+						this._foo ? w(Foo, { key: '2' }) : w(Bar, {})
 					]);
 				}
 			}
@@ -2160,7 +2410,11 @@ jsdomDescribe('vdom', () => {
 						if (this._renderCount === 0) {
 							nodes = v('div', ['Loading']);
 						} else {
-							nodes = v('div', [w(Bar, { id: '1' }), w(Bar, { id: '2' }), w(Bar, { id: '3' })]);
+							nodes = v('div', [
+								w(Bar, { key: '1', id: '1' }),
+								w(Bar, { key: '2', id: '2' }),
+								w(Bar, { key: '3', id: '3' })
+							]);
 						}
 						this._renderCount++;
 						return nodes;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds warning when trying to add or remove nodes that are not distinguishable. The warning is behind the `dojo-debug` has flag.