### PR TITLE
Increase support for defining registry items using w() by allowing a label to be defined

### DIFF
--- a/src/widget-core/Registry.ts
+++ b/src/widget-core/Registry.ts
@@ -7,12 +7,11 @@ import {
 	InjectorItem,
 	RegistryLabel,
 	WidgetBaseConstructor,
-	WidgetBaseInterface
+	WidgetBaseInterface,
+	ESMDefaultWidgetBase,
+	WidgetBaseConstructorFunction,
+	ESMDefaultWidgetBaseFunction
 } from './interfaces';
-
-export type WidgetBaseConstructorFunction = () => Promise<WidgetBaseConstructor>;
-
-export type ESMDefaultWidgetBaseFunction = () => Promise<ESMDefaultWidgetBase<WidgetBaseInterface>>;
 
 export type RegistryItem =
 	| WidgetBaseConstructor
@@ -90,11 +89,6 @@ export interface RegistryInterface {
  */
 export function isWidgetBaseConstructor<T extends WidgetBaseInterface>(item: any): item is Constructor<T> {
 	return Boolean(item && item._type === WIDGET_BASE_TYPE);
-}
-
-export interface ESMDefaultWidgetBase<T> {
-	default: Constructor<T>;
-	__esModule?: boolean;
 }
 
 export function isWidgetConstructorDefaultExport<T>(item: any): item is ESMDefaultWidgetBase<T> {

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -4,14 +4,15 @@ import {
 	DeferredVirtualProperties,
 	DNode,
 	VNode,
-	LazyWidget,
 	RegistryLabel,
 	VNodeProperties,
 	WidgetBaseInterface,
 	WNode,
 	DomOptions,
 	RenderResult,
-	DomVNode
+	DomVNode,
+	LazyWidget,
+	LazyDefine
 } from './interfaces';
 
 /**
@@ -146,12 +147,12 @@ export function w<W extends WidgetBaseInterface>(
 	children?: W['children']
 ): WNode<W>;
 export function w<W extends WidgetBaseInterface>(
-	widgetConstructor: Constructor<W> | RegistryLabel | LazyWidget<W>,
+	widgetConstructor: Constructor<W> | RegistryLabel | LazyWidget<W> | LazyDefine<W>,
 	properties: W['properties'],
 	children?: W['children']
 ): WNode<W>;
 export function w<W extends WidgetBaseInterface>(
-	widgetConstructorOrNode: Constructor<W> | RegistryLabel | WNode<W> | LazyWidget<W>,
+	widgetConstructorOrNode: Constructor<W> | RegistryLabel | WNode<W> | LazyWidget<W> | LazyDefine<W>,
 	properties: W['properties'],
 	children?: W['children']
 ): WNode<W> {

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -353,7 +353,27 @@ export interface DomVNode extends VNode {
 	domNode: Text | Element;
 }
 
-export type LazyWidget<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> = () => Promise<Constructor<W>>;
+export interface ESMDefaultWidgetBase<T> {
+	default: Constructor<T>;
+	__esModule?: boolean;
+}
+
+export type WidgetBaseConstructorFunction<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> = () => Promise<
+	Constructor<W>
+>;
+
+export type ESMDefaultWidgetBaseFunction<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> = () => Promise<
+	ESMDefaultWidgetBase<W>
+>;
+
+export type LazyWidget<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> =
+	| WidgetBaseConstructorFunction<W>
+	| ESMDefaultWidgetBaseFunction<W>;
+
+export type LazyDefine<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> = {
+	label: string;
+	registryItem: LazyWidget<W>;
+};
 
 /**
  * Wrapper for `w`
@@ -362,7 +382,12 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 	/**
 	 * Constructor to create a widget or string constructor label
 	 */
-	widgetConstructor: Constructor<W> | RegistryLabel | LazyWidget<W>;
+	widgetConstructor:
+		| Constructor<W>
+		| RegistryLabel
+		| WidgetBaseConstructorFunction<W>
+		| ESMDefaultWidgetBaseFunction<W>
+		| LazyDefine<W>;
 
 	/**
 	 * Properties to set against a widget instance

--- a/tests/widget-core/unit/Registry.ts
+++ b/tests/widget-core/unit/Registry.ts
@@ -1,8 +1,9 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
-import Registry, { ESMDefaultWidgetBase } from '../../../src/widget-core/Registry';
+import Registry from '../../../src/widget-core/Registry';
 import { WidgetBase } from '../../../src/widget-core/WidgetBase';
 import Promise from '../../../src/shim/Promise';
+import { ESMDefaultWidgetBase } from '../../../src/widget-core/interfaces';
 
 const testPayload = () => ({});
 const testInjector = () => testPayload;

--- a/tests/widget-core/unit/WidgetBase.ts
+++ b/tests/widget-core/unit/WidgetBase.ts
@@ -284,8 +284,6 @@ describe('WidgetBase', () => {
 				assert.deepEqual(resolvedNode.properties, {});
 				assert.strictEqual(resolvedNode.type, WNODE);
 				assert.strictEqual(resolvedNode.widgetConstructor, WidgetBase);
-				// widget.invalidate();
-				// const initialNode = widget.__render__() as WNode;
 			});
 		});
 	});

--- a/tests/widget-core/unit/WidgetBase.ts
+++ b/tests/widget-core/unit/WidgetBase.ts
@@ -171,7 +171,36 @@ describe('WidgetBase', () => {
 			assert.strictEqual((renderResult.children![0] as WNode).widgetConstructor, Bar);
 		});
 
-		it('Should support lazy widgets defined directly with w by adding them to the registry', () => {
+		it('Supports a lazy widget that returns an esm default module defined directly with w', () => {
+			let resolver: any;
+			const promise = new Promise<Constructor<WidgetBase>>((resolve) => {
+				resolver = resolve;
+			});
+			const lazyWidget = () => promise;
+			class MyWidget extends WidgetBase {
+				render() {
+					return w(lazyWidget, {});
+				}
+			}
+			const widget = new MyWidget();
+			const initialNode = widget.__render__() as WNode;
+			assert.strictEqual(initialNode.bind, widget);
+			assert.deepEqual(initialNode.children, []);
+			assert.deepEqual(initialNode.properties, {});
+			assert.strictEqual(initialNode.type, WNODE);
+			assert.isString(initialNode.widgetConstructor);
+			resolver({ default: WidgetBase, __esModule: true });
+			return promise.then(() => {
+				const resolvedNode = widget.__render__() as WNode;
+				assert.strictEqual(resolvedNode.bind, widget);
+				assert.deepEqual(resolvedNode.children, []);
+				assert.deepEqual(resolvedNode.properties, {});
+				assert.strictEqual(resolvedNode.type, WNODE);
+				assert.strictEqual(resolvedNode.widgetConstructor, WidgetBase);
+			});
+		});
+
+		it('Supports a lazy widget that returns a widget defined directly with w', () => {
 			let resolver: any;
 			const promise = new Promise<Constructor<WidgetBase>>((resolve) => {
 				resolver = resolve;
@@ -197,6 +226,66 @@ describe('WidgetBase', () => {
 				assert.deepEqual(resolvedNode.properties, {});
 				assert.strictEqual(resolvedNode.type, WNODE);
 				assert.strictEqual(resolvedNode.widgetConstructor, WidgetBase);
+			});
+		});
+
+		it('Supports an explicit registry define that returns a widget with w', () => {
+			let resolver: any;
+			const promise = new Promise<Constructor<WidgetBase>>((resolve) => {
+				resolver = resolve;
+			});
+			const lazyWidget = () => promise;
+			class MyWidget extends WidgetBase {
+				render() {
+					return w({ label: 'foo', registryItem: lazyWidget }, {});
+				}
+			}
+			const widget = new MyWidget();
+			const initialNode = widget.__render__() as WNode;
+			assert.strictEqual(initialNode.bind, widget);
+			assert.deepEqual(initialNode.children, []);
+			assert.deepEqual(initialNode.properties, {});
+			assert.strictEqual(initialNode.type, WNODE);
+			assert.isString(initialNode.widgetConstructor);
+			resolver(WidgetBase);
+			return promise.then(() => {
+				const resolvedNode = widget.__render__() as WNode;
+				assert.strictEqual(resolvedNode.bind, widget);
+				assert.deepEqual(resolvedNode.children, []);
+				assert.deepEqual(resolvedNode.properties, {});
+				assert.strictEqual(resolvedNode.type, WNODE);
+				assert.strictEqual(resolvedNode.widgetConstructor, WidgetBase);
+			});
+		});
+
+		it('Supports an explicit registry define that returns esm default module with w', () => {
+			let resolver: any;
+			const promise = new Promise<Constructor<WidgetBase>>((resolve) => {
+				resolver = resolve;
+			});
+			const lazyWidget = () => promise;
+			class MyWidget extends WidgetBase {
+				render() {
+					return w({ label: 'foo', registryItem: lazyWidget }, {});
+				}
+			}
+			const widget = new MyWidget();
+			const initialNode = widget.__render__() as WNode;
+			assert.strictEqual(initialNode.bind, widget);
+			assert.deepEqual(initialNode.children, []);
+			assert.deepEqual(initialNode.properties, {});
+			assert.strictEqual(initialNode.type, WNODE);
+			assert.isString(initialNode.widgetConstructor);
+			resolver({ default: WidgetBase, __esModule: true });
+			return promise.then(() => {
+				const resolvedNode = widget.__render__() as WNode;
+				assert.strictEqual(resolvedNode.bind, widget);
+				assert.deepEqual(resolvedNode.children, []);
+				assert.deepEqual(resolvedNode.properties, {});
+				assert.strictEqual(resolvedNode.type, WNODE);
+				assert.strictEqual(resolvedNode.widgetConstructor, WidgetBase);
+				// widget.invalidate();
+				// const initialNode = widget.__render__() as WNode;
 			});
 		});
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support to use a "lazy define" directly in `w()`, that represents the label and registry item to be added to the widgets local registry.

Also resolves an issue with not peeling off the default module if the function returns an esm module.

Resolves #110 
Resolves #111 
