### PR TITLE
Active link children bug

### DIFF
--- a/src/routing/ActiveLink.ts
+++ b/src/routing/ActiveLink.ts
@@ -25,7 +25,7 @@ export class ActiveLink extends WidgetBase<ActiveLinkProperties> {
 			classes = [...classes, ...activeClasses];
 		}
 		props = { ...props, classes };
-		return w(Link, props);
+		return w(Link, props, this.children);
 	}
 
 	@diffProperty('to')

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -92,6 +92,25 @@ describe('ActiveLink', () => {
 		assert.deepEqual(dNode.properties.to, 'foo');
 	});
 
+	it('Should render the ActiveLink children', () => {
+		router.setPath('/foo');
+		const link = new ActiveLink();
+		link.registry.base = registry;
+		link.__setProperties__({ to: 'foo', activeClasses: ['foo'] });
+		link.__setChildren__(['hello']);
+		const dNode = link.__render__() as WNode<Link>;
+		assert.strictEqual(dNode.widgetConstructor, Link);
+		assert.deepEqual(dNode.properties.classes, ['foo']);
+		assert.deepEqual(dNode.properties.to, 'foo');
+		assert.deepEqual(dNode.children[0] as any, {
+			children: undefined,
+			properties: {},
+			tag: '',
+			text: 'hello',
+			type: '__VNODE_TYPE'
+		});
+	});
+
 	it('Should mix the active class onto existing string class when the outlet is active', () => {
 		router.setPath('/foo');
 		const link = new ActiveLink();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

ActiveLink children should be rendered.

Resolves #109 
