### PR TITLE
Use '&' delimiter for query params

### DIFF
--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -177,7 +177,7 @@ export class Router extends QueuingEvented<{ nav: NavEvent; outlet: OutletEvent 
 				}
 			}
 			if (queryParamString) {
-				queryParams = queryParamString.split('$').map((queryParam) => {
+				queryParams = queryParamString.split('&').map((queryParam) => {
 					return queryParam.replace('{', '').replace('}', '');
 				});
 			}

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -416,6 +416,34 @@ describe('Router', () => {
 		assert.strictEqual(link, 'foo/foo/bar/bar/baz/baz');
 	});
 
+	it('Should generate link with multiple params and query params', () => {
+		const router = new Router(
+			[
+				{
+					path: 'foo/{foo}/{bar}?{baz}&{qux}',
+					outlet: 'foo',
+					defaultParams: {
+						foo: 'defaultFoo',
+						bar: 'defaultBar',
+						baz: 'defaultBaz',
+						qux: 'defaultQux'
+					}
+				}
+			],
+			{ HistoryManager }
+		);
+		assert.strictEqual(
+			router.link('foo', {
+				foo: 'foo',
+				bar: 'bar',
+				baz: 'baz',
+				qux: 'qux'
+			}),
+			'foo/foo/bar?baz=baz&qux=qux'
+		);
+		assert.strictEqual(router.link('foo'), 'foo/defaultFoo/defaultBar?baz=defaultBaz&qux=defaultQux');
+	});
+
 	it('Will not generate a link if params are not available', () => {
 		const router = new Router(routeWithChildrenAndMultipleParams, { HistoryManager });
 		const link = router.link('baz');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The delimiter for query params in the routing configuration was incorrect `$`, this fixes it to be `&`.

Resolves #114 
