### PR TITLE
Dom on append

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -151,9 +151,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.4.tgz",
-      "integrity": "sha512-h6+VEw2Vr3ORiFCyyJmcho2zALnUq9cvdB/IO8Xs9itrJVCenC7o26A6+m7D0ihTTr65eS259H5/Ghl/VjYs6g==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.5.tgz",
+      "integrity": "sha512-nyzJ08qQMY4umgXD6SzbLflQucEnoAf2H5iUxPX5t0euDgXDV+bFTJlEmEepM35/2l07jYHdAfP6YEndeTWM0w==",
       "dev": true
     },
     "@types/charm": {
@@ -280,9 +280,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.8.tgz",
-      "integrity": "sha512-OJKHoO3VEzaJq03opzwOxC6HIjZ4H6HZ3PicNS6OdHqLhBPD6AsIwoG7TRucqZ51dHDMLnwYicrLFi1QM48GVw==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.9.tgz",
+      "integrity": "sha512-jd5gnS4K5C3MfcYPXdIPpMnFnbYpRdzZQQGkOBbyMiTsAaNTqMGyAJAZlEbMc0EwPaZFzFD+U3zxL/dhBsWsIQ==",
       "dev": true
     },
     "@types/jsdom": {
@@ -1214,9 +1214,9 @@
       }
     },
     "ci-info": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.5.1.tgz",
-      "integrity": "sha512-fKFIKXaYiL1exImwJ0AhR/6jxFPSKQBk2ayV5NiNoruUs2+rxC2kNw0EG+1Z9dugZRdCrppskQ8DN2cyaUM1Hw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
     "class-utils": {
@@ -1484,9 +1484,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -2599,6 +2599,17 @@
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        }
       }
     },
     "formatio": {
@@ -3721,7 +3732,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -4660,9 +4671,9 @@
       }
     },
     "lolex": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.4.tgz",
-      "integrity": "sha512-Gh6Vffq/piTeHwunLNFR1jFVaqlwK9GMNUxFcsO1cwHyvbRKHwX8UDkxmrDnbcPdHNmpv7z2kxtkkSx5xkNpMw==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
     },
     "loose-envify": {

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -1455,6 +1455,19 @@ const vnode = dom({
 });
 ```
 
+To execute a function after the node has been appended to the DOM, there is an `onAttach` property that will be executed immediately after the append has occurred.
+
+```ts
+const node = document.createElement('div');
+
+const vnode = dom({
+	node,
+	onAttach: () => {
+		// do things after the node has been attached
+	}
+});
+```
+
 ### JSX Support
 
 In addition to creating widgets functionally using the `v()` and `w()` functions from `@dojo/framework/widget-core/d`, Dojo optionally supports the use of the `jsx` syntax known as [`tsx`](https://www.typescriptlang.org/docs/handbook/jsx.html) in TypeScript.

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -221,7 +221,7 @@ export function v(
  * Create a VNode for an existing DOM Node.
  */
 export function dom(
-	{ node, attrs = {}, props = {}, on = {}, diffType = 'none', onAppend }: DomOptions,
+	{ node, attrs = {}, props = {}, on = {}, diffType = 'none', onAttach }: DomOptions,
 	children?: DNode[]
 ): DomVNode {
 	return {
@@ -234,6 +234,6 @@ export function dom(
 		domNode: node,
 		text: isElementNode(node) ? undefined : node.data,
 		diffType,
-		onAppend
+		onAttach
 	};
 }

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -221,7 +221,7 @@ export function v(
  * Create a VNode for an existing DOM Node.
  */
 export function dom(
-	{ node, attrs = {}, props = {}, on = {}, diffType = 'none' }: DomOptions,
+	{ node, attrs = {}, props = {}, on = {}, diffType = 'none', onAppend }: DomOptions,
 	children?: DNode[]
 ): DomVNode {
 	return {
@@ -233,6 +233,7 @@ export function dom(
 		type: DOMVNODE,
 		domNode: node,
 		text: isElementNode(node) ? undefined : node.data,
-		diffType
+		diffType,
+		onAppend
 	};
 }

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -99,7 +99,7 @@ export interface DomOptions {
 	attrs?: { [index: string]: string | undefined };
 	on?: On;
 	diffType?: DiffType;
-	onAppend?: () => void;
+	onAttach?: () => void;
 }
 
 export interface VDomOptions {
@@ -352,7 +352,7 @@ export interface VNode {
 
 export interface DomVNode extends VNode {
 	domNode: Text | Element;
-	onAppend?: () => void;
+	onAttach?: () => void;
 }
 
 export interface ESMDefaultWidgetBase<T> {

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -99,6 +99,7 @@ export interface DomOptions {
 	attrs?: { [index: string]: string | undefined };
 	on?: On;
 	diffType?: DiffType;
+	onAppend?: () => void;
 }
 
 export interface VDomOptions {
@@ -351,6 +352,7 @@ export interface VNode {
 
 export interface DomVNode extends VNode {
 	domNode: Text | Element;
+	onAppend?: () => void;
 }
 
 export interface ESMDefaultWidgetBase<T> {

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -1,7 +1,15 @@
 import global from '../shim/global';
 import has from '../has/has';
 import { WeakMap } from '../shim/WeakMap';
-import { WNode, VNode, DNode, VNodeProperties, WidgetBaseConstructor, TransitionStrategy } from './interfaces';
+import {
+	WNode,
+	VNode,
+	DNode,
+	VNodeProperties,
+	WidgetBaseConstructor,
+	TransitionStrategy,
+	DomVNode
+} from './interfaces';
 import transitionStrategy from './animations/cssTransitions';
 import { isVNode, isWNode, WNODE, v, isDomVNode, w } from './d';
 import { Registry, isWidgetBaseConstructor } from './Registry';
@@ -27,7 +35,7 @@ export interface WNodeWrapper extends BaseNodeWrapper {
 }
 
 export interface VNodeWrapper extends BaseNodeWrapper {
-	node: VNode;
+	node: VNode | DomVNode;
 	merged?: boolean;
 	decoratedDeferredProperties?: VNodeProperties;
 	inserted?: boolean;
@@ -801,6 +809,9 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 						insertBefore = findInsertBefore(next);
 					}
 					parentDomNode.insertBefore(domNode!, insertBefore);
+					if (isDomVNode(next.node) && next.node.onAppend) {
+						next.node.onAppend();
+					}
 				}
 				runEnterAnimation(next, _mountOptions.transition);
 				const instanceData = widgetInstanceMap.get(next.node.bind as WidgetBase);

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -809,8 +809,8 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 						insertBefore = findInsertBefore(next);
 					}
 					parentDomNode.insertBefore(domNode!, insertBefore);
-					if (isDomVNode(next.node) && next.node.onAppend) {
-						next.node.onAppend();
+					if (isDomVNode(next.node) && next.node.onAttach) {
+						next.node.onAttach();
 					}
 				}
 				runEnterAnimation(next, _mountOptions.transition);

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -3176,26 +3176,26 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual(root, divB);
 			assert.strictEqual(root.innerHTML, 'B');
 		});
-		it('Should run onAppend after the dom node has been appended to the dom', () => {
-			let onAppendCallCount = 0;
+		it('Should run onAttach after the dom node has been appended to the dom', () => {
+			let onAttachCallCount = 0;
 			const myDomNode = document.createElement('div');
 			const div = document.createElement('div');
 			let vnode = d({
 				node: myDomNode,
-				onAppend: () => {
-					onAppendCallCount++;
+				onAttach: () => {
+					onAttachCallCount++;
 				}
 			});
 			const [Widget, meta] = getWidget(vnode);
 			const r = renderer(() => w(Widget, {}));
 			r.mount({ domNode: div, sync: true });
-			assert.strictEqual(onAppendCallCount, 1);
+			assert.strictEqual(onAttachCallCount, 1);
 			meta.setRenderResult(vnode);
-			assert.strictEqual(onAppendCallCount, 1);
+			assert.strictEqual(onAttachCallCount, 1);
 			meta.setRenderResult(null);
-			assert.strictEqual(onAppendCallCount, 1);
+			assert.strictEqual(onAttachCallCount, 1);
 			meta.setRenderResult(vnode);
-			assert.strictEqual(onAppendCallCount, 2);
+			assert.strictEqual(onAttachCallCount, 2);
 		});
 	});
 

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -3176,6 +3176,27 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual(root, divB);
 			assert.strictEqual(root.innerHTML, 'B');
 		});
+		it('Should run onAppend after the dom node has been appended to the dom', () => {
+			let onAppendCallCount = 0;
+			const myDomNode = document.createElement('div');
+			const div = document.createElement('div');
+			let vnode = d({
+				node: myDomNode,
+				onAppend: () => {
+					onAppendCallCount++;
+				}
+			});
+			const [Widget, meta] = getWidget(vnode);
+			const r = renderer(() => w(Widget, {}));
+			r.mount({ domNode: div, sync: true });
+			assert.strictEqual(onAppendCallCount, 1);
+			meta.setRenderResult(vnode);
+			assert.strictEqual(onAppendCallCount, 1);
+			meta.setRenderResult(null);
+			assert.strictEqual(onAppendCallCount, 1);
+			meta.setRenderResult(vnode);
+			assert.strictEqual(onAppendCallCount, 2);
+		});
 	});
 
 	describe('deferred properties', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds a `onAttach` property to the `dom` pragma to enable users to specify an function to run after the node has been appended.

Resolves #121 