### PR TITLE
fixed comment at method has()

### DIFF
--- a/src/has/has.ts
+++ b/src/has/has.ts
@@ -215,7 +215,7 @@ export function add(
 /**
  * Return the current value of a named feature.
  *
- * @param feature The name (if a string) or identifier (if an integer) of the feature to test.
+ * @param feature The name of the feature to test.
  */
 export default function has(feature: string): FeatureTestResult {
 	let result: FeatureTestResult;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)

**Description:**
Fixed comment at method has(), the comment before suggests that param can be integer and string, but type is string.

Resolves #84 
