### PR TITLE
Emit the routing event after the routing has been completed

### DIFF
--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -16,8 +16,8 @@ interface RouteWrapper {
 }
 
 export interface NavEvent extends EventObject<string> {
-	outlet: string;
-	context: OutletContext;
+	outlet?: string;
+	context?: OutletContext;
 }
 
 export interface OutletEvent extends EventObject<string> {
@@ -217,7 +217,6 @@ export class Router extends QueuingEvented<{ nav: NavEvent; outlet: OutletEvent 
 	 * @param requestedPath The path of the requested route
 	 */
 	private _onChange = (requestedPath: string): void => {
-		this.emit({ type: 'navstart' });
 		requestedPath = this._stripLeadingSlash(requestedPath);
 		const previousMatchedOutlets = this._matchedOutlets;
 		this._matchedOutlets = Object.create(null);
@@ -328,9 +327,11 @@ export class Router extends QueuingEvented<{ nav: NavEvent; outlet: OutletEvent 
 				this.emit({ type: 'outlet', outlet: previousMatchedOutlets[key], action: 'exit' });
 			}
 		}
-		if (matchedOutletName) {
-			this.emit({ type: 'nav', outlet: matchedOutletName, context: this._matchedOutlets[matchedOutletName] });
-		}
+		this.emit({
+			type: 'nav',
+			outlet: matchedOutletName,
+			context: matchedOutletName ? this._matchedOutlets[matchedOutletName] : undefined
+		});
 	};
 }
 

--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -302,10 +302,10 @@ export class Router extends QueuingEvented<{ nav: NavEvent; outlet: OutletEvent 
 					isExact: () => type === 'index'
 				};
 				const previousMatchedOutlet = previousMatchedOutlets[route.outlet];
+				this._matchedOutlets[route.outlet] = matchedOutlet;
 				if (!previousMatchedOutlet || !matchingParams(previousMatchedOutlet, matchedOutlet)) {
 					this.emit({ type: 'outlet', outlet: matchedOutlet, action: 'enter' });
 				}
-				this._matchedOutlets[route.outlet] = matchedOutlet;
 				matchedRoute = parent;
 			}
 		} else {

--- a/src/routing/RouterInjector.ts
+++ b/src/routing/RouterInjector.ts
@@ -32,7 +32,7 @@ export function registerRouterInjector(
 	}
 	const router = new Router(config, routerOptions);
 	registry.defineInjector(key, (invalidator: () => void) => {
-		router.on('navstart', () => invalidator());
+		router.on('nav', () => invalidator());
 		return () => router;
 	});
 	return router;

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -293,17 +293,17 @@ describe('ActiveLink', () => {
 			router.setPath('/bar');
 			assert.strictEqual(
 				root.outerHTML,
-				'<div><div><a href="foo"></a><a class="bar" href="bar"></a><a href="baz"></a></div></div>'
+				'<div><div><a href="foo"></a><a href="bar" class="bar"></a><a href="baz"></a></div></div>'
 			);
 			router.setPath('/baz');
 			assert.strictEqual(
 				root.outerHTML,
-				'<div><div><a href="foo"></a><a href="bar"></a><a class="baz" href="baz"></a></div></div>'
+				'<div><div><a href="foo"></a><a href="bar"></a><a href="baz" class="baz"></a></div></div>'
 			);
 			router.setPath('/foo');
 			assert.strictEqual(
 				root.outerHTML,
-				'<div><div><a class="foo" href="foo"></a><a href="bar"></a><a href="baz"></a></div></div>'
+				'<div><div><a href="foo" class="foo"></a><a href="bar"></a><a href="baz"></a></div></div>'
 			);
 		});
 	});

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -1,5 +1,6 @@
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
+const { describe: jsdomDescribe } = intern.getPlugin('jsdom');
 
 import { Registry } from '../../../src/widget-core/Registry';
 
@@ -8,6 +9,10 @@ import { MemoryHistory } from '../../../src/routing/history/MemoryHistory';
 import { WNode } from '../../../src/widget-core/interfaces';
 import Link from '../../../src/routing/Link';
 import ActiveLink from '../../../src/routing/ActiveLink';
+import { registerRouterInjector } from '../../../src/routing/RouterInjector';
+import { w, v } from '../../../src/widget-core/d';
+import { renderer } from '../../../src/widget-core/vdom';
+import WidgetBase from '../../../src/widget-core/WidgetBase';
 
 const registry = new Registry();
 
@@ -243,5 +248,63 @@ describe('ActiveLink', () => {
 		const dNode2 = link2.__render__() as WNode<Link>;
 
 		assert.deepEqual(dNode2.properties.classes, []);
+	});
+
+	jsdomDescribe('integration tests', () => {
+		it('should render outlets correctly', () => {
+			const registry = new Registry();
+			const router = registerRouterInjector(
+				[
+					{
+						path: 'foo',
+						outlet: 'foo',
+						defaultRoute: true
+					},
+					{
+						path: 'bar',
+						outlet: 'bar'
+					},
+					{
+						path: 'baz',
+						outlet: 'baz'
+					}
+				],
+				registry,
+				{ HistoryManager: MemoryHistory }
+			);
+
+			class App extends WidgetBase {
+				protected render() {
+					return v('div', [
+						w(ActiveLink, { to: 'foo', activeClasses: ['foo'] }),
+						w(ActiveLink, { to: 'bar', activeClasses: ['bar'] }),
+						w(ActiveLink, { to: 'baz', activeClasses: ['baz'] })
+					]);
+				}
+			}
+
+			const root = document.createElement('div');
+			const r = renderer(() => w(App, {}));
+			r.mount({ domNode: root, sync: true, registry });
+			assert.strictEqual(
+				root.outerHTML,
+				'<div><div><a class="foo" href="foo"></a><a href="bar"></a><a href="baz"></a></div></div>'
+			);
+			router.setPath('/bar');
+			assert.strictEqual(
+				root.outerHTML,
+				'<div><div><a href="foo"></a><a class="bar" href="bar"></a><a href="baz"></a></div></div>'
+			);
+			router.setPath('/baz');
+			assert.strictEqual(
+				root.outerHTML,
+				'<div><div><a href="foo"></a><a href="bar"></a><a class="baz" href="baz"></a></div></div>'
+			);
+			router.setPath('/foo');
+			assert.strictEqual(
+				root.outerHTML,
+				'<div><div><a class="foo" href="foo"></a><a href="bar"></a><a href="baz"></a></div></div>'
+			);
+		});
 	});
 });

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -283,28 +283,24 @@ describe('ActiveLink', () => {
 				}
 			}
 
-			const root = document.createElement('div');
+			const root = document.createElement('div') as any;
 			const r = renderer(() => w(App, {}));
 			r.mount({ domNode: root, sync: true, registry });
-			assert.strictEqual(
-				root.outerHTML,
-				'<div><div><a class="foo" href="foo"></a><a href="bar"></a><a href="baz"></a></div></div>'
-			);
+			assert.strictEqual(root.childNodes[0].childNodes[0].getAttribute('class'), 'foo');
+			assert.isNull(root.childNodes[0].childNodes[1].getAttribute('class'));
+			assert.isNull(root.childNodes[0].childNodes[2].getAttribute('class'));
 			router.setPath('/bar');
-			assert.strictEqual(
-				root.outerHTML,
-				'<div><div><a href="foo"></a><a href="bar" class="bar"></a><a href="baz"></a></div></div>'
-			);
+			assert.isNull(root.childNodes[0].childNodes[0].getAttribute('class'));
+			assert.strictEqual(root.childNodes[0].childNodes[1].getAttribute('class'), 'bar');
+			assert.isNull(root.childNodes[0].childNodes[2].getAttribute('class'));
 			router.setPath('/baz');
-			assert.strictEqual(
-				root.outerHTML,
-				'<div><div><a href="foo"></a><a href="bar"></a><a href="baz" class="baz"></a></div></div>'
-			);
+			assert.isNull(root.childNodes[0].childNodes[0].getAttribute('class'));
+			assert.isNull(root.childNodes[0].childNodes[1].getAttribute('class'));
+			assert.strictEqual(root.childNodes[0].childNodes[2].getAttribute('class'), 'baz');
 			router.setPath('/foo');
-			assert.strictEqual(
-				root.outerHTML,
-				'<div><div><a href="foo" class="foo"></a><a href="bar"></a><a href="baz"></a></div></div>'
-			);
+			assert.strictEqual(root.childNodes[0].childNodes[0].getAttribute('class'), 'foo');
+			assert.isNull(root.childNodes[0].childNodes[1].getAttribute('class'));
+			assert.isNull(root.childNodes[0].childNodes[2].getAttribute('class'));
 		});
 	});
 });

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -506,15 +506,19 @@ describe('Router', () => {
 	it('Queues the first event for the first registered listener', () => {
 		let initialNavEvent = false;
 		const router = new Router(routeConfigDefaultRoute, { HistoryManager });
+		let navCount = 0;
 		router.on('nav', (event) => {
-			assert.strictEqual(event.type, 'nav');
-			assert.strictEqual(event.outlet, 'foo');
-			assert.deepEqual(event.context.queryParams, {});
-			assert.deepEqual(event.context.params, { bar: 'defaultBar' });
-			assert.deepEqual(event.context.type, 'index');
-			assert.isTrue(event.context.isExact());
-			assert.isFalse(event.context.isError());
-			initialNavEvent = true;
+			navCount++;
+			if (navCount > 1) {
+				assert.strictEqual(event.type, 'nav');
+				assert.strictEqual(event.outlet, 'foo');
+				assert.deepEqual(event.context!.queryParams, {});
+				assert.deepEqual(event.context!.params, { bar: 'defaultBar' });
+				assert.deepEqual(event.context!.type, 'index');
+				assert.isTrue(event.context!.isExact());
+				assert.isFalse(event.context!.isError());
+				initialNavEvent = true;
+			}
 		});
 		assert.isTrue(initialNavEvent);
 	});

--- a/tests/routing/unit/RouterInjector.ts
+++ b/tests/routing/unit/RouterInjector.ts
@@ -15,7 +15,7 @@ suite('RouterInjector', () => {
 		assert.isNotNull(injector);
 		assert.strictEqual(injector(), router);
 		const invalidatorSpy = spy(invalidator, 'emit');
-		router.emit({ type: 'navstart' });
+		router.emit({ type: 'nav' });
 		assert.isTrue(invalidatorSpy.calledOnce);
 	});
 
@@ -30,7 +30,7 @@ suite('RouterInjector', () => {
 		assert.isNotNull(injector);
 		const registeredRouter = injector();
 		assert.strictEqual(router, registeredRouter);
-		router.emit({ type: 'navstart' });
+		router.emit({ type: 'nav' });
 		assert.isTrue(invalidatorSpy.calledOnce);
 	});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that the routing events are emitted after the routing navigation is completed.

Resolves #136 
