### PR TITLE
Call `onDetach` after the widget's nodes have been removed

### DIFF
--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -1965,6 +1965,53 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual(removeChildCount, 1);
 		});
 
+		it('calls onDetach after the root nodes has been removed', () => {
+			let removeChildCount = 0;
+			let toggleShow: any;
+			const onDetachStub = stub();
+
+			class Bar extends WidgetBase {
+				render() {
+					return [v('span'), v('div')];
+				}
+
+				onDetach() {
+					onDetachStub();
+				}
+			}
+
+			class Foo extends WidgetBase {
+				private _show = true;
+
+				constructor() {
+					super();
+					toggleShow = this.toggleShow;
+				}
+
+				toggleShow = () => {
+					this._show = !this._show;
+					this.invalidate();
+				};
+
+				render() {
+					return this._show ? w(Bar, {}) : null;
+				}
+			}
+
+			const r = renderer(() => w(Foo, {}));
+			const div = document.createElement('div');
+			const remove = div.removeChild.bind(div);
+			div.removeChild = (child: any) => {
+				removeChildCount++;
+				assert.isTrue(onDetachStub.notCalled);
+				return remove(child);
+			};
+			r.mount({ domNode: div, sync: true });
+			toggleShow();
+			assert.isTrue(onDetachStub.called);
+			assert.strictEqual(removeChildCount, 2);
+		});
+
 		it('should use the latest version of nodes when calling remove', () => {
 			let showFooNodes: any;
 			class Baz extends WidgetBase {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that widget's `onDetach` is called after the nodes have been removed.

Resolves #132 
