### PR TITLE
Allow top level registry items in the renderer

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -344,10 +344,12 @@ function arrayFrom(arr: any) {
 
 function wrapNodes(renderer: () => DNode) {
 	return class extends WidgetBase {
-		static isWrapper = true;
+		public isWNodeWrapper = true;
 
 		protected render() {
-			return renderer();
+			const result = renderer();
+			this.isWNodeWrapper = isWNode(result);
+			return result;
 		}
 	};
 }
@@ -1005,7 +1007,7 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 		}
 		if (next.instance) {
 			_instanceToWrapperMap.set(next.instance, next);
-			if (!parentInvalidate && !(next.instance as any).constructor.isWrapper) {
+			if (!parentInvalidate && !(next.instance as any).isWNodeWrapper) {
 				parentInvalidate = next.instance.invalidate.bind(next.instance);
 			}
 		}

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -342,10 +342,12 @@ function arrayFrom(arr: any) {
 	return Array.prototype.slice.call(arr);
 }
 
-function wrapVNodes(nodes: VNode) {
+function wrapNodes(renderer: () => DNode) {
 	return class extends WidgetBase {
+		static isWrapper = true;
+
 		protected render() {
-			return nodes;
+			return renderer();
 		}
 	};
 }
@@ -698,10 +700,7 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 	function mount(mountOptions: Partial<MountOptions> = {}) {
 		_mountOptions = { ..._mountOptions, ...mountOptions };
 		const { domNode } = _mountOptions;
-		let renderResult = renderer();
-		if (isVNode(renderResult)) {
-			renderResult = w(wrapVNodes(renderResult), {});
-		}
+		const renderResult = w(wrapNodes(renderer), {});
 		const nextWrapper = {
 			node: renderResult,
 			depth: 1
@@ -1006,7 +1005,7 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 		}
 		if (next.instance) {
 			_instanceToWrapperMap.set(next.instance, next);
-			if (!parentInvalidate) {
+			if (!parentInvalidate && !(next.instance as any).constructor.isWrapper) {
 				parentInvalidate = next.instance.invalidate.bind(next.instance);
 			}
 		}

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -399,8 +399,9 @@ jsdomDescribe('vdom', () => {
 				)
 			);
 			const div = document.createElement('div');
-			r.mount({ domNode: div, sync: true, registry });
+			r.mount({ domNode: div, registry, sync: true });
 			resolver(Foo);
+			assert.strictEqual(div.outerHTML, '<div></div>');
 			return promise.then(() => {
 				assert.strictEqual(div.outerHTML, '<div>Top Level Registry</div>');
 			});

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -374,6 +374,38 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual(headerTwoText.data, 'bar');
 		});
 
+		it('support top level registry items', () => {
+			const registry = new Registry();
+			class Foo extends WidgetBase {
+				render() {
+					return 'Top Level Registry';
+				}
+			}
+
+			let resolver: any;
+			const promise = new Promise<any>((resolve) => {
+				resolver = resolve;
+			});
+
+			const r = renderer(() =>
+				w(
+					{
+						label: 'foo',
+						registryItem: () => {
+							return promise;
+						}
+					},
+					{}
+				)
+			);
+			const div = document.createElement('div');
+			r.mount({ domNode: div, sync: true, registry });
+			resolver(Foo);
+			return promise.then(() => {
+				assert.strictEqual(div.outerHTML, '<div>Top Level Registry</div>');
+			});
+		});
+
 		it('registry items', () => {
 			let resolver = () => {};
 			const registry = new Registry();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Registry items are resolved in `WidgetBase`, which means to enable using a registry item at the top level we need to wrap `w()` nodes (as well as `v()` nodes) with a wrapping widget.

The top level projector invalidation needs to ignore the wrapper, and pick the consumers widget.
