### PR TITLE
Update readme to have link to v4 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,15 @@ There are several packages which are designed to support the Dojo platform.  Gen
 * [`dojo/webpack-contrib`](https://github.com/dojo/webpack-contrib) - Specialized webpack loaders and plugins used by the Dojo toolchain.
 * [`dojo/web-editor`](https://github.com/dojo/web-editor) - A web editor that can run projects exported from `cli-export-project`
 
+## Migrating Versions
+
 ### Version 2.x to 3.x Migration Guide
 
 See the [v3 migration guide](./docs/V3-Migration-Guide.md) for details on upgrading from version 2.x to version 3.x.
+
+### Version 3.x to 4.x Migration Guide
+
+See the [v4 migration guide](./docs/V4-Migration-Guide.md) for details on upgrading from version 3.x to version 4.x.
 
 ### Examples
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add migration section to readme