### PR TITLE
Remove linting error note for tsx

### DIFF
--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -1534,8 +1534,6 @@ class MyWidgetWithTsx extends Themed(WidgetBase)<MyProperties> {
 }
 ```
 
-**Note:** Unfortunately `tsx` is not directly used within the module so the tsx module will report as an unused import, and will need to be ignored by linters.
-
 ### Web Components
 
 Widgets can be turned into [Custom Elements](https://www.w3.org/TR/2016/WD-custom-elements-20161013/) with


### PR DESCRIPTION
Removing this line as no linting error is generated using the suggested configuration.

**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Remove a note from the README for widget-core regarding `tsx`. It states a linting error will occur as the import is unused, however no linting error appears. This was tested using [Creating widgets](https://dojo.io/tutorials/003_creating_widgets/) tutorial from [dojo.io](https://dojo.io). TSLint only flags the import as unused if no `jsx` can be found on the page.

Has `jsx`:
![image](https://user-images.githubusercontent.com/1388138/47111515-bb202580-d221-11e8-946a-39cde27c2dcb.png)

No `jsx`:
![image](https://user-images.githubusercontent.com/1388138/47111581-ed318780-d221-11e8-833f-e6f23717dc8c.png)

**Note**: That is typescript doing the checking there not tslint. But even tslint does not flag the `txs` import when `jsx` is present.