### PR TITLE
Fixes: Routing and Link Fixes

### DIFF
--- a/src/routing/Link.ts
+++ b/src/routing/Link.ts
@@ -18,17 +18,14 @@ export class Link extends WidgetBase<LinkProperties> {
 			const onclick = (event: MouseEvent) => {
 				onClick && onClick(event);
 
-				if (!event.defaultPrevented && event.button === 0 && !target) {
+				if (!event.defaultPrevented && event.button === 0 && !event.metaKey && !event.ctrlKey && !target) {
 					event.preventDefault();
 					href !== undefined && router.setPath(href);
 				}
 			};
-			props = { ...props, onclick, href };
-		} else {
-			props = { ...props, href };
+			return { ...props, onclick, href };
 		}
-
-		return props;
+		return { ...props, href };
 	}
 
 	protected render(): VNode {

--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -105,7 +105,7 @@ export class Router extends QueuingEvented<{ nav: NavEvent; outlet: OutletEvent 
 				return undefined;
 			}
 		}
-		return linkPath;
+		return this._history.prefix(linkPath);
 	}
 
 	/**

--- a/src/routing/history/HashHistory.ts
+++ b/src/routing/history/HashHistory.ts
@@ -27,6 +27,7 @@ export class HashHistory implements History {
 
 	public set(path: string) {
 		this._window.location.hash = this.prefix(path);
+		this._onChange();
 	}
 
 	public get current(): string {
@@ -38,8 +39,11 @@ export class HashHistory implements History {
 	}
 
 	private _onChange = () => {
-		this._current = this.normalizePath(this._window.location.hash);
-		this._onChangeFunction(this._current);
+		const path = this.normalizePath(this._window.location.hash);
+		if (path !== this._current) {
+			this._current = path;
+			this._onChangeFunction(this._current);
+		}
 	};
 }
 

--- a/tests/routing/unit/Link.ts
+++ b/tests/routing/unit/Link.ts
@@ -27,13 +27,23 @@ registry.defineInjector('router', () => () => router);
 
 let routerSetPathSpy: SinonSpy;
 
-function createMockEvent(isRightClick: boolean = false) {
+function createMockEvent(
+	options: { isRightClick?: boolean; metaKey?: boolean; ctrlKey?: boolean } = {
+		isRightClick: false,
+		metaKey: false,
+		ctrlKey: false
+	}
+) {
+	const { ctrlKey = false, metaKey = false, isRightClick = false } = options;
+
 	return {
 		defaultPrevented: false,
 		preventDefault() {
 			this.defaultPrevented = true;
 		},
-		button: isRightClick ? undefined : 0
+		button: isRightClick ? undefined : 0,
+		metaKey,
+		ctrlKey
 	};
 }
 
@@ -124,7 +134,33 @@ describe('Link', () => {
 		const dNode: any = link.__render__();
 		assert.strictEqual(dNode.tag, 'a');
 		assert.strictEqual(dNode.properties.href, 'foo');
-		dNode.properties.onclick.call(link, createMockEvent(true));
+		dNode.properties.onclick.call(link, createMockEvent({ isRightClick: true }));
+		assert.isTrue(routerSetPathSpy.notCalled);
+	});
+
+	it('Does not set router path on ctrl click', () => {
+		const link = new Link();
+		link.registry.base = registry;
+		link.__setProperties__({
+			to: 'foo'
+		});
+		const dNode: any = link.__render__();
+		assert.strictEqual(dNode.tag, 'a');
+		assert.strictEqual(dNode.properties.href, 'foo');
+		dNode.properties.onclick.call(link, createMockEvent({ ctrlKey: true }));
+		assert.isTrue(routerSetPathSpy.notCalled);
+	});
+
+	it('Does not set router path on meta click', () => {
+		const link = new Link();
+		link.registry.base = registry;
+		link.__setProperties__({
+			to: 'foo'
+		});
+		const dNode: any = link.__render__();
+		assert.strictEqual(dNode.tag, 'a');
+		assert.strictEqual(dNode.properties.href, 'foo');
+		dNode.properties.onclick.call(link, createMockEvent({ metaKey: true }));
 		assert.isTrue(routerSetPathSpy.notCalled);
 	});
 

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -409,6 +409,18 @@ describe('Router', () => {
 		});
 	});
 
+	it('Should prefix links based on the history manager', () => {
+		class TestHistoryManager extends HistoryManager {
+			prefix(value: string) {
+				return `test-${value}`;
+			}
+		}
+		const router = new Router(routeWithChildrenAndMultipleParams, { HistoryManager: TestHistoryManager });
+		router.setPath('/foo/foo/bar/bar/baz/baz');
+		const link = router.link('baz');
+		assert.strictEqual(link, 'test-foo/foo/bar/bar/baz/baz');
+	});
+
 	it('Should create link using current params', () => {
 		const router = new Router(routeWithChildrenAndMultipleParams, { HistoryManager });
 		router.setPath('/foo/foo/bar/bar/baz/baz');

--- a/tests/routing/unit/history/StateHistory.ts
+++ b/tests/routing/unit/history/StateHistory.ts
@@ -40,6 +40,12 @@ describe('StateHistory', () => {
 		assert.equal(history.prefix('foo'), '/foo');
 	});
 
+	it('prefixes path removes # characters', () => {
+		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+		assert.equal(history.prefix('#/foo'), '/foo');
+		assert.equal(history.prefix('#foo'), '/foo');
+	});
+
 	it('update path', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		history.set('/foo');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

A collection of fixes for the routing:

* Support ctrl/cmd click
* Ensure links are generated with appropriate prefixes
* Ensure routing is synchronous with `setPath` when using `HashHistory`
* Strip leading `#` character when using `StateHistory`

Resolves #147 
Resolves #146 
Resolves #145 
