### PR TITLE
Support undefined and null in active classes

### DIFF
--- a/src/routing/ActiveLink.ts
+++ b/src/routing/ActiveLink.ts
@@ -1,5 +1,5 @@
 import WidgetBase from '../widget-core/WidgetBase';
-import { WNode } from '../widget-core/interfaces';
+import { WNode, SupportedClassName } from '../widget-core/interfaces';
 import { w } from '../widget-core/d';
 import diffProperty from '../widget-core/decorators/diffProperty';
 import { LinkProperties } from './interfaces';
@@ -8,7 +8,7 @@ import Router from './Router';
 import { Handle } from '../shim/interfaces';
 
 export interface ActiveLinkProperties extends LinkProperties {
-	activeClasses: string[];
+	activeClasses: SupportedClassName[];
 }
 
 function paramsEqual(linkParams: any = {}, contextParams: any = {}) {

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -90,10 +90,10 @@ describe('ActiveLink', () => {
 		router.setPath('/foo');
 		const link = new ActiveLink();
 		link.registry.base = registry;
-		link.__setProperties__({ to: 'foo', activeClasses: ['foo'] });
+		link.__setProperties__({ to: 'foo', activeClasses: ['foo', undefined, null] });
 		const dNode = link.__render__() as WNode<Link>;
 		assert.strictEqual(dNode.widgetConstructor, Link);
-		assert.deepEqual(dNode.properties.classes, ['foo']);
+		assert.deepEqual(dNode.properties.classes, ['foo', undefined, null]);
 		assert.deepEqual(dNode.properties.to, 'foo');
 	});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Active classes on `ActiveLink` should support `undefined` and `null` like all other classes (and the return interface of `this.theme()`

Resolves #149 
