### PR TITLE
Fix to support setting a value on a select node

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -547,6 +547,22 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 		return insertBefore;
 	}
 
+	function setValue(domNode: any, propValue?: any, previousValue?: any) {
+		const domValue = domNode.value;
+		const onInputValue = domNode['oninput-value'];
+		const onSelectValue = domNode['select-value'];
+
+		if (onSelectValue && domValue !== onSelectValue) {
+			domNode.value = onSelectValue;
+			if (domNode.value === onSelectValue) {
+				domNode['select-value'] = undefined;
+			}
+		} else if ((onInputValue && domValue === onInputValue) || propValue !== previousValue) {
+			domNode.value = propValue;
+			domNode['oninput-value'] = undefined;
+		}
+	}
+
 	function setProperties(
 		domNode: HTMLElement,
 		currentProperties: VNodeProperties = {},
@@ -602,15 +618,9 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 					propValue = '';
 				}
 				if (propName === 'value') {
-					const domValue = (domNode as any)[propName];
-					if (
-						domValue !== propValue &&
-						((domNode as any)['oninput-value']
-							? domValue === (domNode as any)['oninput-value']
-							: propValue !== previousValue)
-					) {
-						(domNode as any)[propName] = propValue;
-						(domNode as any)['oninput-value'] = undefined;
+					setValue(domNode, propValue, previousValue);
+					if ((domNode as HTMLElement).tagName === 'SELECT') {
+						(domNode as any)['select-value'] = propValue;
 					}
 				} else if (propName !== 'key' && propValue !== previousValue) {
 					const type = typeof propValue;
@@ -824,6 +834,9 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 					if (isDomVNode(next.node) && next.node.onAttach) {
 						next.node.onAttach();
 					}
+				}
+				if ((domNode as HTMLElement).tagName === 'OPTION' && domNode!.parentElement) {
+					setValue(domNode!.parentElement);
 				}
 				runEnterAnimation(next, _mountOptions.transition);
 				const instanceData = widgetInstanceMap.get(next.node.bind as WidgetBase);

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -5089,6 +5089,38 @@ jsdomDescribe('vdom', () => {
 		});
 	});
 
+	describe('selects', () => {
+		it('should set initial select value', () => {
+			const r = renderer(() =>
+				v('select', { value: 'a' }, [
+					v('option'),
+					v('option', { value: 'a' }, ['a']),
+					v('option', { value: 'b' }, ['b'])
+				])
+			);
+
+			const div = document.createElement('div');
+			r.mount({ domNode: div, sync: true });
+			assert.strictEqual((div.children[0] as any).value, 'a');
+		});
+
+		it('should support multi-select selects', () => {
+			const r = renderer(() =>
+				v('select', { key: 'multi', multiple: true }, [
+					v('option', { key: 'a', value: 'a', selected: true }, ['a']),
+					v('option', { key: 'b', value: 'b', selected: true }, ['b']),
+					v('option', { key: 'c', value: 'c' }, ['c'])
+				])
+			);
+
+			const div = document.createElement('div');
+			r.mount({ domNode: div, sync: true });
+			assert.strictEqual((div.childNodes[0].childNodes[0] as any).selected, true);
+			assert.strictEqual((div.childNodes[0].childNodes[1] as any).selected, true);
+			assert.strictEqual((div.childNodes[0].childNodes[2] as any).selected, false);
+		});
+	});
+
 	it('i18n Mixin', () => {
 		let setProperties: any;
 		class MyWidget extends I18nMixin(WidgetBase) {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fix to support setting a value on a `select` node. To set a value for a select the needs to have an option child with the value required. Adds a special `select-value` property to the select node and attempts to set the value when options are attached to the select parent. Only sets the value if the parent has a `select-value` property and the `select.value` doesn't equal the `select.select-value`

Resolves #153 
