### PR TITLE
Update harness() API to allow passing a registry

### DIFF
--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -48,26 +48,18 @@ const router = new Router(
 
 registry.defineInjector('router', () => () => router);
 
-class BaseActiveLink extends ActiveLink {
-	constructor(...args: any[]) {
-		super(...args);
-
-		this.registry.base = registry;
-	}
-}
-
 describe('ActiveLink', () => {
 	it('should invalidate when the outlet has been matched', () => {
 		let invalidateCallCount = 0;
 
-		class MyActiveLink extends BaseActiveLink {
+		class MyActiveLink extends ActiveLink {
 			invalidate() {
 				super.invalidate();
 				invalidateCallCount++;
 			}
 		}
 
-		const h = harness(() => w(MyActiveLink, { to: 'foo', activeClasses: ['foo'] }));
+		const h = harness(() => w(MyActiveLink, { to: 'foo', activeClasses: ['foo'] }), { registry });
 		h.expect(() => w(Link, { classes: [], to: 'foo' }));
 
 		invalidateCallCount = 0;
@@ -81,33 +73,33 @@ describe('ActiveLink', () => {
 
 	it('Does not add active class when outlet is not active', () => {
 		router.setPath('/other');
-		const h = harness(() => w(BaseActiveLink, { to: 'foo', activeClasses: ['foo', undefined, null] }));
+		const h = harness(() => w(ActiveLink, { to: 'foo', activeClasses: ['foo', undefined, null] }), { registry });
 		h.expect(() => w(Link, { classes: [], to: 'foo' }));
 	});
 
 	it('Should add the active class when the outlet is active', () => {
 		router.setPath('/foo');
-		const h = harness(() => w(BaseActiveLink, { to: 'foo', activeClasses: ['foo', undefined, null] }));
+		const h = harness(() => w(ActiveLink, { to: 'foo', activeClasses: ['foo', undefined, null] }), { registry });
 		h.expect(() => w(Link, { classes: ['foo', undefined, null], to: 'foo' }));
 	});
 
 	it('Should render the ActiveLink children', () => {
 		router.setPath('/foo');
-		const h = harness(() => w(BaseActiveLink, { to: 'foo', activeClasses: ['foo'] }, ['hello']));
+		const h = harness(() => w(ActiveLink, { to: 'foo', activeClasses: ['foo'] }, ['hello']), { registry });
 		h.expect(() => w(Link, { classes: ['foo'], to: 'foo' }, ['hello']));
 	});
 
 	it('Should mix the active class onto existing string class when the outlet is active', () => {
 		router.setPath('/foo');
-		const h = harness(() => w(BaseActiveLink, { to: 'foo', activeClasses: ['foo'], classes: 'bar' }));
+		const h = harness(() => w(ActiveLink, { to: 'foo', activeClasses: ['foo'], classes: 'bar' }), { registry });
 		h.expect(() => w(Link, { classes: ['bar', 'foo'], to: 'foo' }));
 	});
 
 	it('Should mix the active class onto existing array of classes when the outlet is active', () => {
 		router.setPath('/foo');
-		const h = harness(() =>
-			w(BaseActiveLink, { to: 'foo', activeClasses: ['foo', 'qux'], classes: ['bar', 'baz'] })
-		);
+		const h = harness(() => w(ActiveLink, { to: 'foo', activeClasses: ['foo', 'qux'], classes: ['bar', 'baz'] }), {
+			registry
+		});
 		h.expect(() => w(Link, { classes: ['bar', 'baz', 'foo', 'qux'], to: 'foo' }));
 	});
 
@@ -115,14 +107,14 @@ describe('ActiveLink', () => {
 		let invalidateCount = 0;
 		router.setPath('/foo');
 
-		class TestActiveLink extends BaseActiveLink {
+		class TestActiveLink extends ActiveLink {
 			invalidate() {
 				invalidateCount++;
 				super.invalidate();
 			}
 		}
 
-		const h = harness(() => w(TestActiveLink, { to: 'foo', activeClasses: ['foo'] }));
+		const h = harness(() => w(TestActiveLink, { to: 'foo', activeClasses: ['foo'] }), { registry });
 		h.expect(() => w(Link, { to: 'foo', classes: ['foo'] }));
 
 		invalidateCount = 0;
@@ -138,7 +130,7 @@ describe('ActiveLink', () => {
 		let invalidateCount = 0;
 		router.setPath('/foo');
 
-		class TestActiveLink extends BaseActiveLink {
+		class TestActiveLink extends ActiveLink {
 			invalidate() {
 				invalidateCount++;
 				super.invalidate();
@@ -147,7 +139,7 @@ describe('ActiveLink', () => {
 
 		let properties: any = { to: 'foo', activeClasses: ['foo'] };
 
-		const h = harness(() => w(TestActiveLink, properties));
+		const h = harness(() => w(TestActiveLink, properties), { registry });
 		h.expect(() => w(Link, { to: 'foo', classes: ['foo'] }));
 
 		invalidateCount = 0;
@@ -166,33 +158,38 @@ describe('ActiveLink', () => {
 
 	it('Should return link when the router injector is not available', () => {
 		router.setPath('/foo');
-		const h = harness(() =>
-			w(BaseActiveLink, { to: 'foo', activeClasses: ['foo'], classes: 'bar', routerKey: 'other' })
+		const h = harness(
+			() => w(ActiveLink, { to: 'foo', activeClasses: ['foo'], classes: 'bar', routerKey: 'other' }),
+			{ registry }
 		);
 		h.expect(() => w(Link, { to: 'foo', classes: ['bar'], routerKey: 'other' }));
 	});
 
 	it('should look at route params when determining active', () => {
 		router.setPath('/param/one');
-		const h1 = harness(() =>
-			w(BaseActiveLink, {
-				to: 'suffixed-param',
-				activeClasses: ['foo'],
-				params: {
-					suffix: 'one'
-				}
-			})
+		const h1 = harness(
+			() =>
+				w(ActiveLink, {
+					to: 'suffixed-param',
+					activeClasses: ['foo'],
+					params: {
+						suffix: 'one'
+					}
+				}),
+			{ registry }
 		);
 		h1.expect(() => w(Link, { to: 'suffixed-param', classes: ['foo'], params: { suffix: 'one' } }));
 
-		const h2 = harness(() =>
-			w(BaseActiveLink, {
-				to: 'suffixed-param',
-				activeClasses: ['foo'],
-				params: {
-					suffix: 'two'
-				}
-			})
+		const h2 = harness(
+			() =>
+				w(ActiveLink, {
+					to: 'suffixed-param',
+					activeClasses: ['foo'],
+					params: {
+						suffix: 'two'
+					}
+				}),
+			{ registry }
 		);
 		h2.expect(() => w(Link, { to: 'suffixed-param', classes: [], params: { suffix: 'two' } }));
 	});

--- a/tests/routing/unit/Link.ts
+++ b/tests/routing/unit/Link.ts
@@ -49,14 +49,6 @@ function createMockEvent(
 	};
 }
 
-class TestLink extends Link {
-	constructor(...args: any[]) {
-		super(...args);
-
-		this.registry.base = registry;
-	}
-}
-
 const noop: any = () => {};
 
 describe('Link', () => {
@@ -69,36 +61,38 @@ describe('Link', () => {
 	});
 
 	it('Generate link component for basic outlet', () => {
-		const h = harness(() => w(TestLink, { to: 'foo' }));
+		const h = harness(() => w(Link, { to: 'foo' }), { registry });
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 	});
 
 	it('Generate link component for outlet with specified params', () => {
-		const h = harness(() => w(TestLink, { to: 'foo2', params: { foo: 'foo' } }));
+		const h = harness(() => w(Link, { to: 'foo2', params: { foo: 'foo' } }), { registry });
 		h.expect(() => v('a', { href: 'foo/foo', onclick: noop }));
 	});
 
 	it('Generate link component for fixed href', () => {
-		const h = harness(() => w(TestLink, { to: '#foo/static', isOutlet: false }));
+		const h = harness(() => w(Link, { to: '#foo/static', isOutlet: false }), { registry });
 		h.expect(() => v('a', { href: '#foo/static', onclick: noop }));
 	});
 
 	it('Set router path on click', () => {
-		const h = harness(() => w(TestLink, { to: '#foo/static', isOutlet: false }));
+		const h = harness(() => w(Link, { to: '#foo/static', isOutlet: false }), { registry });
 		h.expect(() => v('a', { href: '#foo/static', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent());
 		assert.isTrue(routerSetPathSpy.calledWith('#foo/static'));
 	});
 
 	it('Custom onClick handler can prevent default', () => {
-		const h = harness(() =>
-			w(TestLink, {
-				to: 'foo',
-				registry,
-				onClick(event: MouseEvent) {
-					event.preventDefault();
-				}
-			})
+		const h = harness(
+			() =>
+				w(Link, {
+					to: 'foo',
+					registry,
+					onClick(event: MouseEvent) {
+						event.preventDefault();
+					}
+				}),
+			{ registry }
 		);
 		h.expect(() => v('a', { href: 'foo', registry, onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent());
@@ -106,28 +100,28 @@ describe('Link', () => {
 	});
 
 	it('Does not set router path when target attribute is set', () => {
-		const h = harness(() => w(TestLink, { to: 'foo', target: '_blank' }));
+		const h = harness(() => w(Link, { to: 'foo', target: '_blank' }), { registry });
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent());
 		assert.isTrue(routerSetPathSpy.notCalled);
 	});
 
 	it('Does not set router path on right click', () => {
-		const h = harness(() => w(TestLink, { to: 'foo' }));
+		const h = harness(() => w(Link, { to: 'foo' }), { registry });
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent({ isRightClick: true }));
 		assert.isTrue(routerSetPathSpy.notCalled);
 	});
 
 	it('Does not set router path on ctrl click', () => {
-		const h = harness(() => w(TestLink, { to: 'foo' }));
+		const h = harness(() => w(Link, { to: 'foo' }), { registry });
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent({ ctrlKey: true }));
 		assert.isTrue(routerSetPathSpy.notCalled);
 	});
 
 	it('Does not set router path on meta click', () => {
-		const h = harness(() => w(TestLink, { to: 'foo' }));
+		const h = harness(() => w(Link, { to: 'foo' }), { registry });
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent({ metaKey: true }));
 		assert.isTrue(routerSetPathSpy.notCalled);
@@ -135,7 +129,7 @@ describe('Link', () => {
 
 	it('throw error if the injected router cannot be found with the router key', () => {
 		try {
-			harness(() => w(TestLink, { to: '#foo/static', isOutlet: false, routerKey: 'fake-key' }));
+			harness(() => w(Link, { to: '#foo/static', isOutlet: false, routerKey: 'fake-key' }), { registry });
 			assert.fail('Should throw an error when the injected router cannot be found with the routerKey');
 		} catch (err) {
 			// nothing to see here

--- a/tests/routing/unit/Outlet.ts
+++ b/tests/routing/unit/Outlet.ts
@@ -36,31 +36,24 @@ const routeConfig = [
 	}
 ];
 
-let BaseOutlet: new (...args: any[]) => Outlet;
-
 describe('Outlet', () => {
 	beforeEach(() => {
 		registry = new Registry();
-		BaseOutlet = class extends Outlet {
-			constructor(...args: any[]) {
-				super(...args);
-
-				this.registry.base = registry;
-			}
-		};
 	});
 
 	it('Should render the result of the renderer when the outlet matches', () => {
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 
 		router.setPath('/foo');
-		const h = harness(() =>
-			w(BaseOutlet, {
-				id: 'foo',
-				renderer() {
-					return w(Widget, {});
-				}
-			})
+		const h = harness(
+			() =>
+				w(Outlet, {
+					id: 'foo',
+					renderer() {
+						return w(Widget, {});
+					}
+				}),
+			{ registry }
 		);
 		h.expect(() => w(Widget, {}, []));
 	});
@@ -69,14 +62,16 @@ describe('Outlet', () => {
 		let matchType: string | undefined;
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo');
-		const h = harness(() =>
-			w(BaseOutlet, {
-				id: 'foo',
-				renderer(details: any) {
-					matchType = details.type;
-					return null;
-				}
-			})
+		const h = harness(
+			() =>
+				w(Outlet, {
+					id: 'foo',
+					renderer(details: any) {
+						matchType = details.type;
+						return null;
+					}
+				}),
+			{ registry }
 		);
 		h.expect(() => null);
 		assert.strictEqual(matchType, 'index');
@@ -86,14 +81,16 @@ describe('Outlet', () => {
 		let matchType: string | undefined;
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo/other');
-		const h = harness(() =>
-			w(BaseOutlet, {
-				id: 'foo',
-				renderer(details: any) {
-					matchType = details.type;
-					return null;
-				}
-			})
+		const h = harness(
+			() =>
+				w(Outlet, {
+					id: 'foo',
+					renderer(details: any) {
+						matchType = details.type;
+						return null;
+					}
+				}),
+			{ registry }
 		);
 		h.expect(() => null);
 		assert.strictEqual(matchType, 'error');
@@ -108,7 +105,7 @@ describe('Outlet', () => {
 		];
 
 		let invalidateCount = 0;
-		class TestOutlet extends BaseOutlet {
+		class TestOutlet extends Outlet {
 			onAttach() {
 				super.onAttach();
 			}
@@ -120,15 +117,17 @@ describe('Outlet', () => {
 
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo');
-		const h = harness(() =>
-			w(TestOutlet, {
-				id: 'foo',
-				renderer(details: any) {
-					if (details.type === 'index') {
-						return w(Widget, {});
+		const h = harness(
+			() =>
+				w(TestOutlet, {
+					id: 'foo',
+					renderer(details: any) {
+						if (details.type === 'index') {
+							return w(Widget, {});
+						}
 					}
-				}
-			})
+				}),
+			{ registry }
 		);
 		const widget = (h.getRender(0) as any).bind;
 		widget.onAttach();
@@ -145,7 +144,7 @@ describe('Outlet', () => {
 			}
 		];
 
-		class TestOutlet extends BaseOutlet {
+		class TestOutlet extends Outlet {
 			onDetach() {
 				super.onDetach();
 			}
@@ -153,15 +152,17 @@ describe('Outlet', () => {
 
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/other');
-		const h = harness(() =>
-			w(TestOutlet, {
-				id: 'foo',
-				renderer(details: any) {
-					if (details.type === 'index') {
-						return w(Widget, {});
+		const h = harness(
+			() =>
+				w(TestOutlet, {
+					id: 'foo',
+					renderer(details: any) {
+						if (details.type === 'index') {
+							return w(Widget, {});
+						}
 					}
-				}
-			})
+				}),
+			{ registry }
 		);
 		h.expect(() => null);
 	});
@@ -175,7 +176,7 @@ describe('Outlet', () => {
 		];
 
 		let invalidateCount = 0;
-		class TestOutlet extends BaseOutlet {
+		class TestOutlet extends Outlet {
 			invalidate() {
 				invalidateCount++;
 			}
@@ -194,7 +195,7 @@ describe('Outlet', () => {
 		const routerOne = registerRouterInjector(routeConfig, registry, { HistoryManager, key: 'my-router' });
 		const routerTwo = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		routerOne.setPath('/foo');
-		const h = harness(() => w(TestOutlet, properties));
+		const h = harness(() => w(TestOutlet, properties), { registry });
 		invalidateCount = 0;
 		routerOne.setPath('/bar');
 		assert.strictEqual(invalidateCount, 1);

--- a/tests/testing/unit/harness.ts
+++ b/tests/testing/unit/harness.ts
@@ -7,6 +7,7 @@ import { v, w, isVNode } from '../../../src/widget-core/d';
 import Set from '../../../src/shim/Set';
 import Map from '../../../src/shim/Map';
 import { VNode, WNode } from '../../../src/widget-core/interfaces';
+import Registry from '../../../src/widget-core/Registry';
 
 const noop: any = () => {};
 
@@ -433,6 +434,49 @@ describe('harness', () => {
 			const h = harness(() => w(Foo, { foo, bar }));
 			h.expect(() => w(Bar, { foo, bar }));
 		});
+
+		it('supports passing a registry', () => {
+			const registry = new Registry();
+			registry.define('registry-item', ChildWidget);
+			const h = harness(() => w(MyWidget, {}), { registry });
+			h.expect(() =>
+				v('div', { classes: ['root', 'other'], onclick: () => {} }, [
+					v(
+						'span',
+						{ key: 'span', classes: 'span', style: 'width: 100px', id: 'random-id', onclick: () => {} },
+						['hello 0']
+					),
+					w(ChildWidget, { key: 'widget', id: 'random-id', func: noop }),
+					w(ChildWidget, { key: 'registry', id: 'random-id' })
+				])
+			);
+		});
+
+		it('supports passing a registry and comparators', () => {
+			const registry = new Registry();
+			registry.define('registry-item', ChildWidget);
+			const h = harness(() => w(MyWidget, {}), {
+				registry,
+				comparators: [
+					{
+						selector: '*[key="registry"]',
+						property: 'id',
+						comparator: (property: any) => typeof property === 'string'
+					}
+				]
+			});
+			h.expect(() =>
+				v('div', { classes: ['root', 'other'], onclick: () => {} }, [
+					v(
+						'span',
+						{ key: 'span', classes: 'span', style: 'width: 100px', id: 'random-id', onclick: () => {} },
+						['hello 0']
+					),
+					w(ChildWidget, { key: 'widget', id: 'random-id', func: noop }),
+					w(ChildWidget, { key: 'registry', id: '' })
+				])
+			);
+		});
 	});
 
 	describe('widget with an array of DNodes', () => {
@@ -578,6 +622,41 @@ describe('harness', () => {
 				]),
 				w(ChildWidget, { key: 'widget', id: 'random-id' }),
 				w<ChildWidget>('registry-item', { key: 'registry', id: '' })
+			]);
+		});
+
+		it('supports passing a registry', () => {
+			const registry = new Registry();
+			registry.define('registry-item', ChildWidget);
+			const h = harness(() => w(ArrayWidget, {}), { registry });
+			h.expect(() => [
+				v('span', { key: 'span', classes: 'span', style: 'width: 100px', id: 'random-id', onclick: () => {} }, [
+					'hello 0'
+				]),
+				w(ChildWidget, { key: 'widget', id: 'random-id' }),
+				w(ChildWidget, { key: 'registry', id: 'random-id' })
+			]);
+		});
+
+		it('supports passing a registry and comparators', () => {
+			const registry = new Registry();
+			registry.define('registry-item', ChildWidget);
+			const h = harness(() => w(ArrayWidget, {}), {
+				registry,
+				comparators: [
+					{
+						selector: '*[key="registry"]',
+						property: 'id',
+						comparator: (property: any) => typeof property === 'string'
+					}
+				]
+			});
+			h.expect(() => [
+				v('span', { key: 'span', classes: 'span', style: 'width: 100px', id: 'random-id', onclick: () => {} }, [
+					'hello 0'
+				]),
+				w(ChildWidget, { key: 'widget', id: 'random-id' }),
+				w(ChildWidget, { key: 'registry', id: '' })
 			]);
 		});
 	});


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This updates the `harness()` API to allow passing in a registry so tests don't have to subclass a widget class in order to set the registry. I also updated the `routing` tests to use the new API.