### PR TITLE
fixes working with base paths in state history

### DIFF
--- a/src/has/has.ts
+++ b/src/has/has.ts
@@ -247,6 +247,8 @@ export default function has(feature: string): FeatureTestResult {
 /* Used as a value to provide a debug only code path */
 add('debug', true);
 
+add('public-path', undefined);
+
 /* flag for dojo debug, default to false */
 add('dojo-debug', false);
 

--- a/src/routing/history/StateHistory.ts
+++ b/src/routing/history/StateHistory.ts
@@ -23,7 +23,9 @@ export class StateHistory implements HistoryInterface {
 	private _base: string;
 
 	constructor({ onChange, window = global.window, base }: HistoryOptions) {
-		base = `${has('public-path')}` || '/';
+		if (!base) {
+			base = has('public-path') ? `${has('public-path')}` : '/';
+		}
 		if (/(#|\?)/.test(base)) {
 			throw new TypeError("base must not contain '#' or '?'");
 		}

--- a/src/routing/history/StateHistory.ts
+++ b/src/routing/history/StateHistory.ts
@@ -62,7 +62,8 @@ export class StateHistory implements HistoryInterface {
 	}
 
 	private _onChange = () => {
-		const value = stripBase(this._base, this._window.location.pathname + this._window.location.search);
+		const pathName = this._window.location.pathname.replace(/\/$/, '');
+		const value = stripBase(this._base, pathName + this._window.location.search);
 		if (this._current === value) {
 			return;
 		}

--- a/src/routing/history/StateHistory.ts
+++ b/src/routing/history/StateHistory.ts
@@ -1,5 +1,6 @@
 import global from '../../shim/global';
 import { History as HistoryInterface, HistoryOptions, OnChangeFunction } from './../interfaces';
+import has from '../../has/has';
 
 const trailingSlash = new RegExp(/\/$/);
 const leadingSlash = new RegExp(/^\//);
@@ -21,7 +22,8 @@ export class StateHistory implements HistoryInterface {
 	private _window: Window;
 	private _base: string;
 
-	constructor({ onChange, window = global.window, base = global.__public_path__ || '/' }: HistoryOptions) {
+	constructor({ onChange, window = global.window, base }: HistoryOptions) {
+		base = (has('public-path') as string) || '/';
 		if (/(#|\?)/.test(base)) {
 			throw new TypeError("base must not contain '#' or '?'");
 		}

--- a/src/routing/history/StateHistory.ts
+++ b/src/routing/history/StateHistory.ts
@@ -23,7 +23,7 @@ export class StateHistory implements HistoryInterface {
 	private _base: string;
 
 	constructor({ onChange, window = global.window, base }: HistoryOptions) {
-		base = (has('public-path') as string) || '/';
+		base = `${has('public-path')}` || '/';
 		if (/(#|\?)/.test(base)) {
 			throw new TypeError("base must not contain '#' or '?'");
 		}

--- a/tests/routing/unit/history/StateHistory.ts
+++ b/tests/routing/unit/history/StateHistory.ts
@@ -3,6 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import { stub } from 'sinon';
 
 import global from '../../../../src/shim/global';
+import { add } from '../../../../src/has/has';
 import { StateHistory } from '../../../../src/routing/history/StateHistory';
 
 const onChange = stub();
@@ -24,6 +25,7 @@ describe('StateHistory', () => {
 		document.body.removeChild(sandbox);
 		sandbox = null as any;
 		onChange.reset();
+		add('public-path', undefined, true);
 		global.window.__public_path__ = undefined;
 	});
 
@@ -155,6 +157,7 @@ describe('StateHistory', () => {
 		});
 
 		it('Assumes base set in window __public_path__ variable if not explicitly set', () => {
+			add('public-path', 'base/path', true);
 			global.window.__public_path__ = 'base/path';
 			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 			assert.strictEqual(history.prefix('foo'), '/base/path/foo');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

A few fixes for `StateHistory` history adapter:

1) Add leading slash if missing to base path
1) Default to `window.__public_path__` if it exists
1) Strip base on pushing the state

