### PR TITLE
Exposing select in harness

### DIFF
--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -9,6 +9,7 @@ Simple API for testing and asserting Dojo widget's expected virtual DOM and beha
 -   [`harness.expect`](#harnessexpect)
 -   [`harness.expectPartial`](#harnessexpectpartial)
 -   [`harness.trigger`](#harnesstrigger)
+-   `harness.select`
 
 ## Features
 
@@ -38,6 +39,7 @@ The harness returns a `Harness` object that provides a small API for interacting
 -   [`expectPartial`](#harnessexpectpartial): Performs an assertion against a section of the render output from the widget under test.
 -   [`trigger`](#harnesstrigger): Used to trigger a function from a node on the widget under test's API
 -   [`getRender`](#harnessgetRender): Returns a render from the harness based on the index provided
+-   [`select`](#harnessselect): Returns a list of nodes matching the given selector, using the last render.
 
 Setting up a widget for testing is simple and familiar using the `w()` function from `@dojo/framework/widget-core`:
 
@@ -229,4 +231,47 @@ const render = h.getRender();
 ```ts
 // Returns the result of the render for the index provided
 h.getRender(1);
+```
+
+#### `harness.select`
+
+`harness.select` returns a list of DNodes, using the latest render, that match the provided selector. This can be useful if you need access to a widget's properties.
+
+```typescript
+select(selector: string);
+```
+
+-   `selector`: The selector to use while determining matching DNodes
+
+Example Usage:
+
+Given a VDOM tree like,
+
+```typescript
+v(Toolbar, {
+	key: 'toolbar',
+	buttons: [
+		{
+			icon: 'save',
+			onClick: () => this._onSave()
+		},
+		{
+			icon: 'cancel',
+			onClick: () => this._onCancel()
+		}
+	]
+});
+```
+
+And you want to run the save toolbar button's `onClick` function.
+
+```typescript
+// find the toolbar
+const [toolbar] = h.select('@toolbar');
+
+// get the button's properties
+const properties = toolbar.properties as ToolbarProperties;
+
+// manually call the click handler
+properties.buttons[0].onClick();
 ```

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -9,7 +9,7 @@ Simple API for testing and asserting Dojo widget's expected virtual DOM and beha
 -   [`harness.expect`](#harnessexpect)
 -   [`harness.expectPartial`](#harnessexpectpartial)
 -   [`harness.trigger`](#harnesstrigger)
--   `harness.select`
+-   [`harness.select`](#harnessselect)
 
 ## Features
 
@@ -235,10 +235,10 @@ h.getRender(1);
 
 #### `harness.select`
 
-`harness.select` returns a list of DNodes, using the latest render, that match the provided selector. This can be useful if you need access to a widget's properties.
+`harness.select` returns an array of DNodes, using the latest render, that match the provided selector. This can be useful if you need access to a widget's properties.
 
 ```typescript
-select(selector: string);
+select(selector: string): DNode[];
 ```
 
 -   `selector`: The selector to use while determining matching DNodes

--- a/src/testing/harness.ts
+++ b/src/testing/harness.ts
@@ -180,6 +180,7 @@ export function harness(
 			return _getRender(index);
 		},
 		select(selector: string): DNode[] {
+			_tryRender();
 			return select(selector, _getRender());
 		}
 	};

--- a/src/testing/harness.ts
+++ b/src/testing/harness.ts
@@ -42,11 +42,16 @@ export interface GetRender {
 	(index?: number): DNode | DNode[];
 }
 
+export interface Select {
+	(selector: string): DNode[];
+}
+
 export interface HarnessAPI {
 	expect: Expect;
 	expectPartial: ExpectPartial;
 	trigger: Trigger;
 	getRender: GetRender;
+	select: Select;
 }
 
 function decorateNodes(dNode: DNode[]): DecoratorResult<DNode[]>;
@@ -173,6 +178,9 @@ export function harness(
 		},
 		getRender(index?: number): DNode | DNode[] {
 			return _getRender(index);
+		},
+		select(selector: string): DNode[] {
+			return select(selector, _getRender());
 		}
 	};
 }

--- a/tests/testing/unit/harness.ts
+++ b/tests/testing/unit/harness.ts
@@ -581,4 +581,10 @@ describe('harness', () => {
 			]);
 		});
 	});
+
+	describe('select', () => {
+		const h = harness(() => w(MyWidget, {}));
+
+		assert.isTrue(h.select('@span').length === 1);
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

We've already got the `select` utility, but this PR just exposes it to be a little more... friendly. Just adds a way to select DNodes directly from your harness. Once you have a DNode you can asset various things, call callbacks, etc.

```typescript
const h = harness(() => w(MyWidget, {
    key: "root",
    footer: v('button', { onclick: () => doSomething() }, 'footer')
}));
const [myWidget] = h.select("@root");

myWidget.properties.footer.onclick();
```

`select` will trigger a new render when you call it, so you can do things like,

```typescript
const foo = 'hello'
const h = harness(() => w(MyWidget, { foo }));
assert.isTrue(h.select('@span').length === 1);
foo = 'bar';
assert.isTrue(h.select('@span').length === 1);
```