### PR TITLE
Process Exit Animations before removing parent nodes

### DIFF
--- a/src/widget-core/animations/cssTransitions.ts
+++ b/src/widget-core/animations/cssTransitions.ts
@@ -26,12 +26,12 @@ function runAndCleanUp(element: HTMLElement, startAnimation: () => void, finishA
 
 	let finished = false;
 
-	let transitionEnd = function() {
+	let transitionEnd = function(event: Event) {
+		event.stopPropagation();
 		if (!finished) {
 			finished = true;
 			element.removeEventListener(browserSpecificTransitionEndEventName, transitionEnd);
 			element.removeEventListener(browserSpecificAnimationEndEventName, transitionEnd);
-
 			finishAnimation();
 		}
 	};


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Nodes with an exit animation need to be processed before they are orphaned from the DOM. This change detects when there are child nodes with an exit animation and ensures that they are processed before any parent nodes are removed from the DOM.

Resolves #167 
