### PR TITLE
Bug: Value doesn't update when setting the value of select in UI

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -619,10 +619,10 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 					propValue = '';
 				}
 				if (propName === 'value') {
-					setValue(domNode, propValue, previousValue);
 					if ((domNode as HTMLElement).tagName === 'SELECT') {
 						(domNode as any)['select-value'] = propValue;
 					}
+					setValue(domNode, propValue, previousValue);
 				} else if (propName !== 'key' && propValue !== previousValue) {
 					const type = typeof propValue;
 					if (type === 'function' && propName.lastIndexOf('on', 0) === 0 && includesEventsAndAttributes) {

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -5104,7 +5104,7 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual((div.children[0] as any).value, 'a');
 		});
 
-		it('should support clearing select value', () => {
+		it('should support changing the select value', () => {
 			let change: any;
 			class Select extends WidgetBase {
 				constructor() {
@@ -5140,7 +5140,7 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual((div.children[0] as any).value, 'b');
 		});
 
-		it('should support clearing select value - programmatically', () => {
+		it('should support changing the select value - programmatically', () => {
 			let change: any;
 			class Select extends WidgetBase {
 				constructor() {

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -5104,6 +5104,42 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual((div.children[0] as any).value, 'a');
 		});
 
+		it('should support clearing select value', () => {
+			let change: any;
+			class Select extends WidgetBase {
+				constructor() {
+					super();
+					change = this.change.bind(this);
+				}
+
+				value = '';
+				change(event: any) {
+					this.value = event.target.value;
+					this.invalidate();
+				}
+				render() {
+					return v('select', { onchange: this.change, value: this.value }, [
+						v('option', { value: '' }),
+						v('option', { value: 'a' }, ['a']),
+						v('option', { value: 'b' }, ['b'])
+					]);
+				}
+			}
+
+			const r = renderer(() => w(Select, {}));
+			const div = document.createElement('div');
+			r.mount({ domNode: div, sync: true });
+			assert.strictEqual((div.children[0] as any).value, '');
+			// set the value as this is what happens when the select is click in the browser
+			(div.children[0] as any).value = 'a';
+			change({ target: { value: 'a' } });
+			assert.strictEqual((div.children[0] as any).value, 'a');
+			// set the value as this is what happens when the select is click in the browser
+			(div.children[0] as any).value = 'b';
+			change({ target: { value: 'b' } });
+			assert.strictEqual((div.children[0] as any).value, 'b');
+		});
+
 		it('should support multi-select selects', () => {
 			const r = renderer(() =>
 				v('select', { key: 'multi', multiple: true }, [

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -5140,6 +5140,38 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual((div.children[0] as any).value, 'b');
 		});
 
+		it('should support clearing select value - programmatically', () => {
+			let change: any;
+			class Select extends WidgetBase {
+				constructor() {
+					super();
+					change = this.change.bind(this);
+				}
+
+				value = '';
+				change(event: any) {
+					this.value = event.target.value;
+					this.invalidate();
+				}
+				render() {
+					return v('select', { onchange: this.change, value: this.value }, [
+						v('option', { value: '' }),
+						v('option', { value: 'a' }, ['a']),
+						v('option', { value: 'b' }, ['b'])
+					]);
+				}
+			}
+
+			const r = renderer(() => w(Select, {}));
+			const div = document.createElement('div');
+			r.mount({ domNode: div, sync: true });
+			assert.strictEqual((div.children[0] as any).value, '');
+			change({ target: { value: 'a' } });
+			assert.strictEqual((div.children[0] as any).value, 'a');
+			change({ target: { value: 'b' } });
+			assert.strictEqual((div.children[0] as any).value, 'b');
+		});
+
 		it('should support multi-select selects', () => {
 			const r = renderer(() =>
 				v('select', { key: 'multi', multiple: true }, [


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The select value doesn't set because the dom value has already been updated, this means that because we run `setValue` before setting the `select-value` property the mechanism resets the value to the previous select value.

Make sure we set the `select-value` on the select node before we try and set the actual value.