### PR TITLE
Add before and after hooks to store middleware

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -4,10 +4,10 @@ Provides a small set of base classes and core helpers for use within dojo/framew
 
 ## Features
 
-- [Destroyable](#destroyable)
-- [Evented](#evented)
-- [QueuingEvented](#queuingevented)
-- [util](#util)
+-   [Destroyable](#destroyable)
+-   [Evented](#evented)
+-   [QueuingEvented](#queuingevented)
+-   [util](#util)
 
 ### Destroyable
 

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -537,14 +537,14 @@ In this example, `commandOne` is executed, then both `concurrentCommandOne` and 
 
 Middleware provides a hook to apply generic/global functionality across multiple or all processes used within an application. Middleware is a function that returns an object with optional `before` and `after` callback functions.
 
-Multiple middlewares can be provided, and in this case any `before` callbacks will be called in the order they are provided, and `after` callbacks will be called in the opposite order.
+Multiple middlewares can be provided, and in this case any `before` callbacks will be called in the order they are provided, the process will run, and then `after` callbacks will be called in the order provided.
 
 ### After Middleware
 
 If provided, the `after` callback will be passed the error and the result of a process to perform a specific action. If multiple middlewares are provided, their `after` callbacks will be
-executed in the opposite order as they were provided.
+executed in the order they were provided.
 
-In the example below, the `after` callbacks returned snapshot, logger, and callback will be called in that order.
+In the example below, the `after` callbacks returned by callback, logger, and snapshot will be called in that order.
 
 ```ts
 const myProcess = createProcess('my-process', [commandOne, commandTwo], [callback, logger, snapshot]);
@@ -638,9 +638,9 @@ const myProcess = createProcess('my-process', [commandOne, commandTwo], [logger,
 // logger before called
 // before only called
 // callback before called
-// callback after called
-// after only called
 // logger after called
+// after only called
+// callback after called
 ```
 
 ### Local Storage Middleware

--- a/src/stores/middleware/HistoryManager.ts
+++ b/src/stores/middleware/HistoryManager.ts
@@ -17,19 +17,16 @@ export interface HistoryData {
 export class HistoryManager {
 	private _storeMap = new WeakMap();
 
-	public collector(callback?: ProcessCallback): ProcessCallback {
-		return (error: ProcessError | null, result: ProcessResult): void => {
-			const { operations, undoOperations, id, store } = result;
-			const { history, undo } = this._storeMap.get(store) || {
-				history: [],
-				undo: []
-			};
-			history.push({ id, operations });
-			undo.push({ id, operations: undoOperations });
-			this._storeMap.set(store, { history, undo, redo: [] });
-			callback && callback(error, result);
+	public callback: ProcessCallback = (error: ProcessError | null, result: ProcessResult) => {
+		const { operations, undoOperations, id, store } = result;
+		const { history, undo } = this._storeMap.get(store) || {
+			history: [],
+			undo: []
 		};
-	}
+		history.push({ id, operations });
+		undo.push({ id, operations: undoOperations });
+		this._storeMap.set(store, { history, undo, redo: [] });
+	};
 
 	public canUndo(store: Store): boolean {
 		const stacks = this._storeMap.get(store);

--- a/src/stores/middleware/HistoryManager.ts
+++ b/src/stores/middleware/HistoryManager.ts
@@ -93,7 +93,7 @@ export class HistoryManager {
 			if (process) {
 				callback = process[2];
 			}
-			processExecutor(id, [() => operations], store, callback, undefined)({});
+			processExecutor(id, [() => operations], store, callback, undefined, undefined)({});
 		});
 		const stacks = this._storeMap.get(store);
 		redo.forEach(({ id, operations }: HistoryOperation) => {

--- a/src/stores/middleware/localStorage.ts
+++ b/src/stores/middleware/localStorage.ts
@@ -4,7 +4,7 @@ import { Store } from '../Store';
 import { GetPaths } from '../StoreProvider';
 import { add } from '../state/operations';
 
-export function collector<T = any>(id: string, getPaths: GetPaths<T>, callback?: ProcessCallback): ProcessCallback {
+export function collector<T = any>(id: string, getPaths: GetPaths<T>): ProcessCallback {
 	return (error: ProcessError | null, result: ProcessResult): void => {
 		const paths = getPaths(result.store.path);
 		const data = paths.map((path) => {
@@ -12,7 +12,6 @@ export function collector<T = any>(id: string, getPaths: GetPaths<T>, callback?:
 			return { meta: { path: path.path }, state };
 		});
 		global.localStorage.setItem(id, JSON.stringify(data));
-		callback && callback(error, result);
 	};
 }
 

--- a/src/stores/middleware/localStorage.ts
+++ b/src/stores/middleware/localStorage.ts
@@ -24,7 +24,7 @@ export function load<T>(id: string, store: Store<T>) {
 			const operations = parsedData.map((item) => {
 				return add(store.path(item.meta.path), item.state);
 			});
-			processExecutor('local-storage-load', [() => operations], store, undefined, undefined)({});
+			processExecutor('local-storage-load', [() => operations], store, undefined, undefined, undefined)({});
 		} catch {
 			// do nothing?
 		}

--- a/src/stores/middleware/localStorage.ts
+++ b/src/stores/middleware/localStorage.ts
@@ -5,14 +5,16 @@ import { GetPaths } from '../StoreProvider';
 import { add } from '../state/operations';
 
 export function collector<T = any>(id: string, getPaths: GetPaths<T>): ProcessCallback {
-	return (error: ProcessError | null, result: ProcessResult): void => {
-		const paths = getPaths(result.store.path);
-		const data = paths.map((path) => {
-			const state = result.get(path);
-			return { meta: { path: path.path }, state };
-		});
-		global.localStorage.setItem(id, JSON.stringify(data));
-	};
+	return () => ({
+		after: (error: ProcessError | null, result: ProcessResult): void => {
+			const paths = getPaths(result.store.path);
+			const data = paths.map((path) => {
+				const state = result.get(path);
+				return { meta: { path: path.path }, state };
+			});
+			global.localStorage.setItem(id, JSON.stringify(data));
+		}
+	});
 }
 
 export function load<T>(id: string, store: Store<T>) {

--- a/src/stores/process.ts
+++ b/src/stores/process.ts
@@ -280,12 +280,12 @@ function createCallbackDecorator(processCallback: ProcessCallback): ProcessCallb
 			: {};
 		return () => ({
 			after(error: ProcessError | null, result: ProcessResult) {
-				if (after) {
-					after(error, result);
-				}
-
 				if (previousAfter) {
 					previousAfter(error, result);
+				}
+
+				if (after) {
+					after(error, result);
 				}
 			},
 			before(payload: DefaultPayload, store: Store<any>) {

--- a/src/stores/process.ts
+++ b/src/stores/process.ts
@@ -258,7 +258,7 @@ export function createProcess<T = any, P extends object = DefaultPayload>(
  * @param callbacks array of process callback to be used by the returned factory.
  * @param initializers array of process initializers to be used by the returned factory.
  */
-export function createProcessFactoryWith(callbacks: ProcessCallback[] = []) {
+export function createProcessFactoryWith(callbacks: ProcessCallback[]) {
 	return <S, P extends object>(
 		id: string,
 		commands: (Command<S, P>[] | Command<S, P>)[],

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -234,8 +234,8 @@ v(Toolbar, {
 And you want to trigger the save toolbar button's `onClick` function.
 
 ```typescript
-h.trigger("@buttons", (renderResult: DNode<Toolbar>) => {
-  return renderResult.properties.buttons[0].onClick;
+h.trigger('@buttons', (renderResult: DNode<Toolbar>) => {
+	return renderResult.properties.buttons[0].onClick;
 });
 ```
 

--- a/tests/stores/unit/middleware/HistoryManager.ts
+++ b/tests/stores/unit/middleware/HistoryManager.ts
@@ -12,22 +12,12 @@ function incrementCounter({ get, path }: CommandRequest<{ counter: number }>): P
 	return [{ op: OperationType.REPLACE, path: new Pointer('/counter'), value: ++counter }];
 }
 
-function collector(callback?: any): any {
-	return (error: any, result: any): void => {
-		callback && callback(error, result);
-	};
-}
-
 describe('extras', () => {
 	it('can serialize and deserialize history', () => {
 		const historyManager = new HistoryManager();
 		const store = new Store();
 
-		const incrementCounterProcess = createProcess(
-			'increment',
-			[incrementCounter],
-			historyManager.collector(collector())
-		);
+		const incrementCounterProcess = createProcess('increment', [incrementCounter], historyManager.callback);
 		const executor = incrementCounterProcess(store);
 		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 1);

--- a/tests/stores/unit/middleware/localStorage.ts
+++ b/tests/stores/unit/middleware/localStorage.ts
@@ -59,23 +59,6 @@ describe('middleware - local storage', (suite) => {
 		);
 	});
 
-	it('Should call next middleware', () => {
-		let composedMiddlewareCalled = false;
-		const incrementCounterProcess = createProcess(
-			'increment',
-			[incrementCounter],
-			collector(
-				LOCAL_STORAGE_TEST_ID,
-				(path) => [path('counter')],
-				(error, result) => {
-					composedMiddlewareCalled = true;
-				}
-			)
-		);
-		incrementCounterProcess(store)({});
-		assert.isTrue(composedMiddlewareCalled);
-	});
-
 	it('should load from local storage', () => {
 		global.localStorage.setItem(LOCAL_STORAGE_TEST_ID, '[{"meta":{"path":"/counter"},"state":1}]');
 		load(LOCAL_STORAGE_TEST_ID, store);

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -304,15 +304,15 @@ describe('process', () => {
 		const executor = process(store);
 		executor({});
 		assert.lengthOf(results, 2);
-		assert.strictEqual(results[0], 'callback two');
-		assert.strictEqual(results[1], 'callback one');
+		assert.strictEqual(results[0], 'callback one');
+		assert.strictEqual(results[1], 'callback two');
 		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar']]);
 		executor({});
 		assert.lengthOf(results, 4);
-		assert.strictEqual(results[0], 'callback two');
-		assert.strictEqual(results[1], 'callback one');
-		assert.strictEqual(results[2], 'callback two');
-		assert.strictEqual(results[3], 'callback one');
+		assert.strictEqual(results[0], 'callback one');
+		assert.strictEqual(results[1], 'callback two');
+		assert.strictEqual(results[2], 'callback one');
+		assert.strictEqual(results[3], 'callback two');
 		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
 	});
 

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -10,7 +10,6 @@ import {
 	createProcessFactoryWith,
 	ProcessCallback,
 	ProcessError,
-	ProcessInitializer,
 	ProcessResult
 } from '../../../src/stores/process';
 import { Store } from '../../../src/stores/Store';
@@ -237,33 +236,39 @@ describe('process', () => {
 
 	it('can provide a callback that gets called on process completion', () => {
 		let callbackCalled = false;
-		const process = createProcess('test', [testCommandFactory('foo')], () => {
-			callbackCalled = true;
-		});
+		const process = createProcess('test', [testCommandFactory('foo')], () => ({
+			after: () => {
+				callbackCalled = true;
+			}
+		}));
 		const processExecutor = process(store);
 		processExecutor({});
 		assert.isTrue(callbackCalled);
 	});
 
 	it('when a command errors, the error and command is returned in the error argument of the callback', () => {
-		const process = createProcess('test', [testCommandFactory('foo'), testErrorCommand], (error) => {
-			assert.isNotNull(error);
-			assert.strictEqual(error && error.command, testErrorCommand);
-		});
+		const process = createProcess('test', [testCommandFactory('foo'), testErrorCommand], () => ({
+			after: (error) => {
+				assert.isNotNull(error);
+				assert.strictEqual(error && error.command, testErrorCommand);
+			}
+		}));
 		const processExecutor = process(store);
 		processExecutor({});
 	});
 
 	it('executor can be used to programmatically run additional processes', () => {
 		const extraProcess = createProcess('test', [testCommandFactory('bar')]);
-		const process = createProcess('test', [testCommandFactory('foo')], (error, result) => {
-			assert.isNull(error);
-			let bar = store.get(store.path('bar'));
-			assert.isUndefined(bar);
-			result.executor(extraProcess, {});
-			bar = store.get(store.path('bar'));
-			assert.strictEqual(bar, 'bar');
-		});
+		const process = createProcess('test', [testCommandFactory('foo')], () => ({
+			after: (error, result) => {
+				assert.isNull(error);
+				let bar = store.get(store.path('bar'));
+				assert.isUndefined(bar);
+				result.executor(extraProcess, {});
+				bar = store.get(store.path('bar'));
+				assert.strictEqual(bar, 'bar');
+			}
+		}));
 		const processExecutor = process(store);
 		processExecutor({});
 	});
@@ -271,21 +276,27 @@ describe('process', () => {
 	it('Creating a process returned automatically decorates all process callbacks', () => {
 		let results: string[] = [];
 
-		const callback: ProcessCallback = (error, result): void => {
-			results.push('callback one');
-		};
+		const callback: ProcessCallback = () => ({
+			after: (error, result): void => {
+				results.push('callback one');
+			}
+		});
 
-		const callbackTwo = (error: ProcessError | null, result: ProcessResult): void => {
-			results.push('callback two');
-			result.payload;
-		};
+		const callbackTwo = () => ({
+			after: (error: ProcessError | null, result: ProcessResult): void => {
+				results.push('callback two');
+				result.payload;
+			}
+		});
 
-		const logPointerCallback = (error: ProcessError | null, result: ProcessResult<{ logs: string[][] }>): void => {
-			const paths = result.operations.map((operation) => operation.path.path);
-			const logs = result.get(store.path('logs')) || [];
+		const logPointerCallback = () => ({
+			after: (error: ProcessError | null, result: ProcessResult<{ logs: string[][] }>): void => {
+				const paths = result.operations.map((operation) => operation.path.path);
+				const logs = result.get(store.path('logs')) || [];
 
-			result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
-		};
+				result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
+			}
+		});
 
 		const createProcess = createProcessFactoryWith([callback, callbackTwo, logPointerCallback]);
 
@@ -309,36 +320,44 @@ describe('process', () => {
 		let initialization: string[] = [];
 		let firstCall = true;
 
-		const initializer: ProcessInitializer = async (payload, store) => {
-			initialization.push('initializer one');
-			const initLog = store.get(store.path('initLogs')) || [];
-			store.apply([
-				{ op: OperationType.ADD, path: new Pointer(`/initLogs/${initLog.length}`), value: 'initial value' }
-			]);
-		};
+		const initializer: ProcessCallback = () => ({
+			before: async (payload, store) => {
+				initialization.push('initializer one');
+				const initLog = store.get(store.path('initLogs')) || [];
+				store.apply([
+					{ op: OperationType.ADD, path: new Pointer(`/initLogs/${initLog.length}`), value: 'initial value' }
+				]);
+			}
+		});
 
-		const initializerTwo = async (payload: any) => {
-			initialization.push('initializer two');
-			payload.foo;
-			await new Promise((resolve) => {
-				setTimeout(resolve, 100);
-			});
-		};
+		const initializerTwo = () => ({
+			before: async (payload: any) => {
+				initialization.push('initializer two');
+				payload.foo;
+				await new Promise((resolve) => {
+					setTimeout(resolve, 100);
+				});
+			}
+		});
 
-		const initializerThree = () => {
-			initialization.push('initializer three');
-		};
+		const initializerThree = () => ({
+			before: () => {
+				initialization.push('initializer three');
+			}
+		});
 
-		const logPointerCallback = (error: ProcessError | null, result: ProcessResult<{ logs: string[][] }>): void => {
-			assert.lengthOf(initialization, firstCall ? 3 : 6);
-			firstCall = false;
-			const paths = result.operations.map((operation) => operation.path.path);
-			const logs = result.get(store.path('logs')) || [];
+		const logPointerCallback = () => ({
+			after: (error: ProcessError | null, result: ProcessResult<{ logs: string[][] }>): void => {
+				assert.lengthOf(initialization, firstCall ? 3 : 6);
+				firstCall = false;
+				const paths = result.operations.map((operation) => operation.path.path);
+				const logs = result.get(store.path('logs')) || [];
 
-			result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
-		};
+				result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
+			}
+		});
 
-		const createProcess = createProcessFactoryWith(undefined, [initializer, initializerTwo, initializerThree]);
+		const createProcess = createProcessFactoryWith([initializer, initializerTwo, initializerThree]);
 
 		const process = createProcess(
 			'test',
@@ -386,12 +405,10 @@ describe('process', () => {
 			result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
 		};
 
-		const process = createProcess(
-			'test',
-			[testCommandFactory('foo'), testCommandFactory('bar')],
-			logPointerCallback,
-			initializer
-		);
+		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('bar')], () => ({
+			before: initializer,
+			after: logPointerCallback
+		}));
 		const executor = process(store);
 		await executor({});
 		assert.lengthOf(initialization, 1);
@@ -408,13 +425,15 @@ describe('process', () => {
 		const command = ({ payload }: CommandRequest): PatchOperation[] => {
 			return [{ op: OperationType.REPLACE, path: new Pointer('/foo'), value: 'bar' }];
 		};
-		const process = createProcess('foo', [testCommandFactory('foo'), command], (error, result) => {
-			let foo = store.get(result.store.path('foo'));
-			assert.strictEqual(foo, 'bar');
-			store.apply(result.undoOperations);
-			foo = store.get(result.store.path('foo'));
-			assert.isUndefined(foo);
-		});
+		const process = createProcess('foo', [testCommandFactory('foo'), command], () => ({
+			after: (error, result) => {
+				let foo = store.get(result.store.path('foo'));
+				assert.strictEqual(foo, 'bar');
+				store.apply(result.undoOperations);
+				foo = store.get(result.store.path('foo'));
+				assert.isUndefined(foo);
+			}
+		}));
 		const processExecutor = process(store);
 		return processExecutor({});
 	});
@@ -427,13 +446,15 @@ describe('process', () => {
 			return [{ op: OperationType.REPLACE, path: new Pointer('/state/a'), value: 'a' }];
 		};
 
-		const process = createProcess('foo', [commandOne, commandTwo], (error, result) => {
-			let state = store.get(result.store.path('state'));
-			assert.deepEqual(state, { a: 'a', b: 'b' });
-			store.apply(result.undoOperations);
-			state = store.get(result.store.path('state'));
-			assert.isUndefined(state);
-		});
+		const process = createProcess('foo', [commandOne, commandTwo], () => ({
+			after: (error, result) => {
+				let state = store.get(result.store.path('state'));
+				assert.deepEqual(state, { a: 'a', b: 'b' });
+				store.apply(result.undoOperations);
+				state = store.get(result.store.path('state'));
+				assert.isUndefined(state);
+			}
+		}));
 		const processExecutor = process(store);
 		return processExecutor({});
 	});
@@ -449,13 +470,15 @@ describe('process', () => {
 			];
 		});
 
-		const process = createProcess('foo', [commandOne], (error, result) => {
-			let state = store.get(result.store.path('state'));
-			assert.deepEqual(state, { foo: 'foo', bar: 'bar', baz: 'baz' });
-			store.apply(result.undoOperations);
-			state = store.get(result.store.path('state'));
-			assert.isUndefined(state);
-		});
+		const process = createProcess('foo', [commandOne], () => ({
+			after: (error, result) => {
+				let state = store.get(result.store.path('state'));
+				assert.deepEqual(state, { foo: 'foo', bar: 'bar', baz: 'baz' });
+				store.apply(result.undoOperations);
+				state = store.get(result.store.path('state'));
+				assert.isUndefined(state);
+			}
+		}));
 		const processExecutor = process(store);
 		return processExecutor({});
 	});

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -5,9 +5,7 @@ import { Pointer } from './../../../src/stores/state/Pointer';
 import { OperationType, PatchOperation } from './../../../src/stores/state/Patch';
 import {
 	CommandRequest,
-	createCallbackDecorator,
 	createCommandFactory,
-	createInitializerDecorator,
 	createProcess,
 	createProcessFactoryWith,
 	ProcessCallback,
@@ -273,11 +271,8 @@ describe('process', () => {
 	it('Creating a process returned automatically decorates all process callbacks', () => {
 		let results: string[] = [];
 
-		const callbackDecorator = (callback?: ProcessCallback): ProcessCallback => {
-			return (error, result): void => {
-				results.push('callback one');
-				callback && callback(error, result);
-			};
+		const callback: ProcessCallback = (error, result): void => {
+			results.push('callback one');
 		};
 
 		const callbackTwo = (error: ProcessError | null, result: ProcessResult): void => {
@@ -292,11 +287,7 @@ describe('process', () => {
 			result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
 		};
 
-		const createProcess = createProcessFactoryWith([
-			callbackDecorator,
-			createCallbackDecorator(callbackTwo),
-			createCallbackDecorator(logPointerCallback)
-		]);
+		const createProcess = createProcessFactoryWith([callback, callbackTwo, logPointerCallback]);
 
 		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('bar')]);
 		const executor = process(store);
@@ -318,11 +309,8 @@ describe('process', () => {
 		let initialization: string[] = [];
 		let firstCall = true;
 
-		const initializer = (initializer?: ProcessInitializer): ProcessInitializer => {
-			return async (payload) => {
-				initialization.push('initializer one');
-				await (initializer && initializer(payload));
-			};
+		const initializer: ProcessInitializer = async (payload) => {
+			initialization.push('initializer one');
 		};
 
 		const initializerTwo = async (payload: any) => {
@@ -346,11 +334,7 @@ describe('process', () => {
 			result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
 		};
 
-		const createProcess = createProcessFactoryWith(undefined, [
-			initializer,
-			createInitializerDecorator(initializerTwo),
-			createInitializerDecorator(initializerThree)
-		]);
+		const createProcess = createProcessFactoryWith(undefined, [initializer, initializerTwo, initializerThree]);
 
 		const process = createProcess(
 			'test',
@@ -400,7 +384,7 @@ describe('process', () => {
 			'test',
 			[testCommandFactory('foo'), testCommandFactory('bar')],
 			logPointerCallback,
-			createInitializerDecorator(initializer)()
+			initializer
 		);
 		const executor = process(store);
 		await executor({});

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -309,8 +309,12 @@ describe('process', () => {
 		let initialization: string[] = [];
 		let firstCall = true;
 
-		const initializer: ProcessInitializer = async (payload) => {
+		const initializer: ProcessInitializer = async (payload, store) => {
 			initialization.push('initializer one');
+			const initLog = store.get(store.path('initLogs')) || [];
+			store.apply([
+				{ op: OperationType.ADD, path: new Pointer(`/initLogs/${initLog.length}`), value: 'initial value' }
+			]);
 		};
 
 		const initializerTwo = async (payload: any) => {
@@ -355,6 +359,7 @@ describe('process', () => {
 		assert.strictEqual(initialization[1], 'initializer two');
 		assert.strictEqual(initialization[2], 'initializer three');
 		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar']]);
+		assert.deepEqual(store.get(store.path('initLogs')), ['initial value']);
 		await executor({});
 		assert.lengthOf(initialization, 6);
 		assert.strictEqual(initialization[0], 'initializer one');
@@ -364,6 +369,7 @@ describe('process', () => {
 		assert.strictEqual(initialization[4], 'initializer two');
 		assert.strictEqual(initialization[5], 'initializer three');
 		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
+		assert.deepEqual(store.get(store.path('initLogs')), ['initial value', 'initial value']);
 	});
 
 	it('Should work with a single initializer', async () => {


### PR DESCRIPTION
**Type:**feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds the concept of "initializers" that can perform sync/async setup before a process is run. 
Resolves #90 