### PR TITLE
Ensure conditional nodes render in the correct order

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -446,21 +446,23 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 		parent: DNodeWrapper,
 		currentParent: DNodeWrapper | null
 	): DNodeWrapper[] {
+		const { requiresInsertBefore, hasPreviousSiblings, namespace, depth } = parent;
 		const wrappedRendered: DNodeWrapper[] = [];
 		const hasParentWNode = isWNodeWrapper(parent);
-		const currentParentLength = isVNodeWrapper(currentParent) && (currentParent.childrenWrappers || []).length > 1;
-		const requiresInsertBefore =
-			((parent.requiresInsertBefore || parent.hasPreviousSiblings !== false) && hasParentWNode) ||
-			currentParentLength;
+		const currentParentChildren = (isVNodeWrapper(currentParent) && currentParent.childrenWrappers) || [];
+		const hasCurrentParentChildren = currentParentChildren.length > 0;
+		const insertBefore =
+			((requiresInsertBefore || hasPreviousSiblings !== false) && hasParentWNode) ||
+			(hasCurrentParentChildren && rendered.length > 1);
 		let previousItem: DNodeWrapper | undefined;
 		for (let i = 0; i < rendered.length; i++) {
 			const renderedItem = rendered[i];
 			const wrapper = {
 				node: renderedItem,
-				depth: parent.depth + 1,
-				requiresInsertBefore,
+				depth: depth + 1,
+				requiresInsertBefore: insertBefore,
 				hasParentWNode,
-				namespace: parent.namespace
+				namespace: namespace
 			} as DNodeWrapper;
 			if (isVNode(renderedItem) && renderedItem.properties.exitAnimation) {
 				parent.hasAnimations = true;

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -997,7 +997,39 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'hello 3');
 		});
 
-		it('A', () => {
+		it('Should insert the new DOM node before the existing node', () => {
+			let invalidate: any;
+
+			class App extends WidgetBase {
+				private isBig = false;
+
+				constructor() {
+					super();
+					invalidate = this.goBig.bind(this);
+				}
+
+				goBig() {
+					this.isBig = !this.isBig;
+					this.invalidate();
+				}
+
+				protected render() {
+					return v('div', { key: 'root' }, [this.isBig ? v('h1', ['First']) : null, v('h2', ['Second'])]);
+				}
+			}
+
+			const r = renderer(() => w(App, {}));
+			const root: any = document.createElement('div');
+			r.mount({ domNode: root, sync: true });
+			assert.lengthOf(root.childNodes[0].childNodes, 1);
+			assert.strictEqual((root.childNodes[0].childNodes[0].childNodes[0] as Text).data, 'Second');
+			invalidate();
+			assert.lengthOf(root.childNodes[0].childNodes, 2);
+			assert.strictEqual((root.childNodes[0].childNodes[0].childNodes[0] as Text).data, 'First');
+			assert.strictEqual((root.childNodes[0].childNodes[1].childNodes[0] as Text).data, 'Second');
+		});
+
+		it('Should insert sibling DOM nodes in the correct order with a mixture of vnodes and wnodes returns an array', () => {
 			class GrandParent extends WidgetBase {
 				render() {
 					return v('div', [w(Parent, {}), w(ChildOne, {}), v('div', ['insert before me'])]);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensures that nodes that are conditionally rendered are inserted into the correct position in the DOM. This only affected conditional rendering from one node to two nodes.

Resolves #172 
