### PR TITLE
Bug: update dependency diff to 3.5.0 to fix Regular Expression Denial of Service vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1974,9 +1974,9 @@
       }
     },
     "diff": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "dom-serializer": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@webcomponents/webcomponentsjs": "1.1.0",
     "cldrjs": "0.4.8",
     "css-select-umd": "1.3.0-rc0",
-    "diff": "3.4.0",
+    "diff": "3.5.0",
     "globalize": "1.3.0",
     "intersection-observer": "0.4.2",
     "pepjs": "0.4.2",


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #175

There is a vulnerability in the version of Diff being used, more details can be found at https://snyk.io/vuln/npm:diff:20180305

I updated this in the PR