### PR TITLE
Update exit and enter animation to use SupportedClassName interface

### DIFF
--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -116,7 +116,7 @@ export interface VNodeProperties {
 	 * @param element - Element that was just added to the DOM.
 	 * @param properties - The properties object that was supplied to the [[h]] method
 	 */
-	enterAnimation?: ((element: Element, properties?: VNodeProperties) => void) | string;
+	enterAnimation?: ((element: Element, properties?: VNodeProperties) => void) | SupportedClassName;
 	/**
 	 * The animation to perform when this node is removed while its parent remains.
 	 * When this value is a string, you must pass a `projectionOptions.transitions` object when creating the projector using [[createProjector]].
@@ -126,7 +126,9 @@ export interface VNodeProperties {
 	 * You may use this function to remove the element when the animation is done.
 	 * @param properties - The properties object that was supplied to the [[v]] method that rendered this [[VNode]] the previous time.
 	 */
-	exitAnimation?: ((element: Element, removeElement: () => void, properties?: VNodeProperties) => void) | string;
+	exitAnimation?:
+		| ((element: Element, removeElement: () => void, properties?: VNodeProperties) => void)
+		| SupportedClassName;
 	/**
 	 * The animation to perform when the properties of this node change.
 	 * This also includes attributes, styles, css classes. This callback is also invoked when node contains only text and that text changes.

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -4698,7 +4698,7 @@ jsdomDescribe('vdom', () => {
 					enter: stub(),
 					exit: stub()
 				};
-				const [Widget] = getWidget(v('div', [v('span', { enterAnimation: null })]));
+				const [Widget] = getWidget(v('div', [v('span', { enterAnimation: undefined })]));
 				const r = renderer(() => w(Widget, {}));
 				const div = document.createElement('div');
 				r.mount({ domNode: div, sync: true, transition });

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -4682,6 +4682,28 @@ jsdomDescribe('vdom', () => {
 				meta.setRenderResult(v('div', [v('span', { enterAnimation })]));
 				assert.isTrue(enterAnimation.calledWith((div.childNodes[0] as Element).childNodes[0], match({})));
 			});
+			it('Does not invoke transition when null passed as enterAnimation', () => {
+				const transition = {
+					enter: stub(),
+					exit: stub()
+				};
+				const [Widget] = getWidget(v('div', [v('span', { enterAnimation: null })]));
+				const r = renderer(() => w(Widget, {}));
+				const div = document.createElement('div');
+				r.mount({ domNode: div, sync: true, transition });
+				assert.isTrue(transition.enter.notCalled);
+			});
+			it('Does not invoke transition when undefined passed as enterAnimation', () => {
+				const transition = {
+					enter: stub(),
+					exit: stub()
+				};
+				const [Widget] = getWidget(v('div', [v('span', { enterAnimation: null })]));
+				const r = renderer(() => w(Widget, {}));
+				const div = document.createElement('div');
+				r.mount({ domNode: div, sync: true, transition });
+				assert.isTrue(transition.enter.notCalled);
+			});
 		});
 		describe('exitAnimation', () => {
 			it('is invoked when a node is removed from an existing parent node', () => {
@@ -4697,6 +4719,30 @@ jsdomDescribe('vdom', () => {
 				assert.lengthOf((div.childNodes[0] as Element).childNodes, 1);
 				exitAnimation.lastCall.callArg(1); // arg1: removeElement
 				assert.lengthOf((div.childNodes[0] as Element).childNodes, 0);
+			});
+			it('Does not invoke transition when null passed as exitAnimation', () => {
+				const transition = {
+					enter: stub(),
+					exit: stub()
+				};
+				const [Widget, meta] = getWidget(v('div', [v('span', { exitAnimation: null })]));
+				const r = renderer(() => w(Widget, {}));
+				const div = document.createElement('div');
+				r.mount({ domNode: div, sync: true, transition });
+				meta.setRenderResult(v('div', []));
+				assert.isTrue(transition.exit.notCalled);
+			});
+			it('Does not invoke transition when undefined passed as exitAnimation', () => {
+				const transition = {
+					enter: stub(),
+					exit: stub()
+				};
+				const [Widget, meta] = getWidget(v('div', [v('span', { exitAnimation: undefined })]));
+				const r = renderer(() => w(Widget, {}));
+				const div = document.createElement('div');
+				r.mount({ domNode: div, sync: true, transition });
+				meta.setRenderResult(v('div', []));
+				assert.isTrue(transition.exit.notCalled);
 			});
 		});
 		describe('transitionStrategy', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds the `SupportedClassName` interface for the `exitAnimation` and `enterAnimation` vnode properties. The `vdom` already deals with `undefined` and `null` values, added some tests to demonstrate that.

Resolves #134 (partially)
Supersedes #135  
