### PR TITLE
Include external polyfills in shim

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -15,7 +15,6 @@
 		"./dist/dev/tests/shim/unit/all.js",
 		"./dist/dev/tests/core/unit/all.js",
 		"./dist/dev/tests/i18n/unit/all.js",
-		"./dist/dev/tests/widget-core/unit/all.js",
 		"./dist/dev/tests/stores/unit/all.js",
 		"./dist/dev/tests/testing/unit/all.js"
 	],
@@ -58,7 +57,8 @@
 			}
 		},
 		"suites+": [
-			"./dist/dev/tests/routing/unit/all.js"
+			"./dist/dev/tests/routing/unit/all.js",
+			"./dist/dev/tests/widget-core/unit/all.js"
 		],
 		"plugins+": [
 			{
@@ -76,7 +76,13 @@
 		"suites+": [
 			"./dist/dev/tests/routing/unit/**/*.js",
 			"!./dist/dev/tests/routing/unit/**/all.js",
-			"!./dist/dev/tests/routing/unit/history/StateHistory.js"
+			"!./dist/dev/tests/routing/unit/history/StateHistory.js",
+			"./dist/dev/tests/widget-core/unit/**/*.js",
+			"!./dist/dev/tests/widget-core/unit/all.js",
+			"!./dist/dev/tests/widget-core/unit/meta/all.js",
+			"!./dist/dev/tests/widget-core/unit/meta/Resize.js",
+			"!./dist/dev/tests/widget-core/unit/meta/WebAnimation.js",
+			"!./dist/dev/tests/widget-core/unit/meta/Intersection.js"
 		]
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -373,6 +373,11 @@
       "integrity": "sha512-E0QjLIX1q+ThpQ7HLh5SjMtUtPl0tQjxoLMPwJtFDFtH7C0qdXmCgNcBplZ9m24+sOoQBpc0PT/aMW4jlm3K6g==",
       "dev": true
     },
+    "@types/web-animations-js": {
+      "version": "2.2.6",
+      "resolved": "http://registry.npmjs.org/@types/web-animations-js/-/web-animations-js-2.2.6.tgz",
+      "integrity": "sha512-U8GPq6pNFCwettZNgEPiSh4Y9FJZryv4y3ELxpTURzQly+NHx1LpOsA8lSxqDp7/XyBcViFpqQ0H/w+tmIcR8A=="
+    },
     "@types/ws": {
       "version": "4.0.2",
       "resolved": "http://registry.npmjs.org/@types/ws/-/ws-4.0.2.tgz",
@@ -6064,6 +6069,11 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
+      "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
+    },
     "resolve": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
@@ -7197,8 +7207,7 @@
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whatwg-url": {
       "version": "4.8.0",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,10 @@
     "globalize": "1.3.0",
     "intersection-observer": "0.4.2",
     "pepjs": "0.4.2",
+    "resize-observer-polyfill": "1.5.0",
     "tslib": "1.8.1",
-    "web-animations-js": "2.3.1"
+    "web-animations-js": "2.3.1",
+    "whatwg-fetch": "2.0.4"
   },
   "devDependencies": {
     "@dojo/loader": "^2.0.0",
@@ -83,8 +85,7 @@
     "rimraf": "~2.6.2",
     "selenium-webdriver": "3.6.0",
     "sinon": "~4.1.3",
-    "typescript": "~2.6.2",
-    "whatwg-fetch": "^2.0.4"
+    "typescript": "~2.6.2"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/src/has/has.ts
+++ b/src/has/has.ts
@@ -581,3 +581,5 @@ add('dom-intersection-observer', () => has('host-browser') && global.Intersectio
 add('dom-resize-observer', () => has('host-browser') && global.ResizeObserver !== undefined, true);
 
 add('dom-pointer-events', () => has('host-browser') && global.onpointerdown !== undefined, true);
+
+add('build-elide', false);

--- a/src/has/has.ts
+++ b/src/has/has.ts
@@ -575,3 +575,9 @@ add(
 add('abort-controller', () => typeof global.AbortController !== 'undefined');
 
 add('abort-signal', () => typeof global.AbortSignal !== 'undefined');
+
+add('dom-intersection-observer', () => has('host-browser') && global.IntersectionObserver !== undefined, true);
+
+add('dom-resize-observer', () => has('host-browser') && global.ResizeObserver !== undefined, true);
+
+add('dom-pointer-events', () => has('host-browser') && global.onpointerdown !== undefined, true);

--- a/src/shim/IntersectionObserver.ts
+++ b/src/shim/IntersectionObserver.ts
@@ -1,0 +1,5 @@
+import global from './global';
+`has('build-elide')`;
+import 'intersection-observer';
+
+export default global.IntersectionObserver as typeof IntersectionObserver;

--- a/src/shim/IntersectionObserver.ts
+++ b/src/shim/IntersectionObserver.ts
@@ -1,5 +1,5 @@
 import global from './global';
-`has('build-elide')`;
+`!has('build-elide')`;
 import 'intersection-observer';
 
 export default global.IntersectionObserver as typeof IntersectionObserver;

--- a/src/shim/ResizeObserver.ts
+++ b/src/shim/ResizeObserver.ts
@@ -1,6 +1,6 @@
 import global from './global';
 import has from '../../src/has/has';
-`has('build-elide')`;
+`!has('build-elide')`;
 import ResizeObserver from 'resize-observer-polyfill';
 
 if (!has('build-elide')) {

--- a/src/shim/ResizeObserver.ts
+++ b/src/shim/ResizeObserver.ts
@@ -1,0 +1,12 @@
+import global from './global';
+import has from '../../src/has/has';
+`has('build-elide')`;
+import ResizeObserver from 'resize-observer-polyfill';
+
+if (!has('build-elide')) {
+	if (!global.ResizeObserver) {
+		global.ResizeObserver = ResizeObserver;
+	}
+}
+
+export default global.ResizeObserver as typeof ResizeObserver;

--- a/src/shim/WebAnimations.ts
+++ b/src/shim/WebAnimations.ts
@@ -1,5 +1,5 @@
 import global from './global';
-`has('build-elide')`;
+`!has('build-elide')`;
 import 'web-animations-js/web-animations-next-lite.min';
 
 export type AnimationEffectTimingFillMode = 'none' | 'forwards' | 'backwards' | 'both' | 'auto';

--- a/src/shim/WebAnimations.ts
+++ b/src/shim/WebAnimations.ts
@@ -1,0 +1,120 @@
+import global from './global';
+`has('build-elide')`;
+import 'web-animations-js/web-animations-next-lite.min';
+
+export type AnimationEffectTimingFillMode = 'none' | 'forwards' | 'backwards' | 'both' | 'auto';
+export type AnimationEffectTimingPlaybackDirection = 'normal' | 'reverse' | 'alternate' | 'alternate-reverse';
+export type AnimationPlayState = 'idle' | 'running' | 'paused' | 'finished';
+
+export interface AnimationPlaybackEvent {
+	target: Animation;
+	readonly currentTime: number | null;
+	readonly timelineTime: number | null;
+	type: string;
+	bubbles: boolean;
+	cancelable: boolean;
+	currentTarget: Animation;
+	defaultPrevented: boolean;
+	eventPhase: number;
+	timeStamp: number;
+}
+
+export interface AnimationPlaybackEventInit extends EventInit {
+	currentTime?: number | null;
+	timelineTime?: number | null;
+}
+
+declare var AnimationPlaybackEvent: {
+	prototype: AnimationPlaybackEvent;
+	new (type: string, eventInitDict?: AnimationPlaybackEventInit): AnimationPlaybackEvent;
+};
+
+export interface AnimationKeyFrame {
+	easing?: string | string[];
+	offset?: number | Array<number | null> | null;
+	opacity?: number | number[];
+	transform?: string | string[];
+}
+
+export interface AnimationTimeline {
+	readonly currentTime: number | null;
+	getAnimations(): Animation[];
+	play(effect: KeyframeEffect): Animation;
+}
+
+export interface AnimationEffectTiming {
+	delay?: number;
+	direction?: AnimationEffectTimingPlaybackDirection;
+	duration?: number;
+	easing?: string;
+	endDelay?: number;
+	fill?: AnimationEffectTimingFillMode;
+	iterationStart?: number;
+	iterations?: number;
+	playbackRate?: number;
+}
+
+export interface AnimationEffectReadOnly {
+	readonly timing: number;
+	getComputedTiming(): ComputedTimingProperties;
+}
+
+export interface ComputedTimingProperties {
+	endTime: number;
+	activeDuration: number;
+	localTime: number | null;
+	progress: number | null;
+	currentIteration: number | null;
+}
+
+export interface KeyframeEffect extends AnimationEffectReadOnly {
+	activeDuration: number;
+	onsample: (timeFraction: number | null, effect: KeyframeEffect, animation: Animation) => void | undefined;
+	parent: KeyframeEffect | null;
+	target: HTMLElement;
+	timing: number;
+	getComputedTiming(): ComputedTimingProperties;
+	getFrames(): AnimationKeyFrame[];
+	remove(): void;
+}
+
+export interface KeyframeEffectConstructor {
+	prototype: KeyframeEffect;
+	new (
+		target: HTMLElement,
+		effect: AnimationKeyFrame | AnimationKeyFrame[],
+		timing: number | AnimationEffectTiming,
+		id?: string
+	): KeyframeEffect;
+}
+
+export type AnimationEventListener = (this: Animation, evt: AnimationPlaybackEvent) => any;
+
+export interface Animation extends EventTarget {
+	currentTime: number | null;
+	id: string;
+	oncancel: AnimationEventListener;
+	onfinish: AnimationEventListener;
+	readonly playState: AnimationPlayState;
+	playbackRate: number;
+	startTime: number;
+	cancel(): void;
+	finish(): void;
+	pause(): void;
+	play(): void;
+	reverse(): void;
+	addEventListener(type: 'finish' | 'cancel', handler: EventListener): void;
+	removeEventListener(type: 'finish' | 'cancel', handler: EventListener): void;
+	effect: AnimationEffectReadOnly;
+	readonly finished: Promise<Animation>;
+	readonly ready: Promise<Animation>;
+	timeline: AnimationTimeline;
+}
+
+export interface AnimationConstructor {
+	prototype: Animation;
+	new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation;
+}
+
+export const Animation = global.Animation as AnimationConstructor;
+export const KeyframeEffect = global.KeyframeEffect as KeyframeEffectConstructor;

--- a/src/shim/fetch.ts
+++ b/src/shim/fetch.ts
@@ -1,0 +1,5 @@
+import global from './global';
+`!has('fetch')`;
+import 'whatwg-fetch';
+
+export default global.fetch as (input: RequestInfo, init?: RequestInit) => Promise<Response>;

--- a/src/shim/pointerEvents.ts
+++ b/src/shim/pointerEvents.ts
@@ -1,0 +1,2 @@
+`has('build-elide')`;
+import 'pepjs';

--- a/src/shim/pointerEvents.ts
+++ b/src/shim/pointerEvents.ts
@@ -1,2 +1,2 @@
-`has('build-elide')`;
+`!has('build-elide')`;
 import 'pepjs';

--- a/src/shim/util/amd.ts
+++ b/src/shim/util/amd.ts
@@ -23,6 +23,12 @@ function shimAmdDependencies(config: any) {
 	});
 
 	addIfNotPresent(packages, {
+		name: 'resize-observer-polyfill',
+		location: 'node_modules/resize-observer-polyfill/dist',
+		main: 'ResizeObserver'
+	});
+
+	addIfNotPresent(packages, {
 		name: 'intersection-observer',
 		location: 'node_modules/intersection-observer',
 		main: 'intersection-observer'

--- a/src/widget-core/meta/Intersection.ts
+++ b/src/widget-core/meta/Intersection.ts
@@ -1,7 +1,7 @@
-import global from '../../shim/global';
 import WeakMap from '../../shim/WeakMap';
 import Map from '../../shim/Map';
 import { Base } from './Base';
+import IntersectionObserver from '../../shim/IntersectionObserver';
 
 interface ExtendedIntersectionObserverEntry extends IntersectionObserverEntry {
 	readonly isIntersecting: boolean;
@@ -73,7 +73,7 @@ export class Intersection extends Base {
 
 	private _createDetails(options: IntersectionGetOptions, rootNode?: HTMLElement): IntersectionDetail {
 		const entries = new WeakMap<HTMLElement, ExtendedIntersectionObserverEntry>();
-		const observer = new global.IntersectionObserver(this._onIntersect(entries), { ...options, root: rootNode });
+		const observer = new IntersectionObserver(this._onIntersect(entries), { ...options, root: rootNode });
 		const details = { observer, entries, ...options };
 
 		this._details.set(JSON.stringify(options), details);

--- a/src/widget-core/meta/Resize.ts
+++ b/src/widget-core/meta/Resize.ts
@@ -1,18 +1,6 @@
 import { Base } from './Base';
 import Map from '../../shim/Map';
-
-interface Observer {
-	observe(node: HTMLElement): void;
-}
-
-declare const ResizeObserver: {
-	prototype: Observer;
-	new (callback: (entries: ResizeObserverEntry[]) => any): any;
-};
-
-interface ResizeObserverEntry {
-	contentRect: ContentRect;
-}
+import ResizeObserver from '../../shim/ResizeObserver';
 
 export interface ContentRect {
 	readonly bottom: number;

--- a/src/widget-core/meta/WebAnimation.ts
+++ b/src/widget-core/meta/WebAnimation.ts
@@ -1,6 +1,7 @@
 import { Base } from './Base';
 import Map from '../../shim/Map';
 import global from '../../shim/global';
+import { Animation, KeyframeEffect, AnimationEffectTiming, AnimationKeyFrame } from '../../shim/WebAnimations';
 
 /**
  * Animation controls are used to control the web animation that has been applied
@@ -17,36 +18,14 @@ export interface AnimationControls {
 	startTime?: number;
 	currentTime?: number;
 }
-
 /**
- * Animation timing properties passed to a new KeyframeEffect.
- */
-export interface AnimationTimingProperties {
-	duration?: number;
-	delay?: number;
-	direction?: 'normal' | 'reverse' | 'alternate' | 'alternate-reverse';
-	easing?: string;
-	endDelay?: number;
-	fill?: 'none' | 'forwards' | 'backwards' | 'both' | 'auto';
-	iterations?: number;
-	iterationStart?: number;
-}
-
-export interface AnimationKeyFrame {
-	easing?: string | string[];
-	offset?: number | Array<number | null> | null;
-	opacity?: number | number[];
-	transform?: string | string[];
-}
-
-/**
- * Animation propertiues that can be passed as vdom property `animate`
+ * Animation properties that can be passed as vdom property `animate`
  */
 export interface AnimationProperties {
 	id: string;
 	effects: (() => AnimationKeyFrame | AnimationKeyFrame[]) | AnimationKeyFrame | AnimationKeyFrame[];
 	controls?: AnimationControls;
-	timing?: AnimationTimingProperties;
+	timing?: AnimationEffectTiming;
 }
 
 export type AnimationPropertiesFunction = () => AnimationProperties;
@@ -74,9 +53,9 @@ export class WebAnimations extends Base {
 
 		const fx = typeof effects === 'function' ? effects() : effects;
 
-		const keyframeEffect = new global.KeyframeEffect(node, fx, timing);
+		const keyframeEffect = new KeyframeEffect(node, fx, timing);
 
-		return new global.Animation(keyframeEffect, global.document.timeline);
+		return new Animation(keyframeEffect, global.document.timeline);
 	}
 
 	private _updatePlayer(player: any, controls: AnimationControls) {

--- a/tests/shim/functional/amd.ts
+++ b/tests/shim/functional/amd.ts
@@ -30,7 +30,7 @@ registerSuite('AMD Util', {
 				assert.lengthOf(config.packages.filter((p: any) => p.name === '@dojo'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'existingPackage'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'web-animations-js'), 1);
-				assert.lengthOf(config.packages.filter((p: any) => p.name === 'ResizeObserver'), 1);
+				assert.lengthOf(config.packages.filter((p: any) => p.name === 'resize-observer-polyfill'), 1);
 			});
 	},
 	async 'Utility does not inject dependency if it already exists'() {

--- a/tests/shim/functional/amd.ts
+++ b/tests/shim/functional/amd.ts
@@ -23,13 +23,14 @@ registerSuite('AMD Util', {
 				undefined
 			)
 			.then((config: any) => {
-				assert.lengthOf(config.packages, 6);
+				assert.lengthOf(config.packages, 7);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'pepjs'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'tslib'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'intersection-observer'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === '@dojo'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'existingPackage'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'web-animations-js'), 1);
+				assert.lengthOf(config.packages.filter((p: any) => p.name === 'ResizeObserver'), 1);
 			});
 	},
 	async 'Utility does not inject dependency if it already exists'() {

--- a/tests/widget-core/unit/meta/Resize.ts
+++ b/tests/widget-core/unit/meta/Resize.ts
@@ -2,7 +2,7 @@ const { registerSuite } = intern.getPlugin('jsdom');
 const { assert } = intern.getPlugin('chai');
 import global from '../../../../src/shim/global';
 import { stub, SinonStub } from 'sinon';
-import Resize, { ContentRect } from '../../../../src/widget-core/meta/Resize';
+
 import NodeHandler from '../../../../src/widget-core/NodeHandler';
 import WidgetBase from '../../../../src/widget-core/WidgetBase';
 
@@ -11,15 +11,11 @@ let resizeCallback: ([]: any[]) => void;
 let bindInstance: WidgetBase;
 let isFoo: SinonStub;
 let isBar: SinonStub;
+let Resize: any;
 
 registerSuite('meta - Resize', {
-	before() {
+	async before() {
 		bindInstance = new WidgetBase();
-	},
-
-	beforeEach() {
-		isFoo = stub();
-		isBar = stub();
 		resizeObserver = stub().callsFake(function(callback: any) {
 			const observer = {
 				observe: stub()
@@ -27,15 +23,19 @@ registerSuite('meta - Resize', {
 			resizeCallback = callback;
 			return observer;
 		});
-
 		global.ResizeObserver = resizeObserver;
+		Resize = (await import('../../../../src/widget-core/meta/Resize')).default;
+	},
+
+	beforeEach() {
+		isFoo = stub();
+		isBar = stub();
 	},
 
 	afterEach() {
 		isFoo.reset();
 		isBar.reset();
-		resizeObserver.reset();
-		global.ResizeObserver = undefined;
+		resizeObserver.resetHistory();
 	},
 
 	tests: {
@@ -79,7 +79,7 @@ registerSuite('meta - Resize', {
 				bind: bindInstance
 			});
 
-			const contentRect: Partial<ContentRect> = {
+			const contentRect: any = {
 				width: 10
 			};
 
@@ -118,7 +118,7 @@ registerSuite('meta - Resize', {
 				bind: bindInstance
 			});
 
-			const contentRect: Partial<ContentRect> = {
+			const contentRect: any = {
 				width: 10
 			};
 
@@ -148,7 +148,7 @@ registerSuite('meta - Resize', {
 				bind: bindInstance
 			});
 
-			const contentRect: Partial<ContentRect> = {
+			const contentRect: any = {
 				width: 10
 			};
 

--- a/tests/widget-core/unit/meta/WebAnimation.ts
+++ b/tests/widget-core/unit/meta/WebAnimation.ts
@@ -2,10 +2,8 @@ import global from '../../../../src/shim/global';
 const { assert } = intern.getPlugin('chai');
 const { afterEach, beforeEach, before, describe, it } = intern.getInterface('bdd');
 const { describe: jsdomDescribe } = intern.getPlugin('jsdom');
-import WebAnimation, {
-	AnimationControls,
-	AnimationTimingProperties
-} from '../../../../src/widget-core/meta/WebAnimation';
+import WebAnimation, { AnimationControls } from '../../../../src/widget-core/meta/WebAnimation';
+import { AnimationEffectTiming } from '../../../../src/shim/WebAnimations';
 import { WidgetBase } from '../../../../src/widget-core/WidgetBase';
 import { v } from '../../../../src/widget-core/d';
 import { spy, stub } from 'sinon';
@@ -13,7 +11,7 @@ import { spy, stub } from 'sinon';
 jsdomDescribe('WebAnimation', () => {
 	let effects: any;
 	let controls: AnimationControls;
-	let timing: AnimationTimingProperties;
+	let timing: AnimationEffectTiming;
 	let animate: any;
 
 	class TestWidget extends WidgetBase {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

* Creates new shim modules for commonly used DOM ponyfills/polyfills in dojo/framework/shim.
* Adds new `build-elide` has pragma for all external polyfill imports that will be elided at build time
* Adds missing runtime `has` checks for all the new DOM APIs
* Use shims through dojo/framework

Related to #183 