### PR TITLE
Bind `fetch` to gobal

### DIFF
--- a/src/shim/fetch.ts
+++ b/src/shim/fetch.ts
@@ -2,4 +2,4 @@ import global from './global';
 `!has('fetch')`;
 import 'whatwg-fetch';
 
-export default global.fetch as (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+export default global.fetch.bind(global) as (input: RequestInfo, init?: RequestInit) => Promise<Response>;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

In certain scenarios exporting `fetch` from the global results in "illegal invocation" error. Binding to scope resolves the error.