### PR TITLE
Remove select API from `harness`

### DIFF
--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -9,7 +9,6 @@ Simple API for testing and asserting Dojo widget's expected virtual DOM and beha
 -   [`harness.expect`](#harnessexpect)
 -   [`harness.expectPartial`](#harnessexpectpartial)
 -   [`harness.trigger`](#harnesstrigger)
--   [`harness.select`](#harnessselect)
 
 ## Features
 
@@ -39,7 +38,6 @@ The harness returns a `Harness` object that provides a small API for interacting
 -   [`expectPartial`](#harnessexpectpartial): Performs an assertion against a section of the render output from the widget under test.
 -   [`trigger`](#harnesstrigger): Used to trigger a function from a node on the widget under test's API
 -   [`getRender`](#harnessgetRender): Returns a render from the harness based on the index provided
--   [`select`](#harnessselect): Returns a list of nodes matching the given selector, using the last render.
 
 Setting up a widget for testing is simple and familiar using the `w()` function from `@dojo/framework/widget-core`:
 
@@ -231,47 +229,4 @@ const render = h.getRender();
 ```ts
 // Returns the result of the render for the index provided
 h.getRender(1);
-```
-
-#### `harness.select`
-
-`harness.select` returns an array of DNodes, using the latest render, that match the provided selector. This can be useful if you need access to a widget's properties.
-
-```typescript
-select(selector: string): DNode[];
-```
-
--   `selector`: The selector to use while determining matching DNodes
-
-Example Usage:
-
-Given a VDOM tree like,
-
-```typescript
-v(Toolbar, {
-	key: 'toolbar',
-	buttons: [
-		{
-			icon: 'save',
-			onClick: () => this._onSave()
-		},
-		{
-			icon: 'cancel',
-			onClick: () => this._onCancel()
-		}
-	]
-});
-```
-
-And you want to run the save toolbar button's `onClick` function.
-
-```typescript
-// find the toolbar
-const [toolbar] = h.select('@toolbar');
-
-// get the button's properties
-const properties = toolbar.properties as ToolbarProperties;
-
-// manually call the click handler
-properties.buttons[0].onClick();
 ```

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -209,6 +209,36 @@ h.trigger('@foo', 'onclick');
 const result = h.trigger('@bar', 'customFunction', 100);
 ```
 
+A `functionalSelector` can be used return a function that is nested in a widget's properties. The function will be triggered, in the same way that using a plain string `functionSelector`.
+
+Example Usage:
+
+Given a VDOM tree like,
+
+```typescript
+v(Toolbar, {
+	key: 'toolbar',
+	buttons: [
+		{
+			icon: 'save',
+			onClick: () => this._onSave()
+		},
+		{
+			icon: 'cancel',
+			onClick: () => this._onCancel()
+		}
+	]
+});
+```
+
+And you want to trigger the save toolbar button's `onClick` function.
+
+```typescript
+h.trigger("@buttons", (renderResult: DNode<Toolbar>) => {
+  return renderResult.properties.buttons[0].onClick;
+});
+```
+
 #### `harness.getRender`
 
 `harness.getRender()` returns the render with the index provided, when no index is provided it returns the last render.

--- a/src/testing/harness.ts
+++ b/src/testing/harness.ts
@@ -42,16 +42,11 @@ export interface GetRender {
 	(index?: number): DNode | DNode[];
 }
 
-export interface Select {
-	(selector: string): DNode[];
-}
-
 export interface HarnessAPI {
 	expect: Expect;
 	expectPartial: ExpectPartial;
 	trigger: Trigger;
 	getRender: GetRender;
-	select: Select;
 }
 
 function decorateNodes(dNode: DNode[]): DecoratorResult<DNode[]>;
@@ -178,10 +173,6 @@ export function harness(
 		},
 		getRender(index?: number): DNode | DNode[] {
 			return _getRender(index);
-		},
-		select(selector: string): DNode[] {
-			_tryRender();
-			return select(selector, _getRender());
 		}
 	};
 }

--- a/tests/testing/unit/harness.ts
+++ b/tests/testing/unit/harness.ts
@@ -581,10 +581,4 @@ describe('harness', () => {
 			]);
 		});
 	});
-
-	describe('select', () => {
-		const h = harness(() => w(MyWidget, {}));
-
-		assert.isTrue(h.select('@span').length === 1);
-	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The `select` API was added to the `harness` to enable triggering a nested function on a widgets properties. However this was already possible using the `functionalSelector` on the `trigger` API.

As a side effect adding `select` exposed the ability to easily return sections of the widget tree and then be used instead of `expect` for specific assertions, which was never the intention of the API.
