### PR TITLE
Remove unused has flags and stop supporting async has flags

### DIFF
--- a/src/has/has.ts
+++ b/src/has/has.ts
@@ -223,12 +223,6 @@ export default function has(feature: string): FeatureTestResult {
 /*
  * Out of the box feature tests
  */
-
-/* Environments */
-
-/* Used as a value to provide a debug only code path */
-add('debug', true);
-
 add('public-path', undefined);
 
 /* flag for dojo debug, default to false */
@@ -244,70 +238,7 @@ add('host-node', function() {
 	}
 });
 
-add('object-assign', typeof global.Object.assign === 'function', true);
-
-add('arraybuffer', typeof global.ArrayBuffer !== 'undefined', true);
-add('formdata', typeof global.FormData !== 'undefined', true);
-add('filereader', typeof global.FileReader !== 'undefined', true);
-add('xhr', typeof global.XMLHttpRequest !== 'undefined', true);
-add('xhr2', has('xhr') && 'responseType' in global.XMLHttpRequest.prototype, true);
-add(
-	'blob',
-	function() {
-		if (!has('xhr2')) {
-			return false;
-		}
-
-		const request = new global.XMLHttpRequest();
-		request.open('GET', global.location.protocol + '//www.google.com', true);
-		request.responseType = 'blob';
-		request.abort();
-		return request.responseType === 'blob';
-	},
-	true
-);
-
-add('node-buffer', 'Buffer' in global && typeof global.Buffer === 'function', true);
-
 add('fetch', 'fetch' in global && typeof global.fetch === 'function', true);
-
-add(
-	'web-worker-xhr-upload',
-	typeof global.Promise !== 'undefined' &&
-		new Promise((resolve) => {
-			try {
-				if (global.Worker !== undefined && global.URL && global.URL.createObjectURL) {
-					const blob = new Blob(
-						[
-							`(function () {
-self.addEventListener('message', function () {
-	var xhr = new XMLHttpRequest();
-	try {
-		xhr.upload;
-		postMessage('true');
-	} catch (e) {
-		postMessage('false');
-	}
-});
-		})()`
-						],
-						{ type: 'application/javascript' }
-					);
-					const worker = new Worker(URL.createObjectURL(blob));
-					worker.addEventListener('message', ({ data: result }) => {
-						resolve(result === 'true');
-					});
-					worker.postMessage({});
-				} else {
-					resolve(false);
-				}
-			} catch (e) {
-				// IE11 on Winodws 8.1 encounters a security error.
-				resolve(false);
-			}
-		}),
-	true
-);
 
 add(
 	'es6-array',

--- a/tests/has/unit/has.ts
+++ b/tests/has/unit/has.ts
@@ -143,56 +143,6 @@ registerSuite('has', {
 				);
 			},
 
-			'works with thenable'() {
-				const dfd = this.async();
-
-				const thenable: PromiseLike<number> = {
-					then(resolve?: ((_: number) => void) | null) {
-						setTimeout(() => {
-							resolve!(5);
-						}, 10);
-
-						return thenable as any;
-					}
-				};
-
-				hasAdd('thenable', thenable);
-				assert.isFalse(has('thenable'));
-
-				setTimeout(
-					dfd.callback(() => {
-						assert.equal(has('thenable'), 5);
-					}),
-					100
-				);
-			},
-
-			'failed thenable removes itself from cache'() {
-				const dfd = this.async();
-
-				const thenable: PromiseLike<number> = {
-					then(_?: ((_: number) => void) | null, reject?: ((_: Error) => void) | null) {
-						setTimeout(() => {
-							reject!(new Error('test error'));
-						}, 10);
-
-						return thenable as any;
-					}
-				};
-
-				hasAdd('thenable', thenable);
-				assert.isFalse(has('thenable'));
-
-				setTimeout(
-					dfd.callback(() => {
-						assert.throws(() => {
-							has('thenable');
-						});
-					}),
-					100
-				);
-			},
-
 			overwrite: {
 				'value with value'() {
 					hasAdd(feature, 'old');
@@ -242,30 +192,6 @@ registerSuite('has', {
 			'null test value counts as being defined'() {
 				hasAdd(feature, null as any);
 				assert.isTrue(hasExists(feature));
-			},
-
-			'exists with thenabale'() {
-				const dfd = this.async();
-
-				const thenable: PromiseLike<number> = {
-					then(resolve?: ((_: number) => void) | null) {
-						setTimeout(() => {
-							resolve!(5);
-						}, 10);
-
-						return thenable as any;
-					}
-				};
-
-				hasAdd('thenable', thenable);
-				assert.isFalse(hasExists('thenable'));
-
-				setTimeout(
-					dfd.callback(() => {
-						assert.isTrue(hasExists('thenable'));
-					}),
-					100
-				);
 			},
 
 			'case should not matter'() {
@@ -363,10 +289,6 @@ registerSuite('has', {
 		},
 
 		'built in feature flags': {
-			debug() {
-				assert.isTrue(hasExists('debug'));
-				assert.isTrue(has('debug'), 'Debug should default to true');
-			},
 			'host-browser'() {
 				assert.isTrue(hasExists('host-browser'));
 				assert.strictEqual(


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

* Removes `has` flags that are not used in `@dojo/framework`
* Removes support for async has flags.

