### PR TITLE
Cache decorator map by widget

### DIFF
--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -110,13 +110,9 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 
 	private _metaMap: Map<WidgetMetaConstructor<any>, WidgetMetaBase> | undefined;
 
-	private _boundInvalidate: () => void = () => {
-		this.invalidate();
-	};
+	private _boundRenderFunc: Render;
 
-	private _boundRenderFunc: Render = () => {
-		return this.render();
-	};
+	private _boundInvalidate: () => void;
 
 	private _nodeHandler: NodeHandler = new NodeHandler();
 
@@ -129,6 +125,8 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		this._children = [];
 		this._decoratorCache = new Map<string, any[]>();
 		this._properties = {} as P;
+		this._boundRenderFunc = this.render.bind(this);
+		this._boundInvalidate = this.invalidate.bind(this);
 
 		widgetInstanceMap.set(this, {
 			dirty: true,
@@ -141,8 +139,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 			},
 			nodeHandler: this._nodeHandler,
 			rendering: false,
-			inputProperties: {},
-			invalidate: undefined
+			inputProperties: {}
 		});
 
 		this.own({
@@ -537,9 +534,11 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	}
 
 	protected destroy() {
-		let handle: Handle | undefined;
-		while ((handle = this._handles.pop())) {
-			handle.destroy();
+		while (this._handles.length > 0) {
+			const handle = this._handles.pop();
+			if (handle) {
+				handle.destroy();
+			}
 		}
 	}
 }

--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -43,7 +43,8 @@ export type BoundFunctionData = { boundFunc: (...args: any[]) => any; scope: any
 
 let lazyWidgetId = 0;
 const lazyWidgetIdMap = new WeakMap<LazyWidget, string>();
-const decoratorMap = new Map<Function, Map<string, any[]>>();
+const decoratorMap = new WeakMap<Function, Map<string, any[]>>();
+const builtDecoratorMap = new WeakMap<Function, Map<string, any[]>>();
 export const widgetInstanceMap = new WeakMap<
 	WidgetBase<WidgetProperties, DNode<DefaultWidgetBaseInterface>>,
 	WidgetData
@@ -109,9 +110,13 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 
 	private _metaMap: Map<WidgetMetaConstructor<any>, WidgetMetaBase> | undefined;
 
-	private _boundRenderFunc: Render;
+	private _boundInvalidate: () => void = () => {
+		this.invalidate();
+	};
 
-	private _boundInvalidate: () => void;
+	private _boundRenderFunc: Render = () => {
+		return this.render();
+	};
 
 	private _nodeHandler: NodeHandler = new NodeHandler();
 
@@ -123,9 +128,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	constructor() {
 		this._children = [];
 		this._decoratorCache = new Map<string, any[]>();
-		this._properties = <P>{};
-		this._boundRenderFunc = this.render.bind(this);
-		this._boundInvalidate = this.invalidate.bind(this);
+		this._properties = {} as P;
 
 		widgetInstanceMap.set(this, {
 			dirty: true,
@@ -138,7 +141,8 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 			},
 			nodeHandler: this._nodeHandler,
 			rendering: false,
-			inputProperties: {}
+			inputProperties: {},
+			invalidate: undefined
 		});
 
 		this.own({
@@ -403,6 +407,9 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 			constructor = Object.getPrototypeOf(constructor);
 		}
 
+		const buildDecorators = builtDecoratorMap.get(this.constructor) || new Map();
+		buildDecorators.set(decoratorKey, allDecorators);
+		builtDecoratorMap.set(this.constructor, buildDecorators);
 		return allDecorators;
 	}
 
@@ -413,7 +420,9 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	 * @returns An array of decorator values
 	 */
 	protected getDecorator(decoratorKey: string): any[] {
-		let allDecorators = this._decoratorCache.get(decoratorKey);
+		let decoratorCache = builtDecoratorMap.get(this.constructor);
+		let allDecorators =
+			this._decoratorCache.get(decoratorKey) || (decoratorCache && decoratorCache.get(decoratorKey));
 
 		if (allDecorators !== undefined) {
 			return allDecorators;
@@ -421,6 +430,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 
 		allDecorators = this._buildDecoratorList(decoratorKey);
 
+		allDecorators = [...allDecorators];
 		this._decoratorCache.set(decoratorKey, allDecorators);
 		return allDecorators;
 	}
@@ -527,11 +537,9 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	}
 
 	protected destroy() {
-		while (this._handles.length > 0) {
-			const handle = this._handles.pop();
-			if (handle) {
-				handle.destroy();
-			}
+		let handle: Handle | undefined;
+		while ((handle = this._handles.pop())) {
+			handle.destroy();
 		}
 	}
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Currently decorators are calculated for widgets the first time they are used in every new widget instance. The decorator map only needs to be calculated once per widget and cached for each subsequent new widget instance.

Resolves #185 
