### PR TITLE
Add Build Meta for Node BTR Functions

### DIFF
--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -11,18 +11,19 @@ import {
 	DefaultWidgetBaseInterface,
 	LazyWidget,
 	Render,
-	WidgetMetaBase,
 	WidgetMetaConstructor,
 	WidgetBaseInterface,
 	WidgetProperties,
 	WNode,
 	VNode,
-	LazyDefine
+	LazyDefine,
+	MetaBase
 } from './interfaces';
 import RegistryHandler from './RegistryHandler';
 import NodeHandler from './NodeHandler';
 import { isWidgetBaseConstructor, WIDGET_BASE_TYPE } from './Registry';
 import { Handle } from '../core/Destroyable';
+import { Base } from './meta/Base';
 
 interface ReactionFunctionConfig {
 	propertyName: string;
@@ -67,6 +68,10 @@ function isLazyDefine(item: any): item is LazyDefine {
 	return Boolean(item && item.label);
 }
 
+function isDomMeta(meta: any): meta is Base {
+	return Boolean(meta.afterRender);
+}
+
 /**
  * Main widget base for all widgets to extend
  */
@@ -108,7 +113,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	 */
 	private _bindFunctionPropertyMap: WeakMap<(...args: any[]) => any, BoundFunctionData> | undefined;
 
-	private _metaMap: Map<WidgetMetaConstructor<any>, WidgetMetaBase> | undefined;
+	private _metaMap: Map<WidgetMetaConstructor<any>, MetaBase> | undefined;
 
 	private _boundRenderFunc: Render;
 
@@ -153,9 +158,9 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		this._runAfterConstructors();
 	}
 
-	protected meta<T extends WidgetMetaBase>(MetaType: WidgetMetaConstructor<T>): T {
+	protected meta<T extends MetaBase>(MetaType: WidgetMetaConstructor<T>): T {
 		if (this._metaMap === undefined) {
-			this._metaMap = new Map<WidgetMetaConstructor<any>, WidgetMetaBase>();
+			this._metaMap = new Map<WidgetMetaConstructor<any>, MetaBase>();
 		}
 		let cached = this._metaMap.get(MetaType);
 		if (!cached) {
@@ -514,7 +519,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 
 		if (this._metaMap !== undefined) {
 			this._metaMap.forEach((meta) => {
-				meta.afterRender();
+				isDomMeta(meta) && meta.afterRender();
 			});
 		}
 

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -487,7 +487,12 @@ export interface WidgetBaseInterface<P = WidgetProperties, C extends DNode = DNo
 /**
  * Meta Base type
  */
-export interface WidgetMetaBase extends Destroyable {
+export interface MetaBase extends Destroyable {}
+
+/**
+ * Meta Base type
+ */
+export interface WidgetMetaBase extends MetaBase {
 	has(key: string | number): boolean;
 	afterRender(): void;
 }
@@ -495,7 +500,7 @@ export interface WidgetMetaBase extends Destroyable {
 /**
  * Meta Base constructor type
  */
-export interface WidgetMetaConstructor<T extends WidgetMetaBase> {
+export interface WidgetMetaConstructor<T extends MetaBase> {
 	new (properties: WidgetMetaProperties): T;
 }
 

--- a/src/widget-core/meta/Build.ts
+++ b/src/widget-core/meta/Build.ts
@@ -1,0 +1,42 @@
+import { Destroyable } from '../../core/Destroyable';
+import Map from '../../shim/Map';
+import WeakMap from '../../shim/WeakMap';
+import { WidgetMetaProperties, MetaBase } from '../interfaces';
+
+export class Build extends Destroyable implements MetaBase {
+	private _moduleMap = new WeakMap<Function, any>();
+	private _invalidate: () => void;
+
+	constructor(properties: WidgetMetaProperties) {
+		super();
+		this._invalidate = properties.invalidate;
+	}
+	public run<T extends Function>(module: T): T {
+		const decoratedModule: any = (...args: any[]) => {
+			let valueMap = this._moduleMap.get(module);
+			if (!valueMap) {
+				valueMap = new Map();
+				this._moduleMap.set(module, valueMap);
+			}
+			const argsString = JSON.stringify(args);
+			const value = valueMap.get(argsString);
+			if (value !== undefined) {
+				return value;
+			}
+
+			valueMap.set(argsString, null);
+			const result = module(...args);
+			if (typeof result.then === 'function') {
+				result.then((result: any) => {
+					valueMap.set(argsString, result);
+					this._invalidate();
+				});
+				return null;
+			}
+			return result;
+		};
+		return decoratedModule as T;
+	}
+}
+
+export default Build;

--- a/src/widget-core/meta/Build.ts
+++ b/src/widget-core/meta/Build.ts
@@ -11,6 +11,7 @@ export class Build extends Destroyable implements MetaBase {
 		super();
 		this._invalidate = properties.invalidate;
 	}
+
 	public run<T extends Function>(module: T): T {
 		const decoratedModule: any = (...args: any[]) => {
 			let valueMap = this._moduleMap.get(module);

--- a/tests/widget-core/unit/WidgetBase.ts
+++ b/tests/widget-core/unit/WidgetBase.ts
@@ -5,7 +5,7 @@ import { spy, stub, SinonStub } from 'sinon';
 import { WidgetBase, noBind, widgetInstanceMap } from '../../../src/widget-core/WidgetBase';
 import { v, w, WNODE } from '../../../src/widget-core/d';
 import { WIDGET_BASE_TYPE } from '../../../src/widget-core/Registry';
-import { Constructor, VNode, WidgetMetaConstructor, WidgetMetaBase, WNode } from '../../../src/widget-core/interfaces';
+import { Constructor, VNode, WidgetMetaConstructor, WNode, MetaBase } from '../../../src/widget-core/interfaces';
 import { handleDecorator } from '../../../src/widget-core/decorators/handleDecorator';
 import { diffProperty } from '../../../src/widget-core/decorators/diffProperty';
 import { Base } from '../../../src/widget-core/meta/Base';
@@ -38,7 +38,7 @@ class TestMeta extends Base {
 }
 
 class BaseTestWidget extends WidgetBase<TestProperties> {
-	public meta<T extends WidgetMetaBase>(metaType: WidgetMetaConstructor<T>) {
+	public meta<T extends MetaBase>(metaType: WidgetMetaConstructor<T>) {
 		return super.meta(metaType) as T;
 	}
 

--- a/tests/widget-core/unit/meta/Build.ts
+++ b/tests/widget-core/unit/meta/Build.ts
@@ -1,0 +1,71 @@
+const { assert } = intern.getPlugin('chai');
+const { describe, it } = intern.getInterface('bdd');
+import * as sinon from 'sinon';
+import NodeHandler from '../../../../src/widget-core/NodeHandler';
+import WidgetBase from '../../../../src/widget-core/WidgetBase';
+import Build from '../../../../src/widget-core/meta/Build';
+
+let bindInstance = new WidgetBase();
+
+describe('Build Meta', () => {
+	it('Should resolve module result when async', () => {
+		let resolverOne: any;
+		let resolverTwo: any;
+		const promiseOne = new Promise((resolve) => {
+			resolverOne = resolve;
+		});
+		const promiseTwo = new Promise((resolve) => {
+			resolverTwo = resolve;
+		});
+
+		const invalidate = sinon.stub();
+		const nodeHandler = new NodeHandler();
+
+		function testModule(a: string): string | null {
+			return promiseOne as any;
+		}
+
+		function testModuleOther(a: string): string | null {
+			return promiseTwo as any;
+		}
+
+		const meta = new Build({
+			invalidate,
+			nodeHandler,
+			bind: bindInstance
+		});
+
+		const resultOne = meta.run(testModule)('test');
+		const resultTwo = meta.run(testModuleOther)('test');
+		assert.isNull(resultOne);
+		assert.isNull(resultTwo);
+
+		resolverOne('resultOne');
+		resolverTwo('resultTwo');
+
+		return Promise.all([promiseOne, promiseTwo]).then(() => {
+			const resultOne = meta.run(testModule)('test');
+			assert.strictEqual(resultOne, 'resultOne');
+			const resultTwo = meta.run(testModuleOther)('test');
+			assert.strictEqual(resultTwo, 'resultTwo');
+		});
+	});
+
+	it('Should return the result immediately when sync', () => {
+		const invalidate = sinon.stub();
+		const nodeHandler = new NodeHandler();
+
+		function testModule(a: string): string | null {
+			return 'sync';
+		}
+
+		const meta = new Build({
+			invalidate,
+			nodeHandler,
+			bind: bindInstance
+		});
+
+		const resultOne = meta.run(testModule)('test');
+		assert.strictEqual(resultOne, 'sync');
+	});
+});

--- a/tests/widget-core/unit/meta/all.ts
+++ b/tests/widget-core/unit/meta/all.ts
@@ -1,3 +1,4 @@
+import './Build';
 import './meta';
 import './Dimensions';
 import './Drag';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

A `Build` meta designed to be used to call node functions during build time render. The meta accepts a function and returns either `null` or the result of the function. If the function returns a promise then it will invalidate the widget and return the cached resolved value.

The results are cached, first by the function reference and then by the stringify'd arguments... The functions arguments must be serialisable so cannot accept functions or class instances etc.
