### PR TITLE
Export default for watch decorator

### DIFF
--- a/src/widget-core/decorators/watch.ts
+++ b/src/widget-core/decorators/watch.ts
@@ -18,3 +18,5 @@ export function watch(): DecoratorHandler {
 		});
 	});
 }
+
+export default watch;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add default export for watch decorator.