### PR TITLE
always render the store provider

### DIFF
--- a/src/stores/StoreProvider.ts
+++ b/src/stores/StoreProvider.ts
@@ -4,6 +4,7 @@ import { Store, StatePaths, Path } from './Store';
 import { diffProperty } from '../widget-core/decorators/diffProperty';
 import { Handle } from '../core/Destroyable';
 import { shallow } from '../widget-core/diff';
+import { alwaysRender } from '../widget-core/decorators/alwaysRender';
 
 export interface GetPaths<S = any> {
 	(path: StatePaths<S>): Path<S, any>[];
@@ -29,6 +30,7 @@ function pathDiff(previousProperty: Function, newProperty: Function) {
 	};
 }
 
+@alwaysRender()
 export class StoreProvider<S = any> extends WidgetBase<StoreProviderProperties<S>, never> {
 	private _handle: Handle | undefined;
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that the `StoreProvider` re-renders when it's parent is invalidated.

Resolves #188 
