### PR TITLE
Use root node display property to set custom element root node display property

### DIFF
--- a/src/widget-core/registerCustomElement.ts
+++ b/src/widget-core/registerCustomElement.ts
@@ -137,6 +137,11 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 			const r = renderer(() => w(Wrapper, {}));
 			this._renderer = r;
 			r.mount({ domNode: this, merge: false, registry });
+			const root = this.children[0];
+			if (root) {
+				const { display = 'block' } = global.getComputedStyle(root);
+				this.style.display = display;
+			}
 
 			this._initialised = true;
 			this.dispatchEvent(

--- a/tests/widget-core/unit/registerCustomElement.ts
+++ b/tests/widget-core/unit/registerCustomElement.ts
@@ -22,6 +22,24 @@ class Foo extends WidgetBase {
 	}
 }
 
+@customElement({
+	tag: 'display-element-inline-block'
+})
+class DisplayElement extends WidgetBase {
+	render() {
+		return v('div', { styles: { display: 'inline-block' } }, ['hello world']);
+	}
+}
+
+@customElement({
+	tag: 'display-element-default-block'
+})
+class DisplayElementDefault extends WidgetBase {
+	render() {
+		return v('div', ['hello world']);
+	}
+}
+
 function createTestWidget(options: any) {
 	const { properties, attributes, events, childType = CustomElementChildType.DOJO } = options;
 	@customElement<any>({
@@ -60,7 +78,7 @@ function createTestWidget(options: any) {
 			if (onExternalFunction) {
 				onExternalFunction('hello');
 			}
-			return v('div', [
+			return v('div', { styles: { display: 'inline-block' } }, [
 				v('button', { classes: ['event'], onclick: this._onClick }),
 				v('div', { classes: ['prop'] }, [`${myProp}`]),
 				v('div', { classes: ['attr'] }, [`${myAttr}`]),
@@ -120,7 +138,7 @@ describe('registerCustomElement', () => {
 		register(Foo);
 		element = document.createElement('foo-element');
 		document.body.appendChild(element);
-		assert.equal(element.outerHTML, '<foo-element><div>hello world</div></foo-element>');
+		assert.equal(element.outerHTML, '<foo-element style="display: block;"><div>hello world</div></foo-element>');
 	});
 
 	it('custom element with property', () => {
@@ -314,5 +332,21 @@ describe('registerCustomElement', () => {
 		resolvers.resolve();
 		assert.equal(functionText, 'hello');
 		assert.equal(scope, undefined, 'function scope should not be tampered with');
+	});
+
+	it('adds the correct display style to the wrapping node based on the root node of the widget', () => {
+		register(DisplayElement);
+		element = document.createElement('display-element-inline-block');
+		document.body.appendChild(element);
+		const { display } = global.getComputedStyle(element);
+		assert.equal(display, 'inline-block');
+	});
+
+	it('adds display:block if no style found on root node of widget', () => {
+		register(DisplayElementDefault);
+		element = document.createElement('display-element-default-block');
+		document.body.appendChild(element);
+		const { display } = global.getComputedStyle(element);
+		assert.equal(display, 'block');
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR


**Description:**
Use the root node of the widgets display property and set it on the custom element node. If none set default to `block` which is more common/preferable than the custom element default of `inline`

This solution differs to what I originally postured here: https://github.com/dojo/framework/issues/209#issuecomment-451537164, because I think this way is simpler, slightly more ergonomic and a lot of `dojo/widgets` already specify the desired `display` on their root node (for example: https://github.com/dojo/widgets/blob/master/src/theme/button.m.css#L5)

Resolves https://github.com/dojo/framework/issues/209

Thanks to @jcfranco for raising the original issue.
