### PR TITLE
Update type that causes 'Maximum call stack size exceeded' in 3.2.x

### DIFF
--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -417,7 +417,7 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 /**
  * union type for all possible return types from render
  */
-export type DNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> =
+export type DNode<W extends WidgetBaseInterface<WidgetProperties, any> = WidgetBaseInterface<WidgetProperties, any>> =
 	| VNode
 	| WNode<W>
 	| undefined


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

TypeScript 3.2.x starts throwing an error `RangeError: Maximum call stack size exceeded` due to circular type reference used as a default type.

This change updates the default type for the children nodes to `any` for a `DNode` to remove the use of `DNode` as a circular reference.

Resolves #205 
