### PR TITLE
Assertion Templates

### DIFF
--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -1,0 +1,81 @@
+import select from '@dojo/framework/testing/support/selector';
+import { isWNode, isVNode, decorate } from '@dojo/framework/widget-core/d';
+import { DNode } from '@dojo/framework/widget-core/interfaces';
+
+interface AssertionTemplateResult {
+	(): DNode | DNode[];
+	setChildren?(selector: string, children: DNode[]): AssertionTemplateResult;
+	setProperty?(selector: string, property: string, value: any): AssertionTemplateResult;
+	getChildren?(selector: string): DNode[];
+	getProperty?(selector: string, property: string): any;
+}
+
+const findOne = (nodes: DNode | DNode[], selector: string): DNode | undefined => {
+	let [node] = select(selector, nodes);
+	if (!node && selector.indexOf('@') === 0) {
+		selector = `[\\~key='${selector.substr(1)}']`;
+		[node] = select(selector, node);
+	}
+	return node;
+};
+
+export const assertionTemplate = (renderFunc: () => DNode | DNode[]) => {
+	const assertionTemplateResult: AssertionTemplateResult = () => {
+		const render = renderFunc();
+		decorate(render, (node) => {
+			if ((isWNode(node) || isVNode(node)) && node.properties['~key']) {
+				delete node.properties['~key'];
+			}
+		});
+		return render;
+	};
+	assertionTemplateResult.setProperty = (selector, property, value) => {
+		const render = renderFunc();
+		const node = findOne(render, selector);
+		if (!node) {
+			throw Error('Node not found');
+		}
+		if (typeof node === 'string') {
+			throw Error('Cannot set property on text node');
+		}
+		node.properties[property] = value;
+		return assertionTemplate(() => render);
+	};
+	assertionTemplateResult.setChildren = (selector, children) => {
+		const render = renderFunc();
+		const node = findOne(render, selector);
+		if (!node) {
+			throw Error('Node not found');
+		}
+		if (typeof node === 'string') {
+			throw Error('Cannot set children on text node');
+		}
+		node.children = children;
+		return assertionTemplate(() => render);
+	};
+	assertionTemplateResult.getProperty = (selector, property) => {
+		const render = renderFunc();
+		const node = findOne(render, selector);
+		if (!node) {
+			throw Error('Node not found');
+		}
+		if (typeof node === 'string') {
+			throw Error('Cannot get property on text node');
+		}
+		return node.properties[property];
+	};
+	assertionTemplateResult.getChildren = (selector) => {
+		const render = renderFunc();
+		const node = findOne(render, selector);
+		if (!node) {
+			throw Error('Node not found');
+		}
+		if (typeof node === 'string') {
+			throw Error('Cannot get children on text node');
+		}
+		return node.children || [];
+	};
+	return assertionTemplateResult;
+};
+
+export default assertionTemplate;

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -1,81 +1,68 @@
-import select from '@dojo/framework/testing/support/selector';
-import { isWNode, isVNode, decorate } from '@dojo/framework/widget-core/d';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import select from './support/selector';
+import { isWNode, isVNode, decorate } from '../widget-core/d';
+import { VNode, WNode, DNode } from '../widget-core/interfaces';
 
-interface AssertionTemplateResult {
+export interface AssertionTemplateResult {
 	(): DNode | DNode[];
-	setChildren?(selector: string, children: DNode[]): AssertionTemplateResult;
-	setProperty?(selector: string, property: string, value: any): AssertionTemplateResult;
-	getChildren?(selector: string): DNode[];
-	getProperty?(selector: string, property: string): any;
+	setChildren(selector: string, children: DNode[]): AssertionTemplateResult;
+	setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
+	getChildren(selector: string): DNode[];
+	getProperty(selector: string, property: string): any;
 }
 
 const findOne = (nodes: DNode | DNode[], selector: string): DNode | undefined => {
-	let [node] = select(selector, nodes);
-	if (!node && selector.indexOf('@') === 0) {
+	if (selector.indexOf('~') === 0) {
 		selector = `[\\~key='${selector.substr(1)}']`;
-		[node] = select(selector, node);
+	}
+	const [node] = select(selector, nodes);
+	return node;
+};
+
+type NodeWithProperties = (VNode | WNode) & { properties: { [index: string]: any } };
+
+const guard = (node: DNode): NodeWithProperties => {
+	if (!node) {
+		throw Error('Node not found');
+	}
+	if (!isWNode(node) && !isVNode(node)) {
+		throw Error('Cannot set or get on unknown node');
 	}
 	return node;
 };
 
-export const assertionTemplate = (renderFunc: () => DNode | DNode[]) => {
-	const assertionTemplateResult: AssertionTemplateResult = () => {
+export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
+	const assertionTemplateResult: any = () => {
 		const render = renderFunc();
 		decorate(render, (node) => {
-			if ((isWNode(node) || isVNode(node)) && node.properties['~key']) {
-				delete node.properties['~key'];
+			if (isWNode(node) || isVNode(node)) {
+				delete (node as NodeWithProperties).properties['~key'];
 			}
 		});
 		return render;
 	};
-	assertionTemplateResult.setProperty = (selector, property, value) => {
+	assertionTemplateResult.setProperty = (selector: string, property: string, value: any) => {
 		const render = renderFunc();
-		const node = findOne(render, selector);
-		if (!node) {
-			throw Error('Node not found');
-		}
-		if (typeof node === 'string') {
-			throw Error('Cannot set property on text node');
-		}
+		const node = guard(findOne(render, selector));
 		node.properties[property] = value;
 		return assertionTemplate(() => render);
 	};
-	assertionTemplateResult.setChildren = (selector, children) => {
+	assertionTemplateResult.setChildren = (selector: string, children: DNode[]) => {
 		const render = renderFunc();
-		const node = findOne(render, selector);
-		if (!node) {
-			throw Error('Node not found');
-		}
-		if (typeof node === 'string') {
-			throw Error('Cannot set children on text node');
-		}
+		const node = guard(findOne(render, selector));
 		node.children = children;
 		return assertionTemplate(() => render);
 	};
-	assertionTemplateResult.getProperty = (selector, property) => {
+	assertionTemplateResult.getProperty = (selector: string, property: string) => {
 		const render = renderFunc();
-		const node = findOne(render, selector);
-		if (!node) {
-			throw Error('Node not found');
-		}
-		if (typeof node === 'string') {
-			throw Error('Cannot get property on text node');
-		}
+		const node = guard(findOne(render, selector));
 		return node.properties[property];
 	};
-	assertionTemplateResult.getChildren = (selector) => {
+	assertionTemplateResult.getChildren = (selector: string) => {
 		const render = renderFunc();
-		const node = findOne(render, selector);
-		if (!node) {
-			throw Error('Node not found');
-		}
-		if (typeof node === 'string') {
-			throw Error('Cannot get children on text node');
-		}
+		const node = guard(findOne(render, selector));
 		return node.children || [];
 	};
-	return assertionTemplateResult;
-};
+	return assertionTemplateResult as AssertionTemplateResult;
+}
 
 export default assertionTemplate;

--- a/tests/testing/unit/all.ts
+++ b/tests/testing/unit/all.ts
@@ -1,3 +1,4 @@
 import './harness';
 import './harnessWithTsx';
+import './assertionTemplate';
 import './support/all';

--- a/tests/testing/unit/assertionTemplate.ts
+++ b/tests/testing/unit/assertionTemplate.ts
@@ -1,0 +1,53 @@
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+import { harness } from '../../../src/testing/harness';
+import { WidgetBase } from '../../../src/widget-core/WidgetBase';
+import { v, w } from '../../../src/widget-core/d';
+import assertionTemplate from '../../../src/testing/assertionTemplate';
+
+class MyWidget extends WidgetBase<{ toggleProperty?: boolean; toggleChild?: boolean }> {
+	render() {
+		const { toggleProperty, toggleChild } = this.properties;
+		return v('div', { classes: ['root'] }, [
+			v('h2', [toggleChild ? 'world' : 'hello']),
+			v('ul', [v('li', { foo: toggleProperty ? 'b' : 'a' }, ['one']), v('li', ['two']), v('li', ['three'])])
+		]);
+	}
+}
+
+const baseAssertion = assertionTemplate(() =>
+	v('div', { '~key': 'root', classes: ['root'] }, [
+		v('h2', { '~key': 'header' }, ['hello']),
+		v('ul', [v('li', { '~key': 'li-one', foo: 'a' }, ['one']), v('li', ['two']), v('li', ['three'])])
+	])
+);
+
+describe('assertionTemplate', () => {
+	it('can get a property', () => {
+		const classes = baseAssertion.getProperty('~root', 'classes');
+		assert.deepEqual(classes, ['root']);
+	});
+
+	it('can get a child', () => {
+		const children = baseAssertion.getChildren('~header');
+		assert.equal(children[0], 'hello');
+	});
+
+	it('can assert a base assertion', () => {
+		const h = harness(() => w(MyWidget, {}));
+		h.expect(baseAssertion);
+	});
+
+	it('can set a property', () => {
+		const h = harness(() => w(MyWidget, { toggleProperty: true }));
+		const propertyAssertion = baseAssertion.setProperty('~li-one', 'foo', 'b');
+		h.expect(propertyAssertion);
+	});
+
+	it('can set a child', () => {
+		const h = harness(() => w(MyWidget, { toggleChild: true }));
+		const childAssertion = baseAssertion.setChildren('~header', ['world']);
+		h.expect(childAssertion);
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Asserting full render functions can be brittle and end up encapsulating lots of logic in tests. While asserting only portions of a render function does not potentially cover everything (because a render function is the smallest unit).

To solve the above problems, Assertion Templates allow the user to always assert against a full render, while allowing them to easily modify the assertion themselves per scenario. 

The AssertionTemplate uses the existing selector api used elsewhere in harness, and supports an additional magic `~key` selector which is erased on render, this allows the user to select nodes in the AssertionTemplate, without the key being in the actual render result itself.

The api for AssertionTemplate is very simple with the following api's:
* getProperty - gets a property on a selected node
* setProperty - sets a property on a selected node
* getChildren - gets the children on a selected node
* setChildren - sets the children on a selected node

AssertionTemplates are always immutable, setting a value will always result in a new AssertionTemplate being returned. This allows you to use assertions that build on top of other assertions.


Resolves https://github.com/dojo/framework/issues/190
