### PR TITLE
Remove custom element initialization section from README

### DIFF
--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -1626,27 +1626,3 @@ and lower-casing the resulting name.
 ##### Tag Name
 
 Your widget will be registered with the browser using the provided tag name. The tag name **must** have a `-` in it.
-
-##### Initialization
-
-Custom logic can be performed after properties/attributes have been defined but before the custom element is rendered. This
-allows you full control over your widget, allowing you to add custom properties, event handlers, work with child nodes, etc.
-The initialization function is run from the context of the HTML element.
-
-```ts
-{
-	initialization(properties) {
-		const footer = this.getElementsByTagName('footer');
-		if (footer) {
-			properties.footer = footer;
-		}
-
-		const header = this.getElementsByTagName('header');
-		if (header) {
-			properties.header = header;
-		}
-	}
-}
-```
-
-It should be noted that children nodes are removed from the DOM when attached, and added as children to the widget instance.


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #208
