### PR TITLE
Rename Build meta to Block

### DIFF
--- a/src/widget-core/meta/Block.ts
+++ b/src/widget-core/meta/Block.ts
@@ -3,7 +3,7 @@ import Map from '../../shim/Map';
 import WeakMap from '../../shim/WeakMap';
 import { WidgetMetaProperties, MetaBase } from '../interfaces';
 
-export class Build extends Destroyable implements MetaBase {
+export class Block extends Destroyable implements MetaBase {
 	private _moduleMap = new WeakMap<Function, any>();
 	private _invalidate: () => void;
 
@@ -42,4 +42,4 @@ export class Build extends Destroyable implements MetaBase {
 	}
 }
 
-export default Build;
+export default Block;

--- a/tests/widget-core/unit/meta/Block.ts
+++ b/tests/widget-core/unit/meta/Block.ts
@@ -3,11 +3,11 @@ const { describe, it } = intern.getInterface('bdd');
 import * as sinon from 'sinon';
 import NodeHandler from '../../../../src/widget-core/NodeHandler';
 import WidgetBase from '../../../../src/widget-core/WidgetBase';
-import Build from '../../../../src/widget-core/meta/Build';
+import Block from '../../../../src/widget-core/meta/Block';
 
 let bindInstance = new WidgetBase();
 
-describe('Build Meta', () => {
+describe('Block Meta', () => {
 	it('Should resolve module result when async', () => {
 		let resolverOne: any;
 		let resolverTwo: any;
@@ -29,7 +29,7 @@ describe('Build Meta', () => {
 			return promiseTwo as any;
 		}
 
-		const meta = new Build({
+		const meta = new Block({
 			invalidate,
 			nodeHandler,
 			bind: bindInstance
@@ -59,7 +59,7 @@ describe('Build Meta', () => {
 			return 'sync';
 		}
 
-		const meta = new Build({
+		const meta = new Block({
 			invalidate,
 			nodeHandler,
 			bind: bindInstance

--- a/tests/widget-core/unit/meta/all.ts
+++ b/tests/widget-core/unit/meta/all.ts
@@ -1,4 +1,4 @@
-import './Build';
+import './Block';
 import './meta';
 import './Dimensions';
 import './Drag';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Renames the `Build` meta to `Block`.
