### PR TITLE
Only import `fetch` polyfill when `build-elide` is false

### DIFF
--- a/src/shim/fetch.ts
+++ b/src/shim/fetch.ts
@@ -1,5 +1,5 @@
 import global from './global';
-`!has('fetch')`;
+`!has('build-elide')`;
 import 'whatwg-fetch';
 
 export default global.fetch.bind(global) as (input: RequestInfo, init?: RequestInit) => Promise<Response>;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Update to use the `build-elide` flag to determine whether to the fetch polyfill should be elided.
