### PR TITLE
Determine the correct insertion position when rendering extra nodes on a merge

### DIFF
--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -2685,40 +2685,12 @@ jsdomDescribe('vdom', () => {
 			});
 
 			it('should render in the correct order when inserting a node between nodes that already exist on a merge', () => {
-				class Header extends WidgetBase {
-					render() {
-						return v('header', { id: 'header' });
-					}
-				}
-
-				class Body extends WidgetBase {
-					render() {
-						return v('div', { id: 'my-body' });
-					}
-				}
-
-				class Footer extends WidgetBase {
-					render() {
-						return v('footer', { id: 'footer' }, [v('span', ['span'])]);
-					}
-				}
-
-				class MyRendererWidget extends WidgetBase<any> {
-					render() {
-						return this.properties.renderer();
-					}
-				}
-
 				class App extends WidgetBase {
 					render() {
 						return v('div', [
-							w(Header, {}),
-							w(MyRendererWidget, {
-								renderer: () => {
-									return w(Body, {});
-								}
-							}),
-							w(Footer, {})
+							v('header', { id: 'header' }),
+							v('div', { id: 'my-body' }),
+							v('footer', { id: 'footer' }, [v('span', ['span'])])
 						]);
 					}
 				}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

During a merge on the first render, use the next merge node candidate to insert before if the parent of the node about to be created and the next merge node have the same parent.

Resolves #228 
