### PR TITLE
Block meta should only locally cache values resolved from promises

### DIFF
--- a/src/widget-core/meta/Block.ts
+++ b/src/widget-core/meta/Block.ts
@@ -18,7 +18,7 @@ export class Block extends Destroyable implements MetaBase {
 			let valueMap = this._moduleMap.get(module);
 			if (valueMap) {
 				const cachedValue = valueMap.get(argsString);
-				if (cachedValue) {
+				if (cachedValue !== undefined) {
 					return cachedValue;
 				}
 			}

--- a/src/widget-core/meta/Block.ts
+++ b/src/widget-core/meta/Block.ts
@@ -27,6 +27,9 @@ export class Block extends Destroyable implements MetaBase {
 
 			valueMap.set(argsString, null);
 			const result = module(...args);
+			if (!result) {
+				return null;
+			}
 			if (typeof result.then === 'function') {
 				result.then((result: any) => {
 					valueMap.set(argsString, result);

--- a/src/widget-core/meta/Block.ts
+++ b/src/widget-core/meta/Block.ts
@@ -14,30 +14,25 @@ export class Block extends Destroyable implements MetaBase {
 
 	public run<T extends Function>(module: T): T {
 		const decoratedModule: any = (...args: any[]) => {
-			let valueMap = this._moduleMap.get(module);
-			if (!valueMap) {
-				valueMap = new Map();
-				this._moduleMap.set(module, valueMap);
-			}
 			const argsString = JSON.stringify(args);
-			const value = valueMap.get(argsString);
-			if (value !== undefined) {
-				return value;
+			let valueMap = this._moduleMap.get(module);
+			if (valueMap) {
+				const cachedValue = valueMap.get(argsString);
+				if (cachedValue) {
+					return cachedValue;
+				}
 			}
-
-			valueMap.set(argsString, null);
 			const result = module(...args);
-			if (!result) {
-				return null;
-			}
-			if (typeof result.then === 'function') {
+			if (result && typeof result.then === 'function') {
 				result.then((result: any) => {
+					if (!valueMap) {
+						valueMap = new Map();
+						this._moduleMap.set(module, valueMap);
+					}
 					valueMap.set(argsString, result);
 					this._invalidate();
 				});
 				return null;
-			} else {
-				valueMap.set(argsString, result);
 			}
 			return result;
 		};

--- a/tests/widget-core/unit/meta/Block.ts
+++ b/tests/widget-core/unit/meta/Block.ts
@@ -71,7 +71,7 @@ describe('Block Meta', () => {
 		assert.strictEqual(resultOne, 'sync');
 	});
 
-	it('Should return null if module does not return a result', () => {
+	it('Should return result value if module does not return a promise', () => {
 		const invalidate = sinon.stub();
 		const nodeHandler = new NodeHandler();
 
@@ -86,6 +86,6 @@ describe('Block Meta', () => {
 		});
 
 		let result = meta.run(testModule)('test');
-		assert.isNull(result);
+		assert.isUndefined(result);
 	});
 });

--- a/tests/widget-core/unit/meta/Block.ts
+++ b/tests/widget-core/unit/meta/Block.ts
@@ -70,4 +70,22 @@ describe('Block Meta', () => {
 		resultOne = meta.run(testModule)('test');
 		assert.strictEqual(resultOne, 'sync');
 	});
+
+	it('Should return null if module does not return a result', () => {
+		const invalidate = sinon.stub();
+		const nodeHandler = new NodeHandler();
+
+		function testModule(a: string) {
+			return undefined;
+		}
+
+		const meta = new Block({
+			invalidate,
+			nodeHandler,
+			bind: bindInstance
+		});
+
+		let result = meta.run(testModule)('test');
+		assert.isNull(result);
+	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

There is no need to cache value locally in the `Block` meta unless the `module` returns a promise. Only cache the resolved result from a promise, otherwise always use the result from the `module` (which is the from the block cache at runtime)