### PR TITLE
Add support for using resize-observer-polyfill's UMD module

### DIFF
--- a/src/shim/ResizeObserver.ts
+++ b/src/shim/ResizeObserver.ts
@@ -1,7 +1,7 @@
 import global from './global';
 import has from '../has/has';
 `!has('build-elide')`;
-import Resize from 'resize-observer-polyfill';
+import * as Resize from 'resize-observer-polyfill';
 
 export interface DOMRectReadOnly {
 	readonly x: number;
@@ -33,7 +33,8 @@ export interface ResizeObserver {
 
 if (!has('build-elide')) {
 	if (!global.ResizeObserver) {
-		global.ResizeObserver = Resize;
+		// default is undefined when UMD module is used
+		global.ResizeObserver = Resize.default || Resize;
 	}
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The shim returns `undefined` if using an AMD loader that uses the polyfill's UMD module since `default` is then `undefined`.

Resolves https://github.com/dojo/framework/issues/237#issuecomment-459818424