### PR TITLE
Add `prepend` and `append` options to setChildren 

### DIFF
--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -281,9 +281,7 @@ class NumberWidget extends WidgetBase<{ num?: number }> {
 	protected render() {
 		const { num } = this.properties;
 		const message = num === undefined ? 'no number passed' : `the number ${num}`;
-		return v('div', [
-			v('span', [ message ])
-		]);
+		return v('div', [v('span', [message])]);
 	}
 }
 ```
@@ -311,7 +309,7 @@ now lets see how we'd test the output when the `num` property is passed to the `
 
 ```ts
 it('should render the number when a number is passed as a property', () => {
-	const numberAssertion = baseAssertion.setChildren('~message', [ 'the number 5' ]);
+	const numberAssertion = baseAssertion.setChildren('~message', ['the number 5']);
 	const h = harness(() => w(NumberWidget, { num: 5 }));
 	h.expect(numberAssertion);
 });
@@ -327,5 +325,3 @@ setProperty(selector: string, property: string, value: any): AssertionTemplateRe
 getChildren(selector: string): DNode[];
 getProperty(selector: string, property: string): any;
 ```
-
-

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -4,7 +4,7 @@ import { VNode, WNode, DNode } from '../widget-core/interfaces';
 
 export interface AssertionTemplateResult {
 	(): DNode | DNode[];
-	setChildren(selector: string, children: DNode[]): AssertionTemplateResult;
+	setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 	setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
 	getChildren(selector: string): DNode[];
 	getProperty(selector: string, property: string): any;
@@ -46,10 +46,25 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		node.properties[property] = value;
 		return assertionTemplate(() => render);
 	};
-	assertionTemplateResult.setChildren = (selector: string, children: DNode[]) => {
+	assertionTemplateResult.setChildren = (
+		selector: string,
+		children: DNode[],
+		type: 'prepend' | 'replace' | 'append' = 'replace'
+	) => {
 		const render = renderFunc();
 		const node = guard(findOne(render, selector));
-		node.children = children;
+		node.children = node.children || [];
+		switch (type) {
+			case 'prepend':
+				node.children = [...children, ...node.children];
+				break;
+			case 'append':
+				node.children = [...node.children, ...children];
+				break;
+			case 'replace':
+				node.children = [...children];
+				break;
+		}
 		return assertionTemplate(() => render);
 	};
 	assertionTemplateResult.getProperty = (selector: string, property: string) => {

--- a/tests/testing/unit/assertionTemplate.ts
+++ b/tests/testing/unit/assertionTemplate.ts
@@ -6,11 +6,26 @@ import { WidgetBase } from '../../../src/widget-core/WidgetBase';
 import { v, w } from '../../../src/widget-core/d';
 import assertionTemplate from '../../../src/testing/assertionTemplate';
 
-class MyWidget extends WidgetBase<{ toggleProperty?: boolean; toggleChild?: boolean }> {
+class MyWidget extends WidgetBase<{
+	toggleProperty?: boolean;
+	prependChild?: boolean;
+	appendChild?: boolean;
+	replaceChild?: boolean;
+}> {
 	render() {
-		const { toggleProperty, toggleChild } = this.properties;
+		const { toggleProperty, prependChild, appendChild, replaceChild } = this.properties;
+		let children = ['hello'];
+		if (prependChild) {
+			children = ['prepend', ...children];
+		}
+		if (appendChild) {
+			children = [...children, 'append'];
+		}
+		if (replaceChild) {
+			children = ['replace'];
+		}
 		return v('div', { classes: ['root'] }, [
-			v('h2', [toggleChild ? 'world' : 'hello']),
+			v('h2', children),
 			v('ul', [v('li', { foo: toggleProperty ? 'b' : 'a' }, ['one']), v('li', ['two']), v('li', ['three'])])
 		]);
 	}
@@ -46,8 +61,26 @@ describe('assertionTemplate', () => {
 	});
 
 	it('can set a child', () => {
-		const h = harness(() => w(MyWidget, { toggleChild: true }));
-		const childAssertion = baseAssertion.setChildren('~header', ['world']);
+		const h = harness(() => w(MyWidget, { replaceChild: true }));
+		const childAssertion = baseAssertion.setChildren('~header', ['replace']);
+		h.expect(childAssertion);
+	});
+
+	it('can set a child with replace', () => {
+		const h = harness(() => w(MyWidget, { replaceChild: true }));
+		const childAssertion = baseAssertion.setChildren('~header', ['replace'], 'replace');
+		h.expect(childAssertion);
+	});
+
+	it('can set a child with prepend', () => {
+		const h = harness(() => w(MyWidget, { prependChild: true }));
+		const childAssertion = baseAssertion.setChildren('~header', ['prepend'], 'prepend');
+		h.expect(childAssertion);
+	});
+
+	it('can set a child with append', () => {
+		const h = harness(() => w(MyWidget, { appendChild: true }));
+		const childAssertion = baseAssertion.setChildren('~header', ['append'], 'append');
 		h.expect(childAssertion);
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Adds the ability prepend and append nodes when setting children. This is quite a common scenario which means the user has to get the children first and then spread currently. This is a non-breaking api change, the default behaviour is the same as currently, which is to replace.
