### PR TITLE
Make sure we support assertion key for tsx in assertion templates

### DIFF
--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -315,12 +315,12 @@ it('should render the number when a number is passed as a property', () => {
 });
 ```
 
-Here we're using the `setChildren()` api on the baseAssertion, and we're using the special `~` selector to find a node with a key of `~message`. The `~key` property is a special property on Assertion Templates that will be erased at assertion time so it doesn't show up when matching the renders. This allows you to decorate the AssertionTemplates to easily select nodes, without having to augment the actual widgets render function. Once we have the `message` node we then set the children to the expected `the number 5`, and use the resulting template in `h.expect`. It's important to note that Assertion Templates always return a new Assertion Template when setting a value, this ensures that you do not accidentally mutate an existing template (causing other tests to potentially fail), and allows you to build layered Templates that incrementally build on each other.
+Here we're using the `setChildren()` api on the baseAssertion, and we're using the special `~` selector to find a node with a key of `~message`. The `~key` property (or when using tsx in a template, `assertion-key`) is a special property on Assertion Templates that will be erased at assertion time so it doesn't show up when matching the renders. This allows you to decorate the AssertionTemplates to easily select nodes, without having to augment the actual widgets render function. Once we have the `message` node we then set the children to the expected `the number 5`, and use the resulting template in `h.expect`. It's important to note that Assertion Templates always return a new Assertion Template when setting a value, this ensures that you do not accidentally mutate an existing template (causing other tests to potentially fail), and allows you to build layered Templates that incrementally build on each other.
 
 Assertion Template has the following api's:
 
 ```
-setChildren(selector: string, children: DNode[]): AssertionTemplateResult;
+setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
 getChildren(selector: string): DNode[];
 getProperty(selector: string, property: string): any;

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -11,10 +11,15 @@ export interface AssertionTemplateResult {
 }
 
 const findOne = (nodes: DNode | DNode[], selector: string): DNode | undefined => {
+	let finalSelector = selector;
 	if (selector.indexOf('~') === 0) {
-		selector = `[\\~key='${selector.substr(1)}']`;
+		finalSelector = `[\\~key='${selector.substr(1)}']`;
 	}
-	const [node] = select(selector, nodes);
+	let [node] = select(finalSelector, nodes);
+	if (!node) {
+		finalSelector = `[assertion-key='${selector.substr(1)}']`;
+		[node] = select(finalSelector, nodes);
+	}
 	return node;
 };
 
@@ -36,6 +41,7 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		decorate(render, (node) => {
 			if (isWNode(node) || isVNode(node)) {
 				delete (node as NodeWithProperties).properties['~key'];
+				delete (node as NodeWithProperties).properties['assertion-key'];
 			}
 		});
 		return render;

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -4,6 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import { harness } from '../../../src/testing/harness';
 import { WidgetBase } from '../../../src/widget-core/WidgetBase';
 import { v, w } from '../../../src/widget-core/d';
+import { tsx } from '../../../src/widget-core/tsx';
 import assertionTemplate from '../../../src/testing/assertionTemplate';
 
 class MyWidget extends WidgetBase<{
@@ -37,6 +38,19 @@ const baseAssertion = assertionTemplate(() =>
 		v('ul', [v('li', { '~key': 'li-one', foo: 'a' }, ['one']), v('li', ['two']), v('li', ['three'])])
 	])
 );
+
+const tsxAssertion = assertionTemplate(() => (
+	<div classes={['root']}>
+		<h2>hello</h2>
+		<ul>
+			<li assertion-key="li-one" foo="a">
+				one
+			</li>
+			<li>two</li>
+			<li>three</li>
+		</ul>
+	</div>
+));
 
 describe('assertionTemplate', () => {
 	it('can get a property', () => {
@@ -82,5 +96,11 @@ describe('assertionTemplate', () => {
 		const h = harness(() => w(MyWidget, { appendChild: true }));
 		const childAssertion = baseAssertion.setChildren('~header', ['append'], 'append');
 		h.expect(childAssertion);
+	});
+
+	it('can be used with tsx', () => {
+		const h = harness(() => <MyWidget toggleProperty={true} />);
+		const propertyAssertion = tsxAssertion.setProperty('~li-one', 'foo', 'b');
+		h.expect(propertyAssertion);
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
the tilde `~` is not supported as an attribute in `tsx`, so can't use the assertion key. This adds an also support attribute name of `assertion-key` so it can be used in tsx. note: you still select using the tilde `~`
