### PR TITLE
Support `false` type for classes and DNodes

### DIFF
--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -32,7 +32,7 @@ export function formatDNodes(nodes: DNode | DNode[], depth: number = 0): string 
 	}
 	let requiresCarriageReturn = false;
 	let formattedNode = nodes.reduce((result: string, node, index) => {
-		if (!node) {
+		if (!node || node === true) {
 			return result;
 		}
 		if (requiresCarriageReturn) {

--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -292,7 +292,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		const convertedNodes: (WNode | VNode)[] = [];
 		for (let i = 0; i < filteredNodes.length; i++) {
 			const node = filteredNodes[i];
-			if (!node) {
+			if (!node || node === true) {
 				continue;
 			}
 			if (typeof node === 'string') {

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -36,21 +36,23 @@ export const DOMVNODE = '__DOMVNODE_TYPE';
 export function isWNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterface>(
 	child: DNode<W> | any
 ): child is WNode<W> {
-	return Boolean(child && typeof child !== 'string' && child.type === WNODE);
+	return Boolean(child && child !== true && typeof child !== 'string' && child.type === WNODE);
 }
 
 /**
  * Helper function that returns true if the `DNode` is a `VNode` using the `type` property
  */
 export function isVNode(child: DNode): child is VNode {
-	return Boolean(child && typeof child !== 'string' && (child.type === VNODE || child.type === DOMVNODE));
+	return Boolean(
+		child && child !== true && typeof child !== 'string' && (child.type === VNODE || child.type === DOMVNODE)
+	);
 }
 
 /**
  * Helper function that returns true if the `DNode` is a `VNode` created with `dom()` using the `type` property
  */
 export function isDomVNode(child: DNode): child is DomVNode {
-	return Boolean(child && typeof child !== 'string' && child.type === DOMVNODE);
+	return Boolean(child && child !== true && typeof child !== 'string' && child.type === DOMVNODE);
 }
 
 export function isElementNode(value: any): value is Element {
@@ -126,7 +128,7 @@ export function decorate(
 	}
 	while (nodes.length) {
 		const node = nodes.shift();
-		if (node) {
+		if (node && node !== true) {
 			if (!shallow && (isWNode(node) || isVNode(node)) && node.children) {
 				nodes = [...nodes, ...node.children];
 			}

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -81,7 +81,7 @@ export interface Projection {
 	readonly domNode: Element;
 }
 
-export type SupportedClassName = string | null | undefined;
+export type SupportedClassName = string | null | undefined | false;
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 
@@ -422,7 +422,8 @@ export type DNode<W extends WidgetBaseInterface<WidgetProperties, any> = WidgetB
 	| WNode<W>
 	| undefined
 	| null
-	| string;
+	| string
+	| boolean;
 
 /**
  * Property Change record for specific property diff functions

--- a/src/widget-core/mixins/Themed.ts
+++ b/src/widget-core/mixins/Themed.ts
@@ -170,7 +170,7 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 		}
 
 		private _getThemeClass(className: SupportedClassName): SupportedClassName {
-			if (className === undefined || className === null) {
+			if (className === undefined || className === null || className === false) {
 				return className;
 			}
 

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -303,7 +303,10 @@ function findIndexOfChild(children: DNodeWrapper[], sameAs: DNodeWrapper, start:
 
 function createClassPropValue(classes: string | string[] = []) {
 	classes = Array.isArray(classes) ? classes : [classes];
-	return classes.join(' ').trim();
+	return classes
+		.filter((className) => className)
+		.join(' ')
+		.trim();
 }
 
 function updateAttribute(domNode: Element, attrName: string, attrValue: string | undefined, namespace?: string) {

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -853,7 +853,7 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual(textNodeThree.data, '3');
 		});
 
-		it('supports null and undefined return from render', () => {
+		it('supports null, undefined and false return from render', () => {
 			class Foo extends WidgetBase {
 				render() {
 					return null;
@@ -866,9 +866,15 @@ jsdomDescribe('vdom', () => {
 				}
 			}
 
+			class Qux extends WidgetBase {
+				render() {
+					return false;
+				}
+			}
+
 			class Baz extends WidgetBase {
 				render() {
-					return v('div', [w(Foo, {}), w(Bar, {})]);
+					return v('div', [w(Foo, {}), w(Bar, {}), w(Qux, {})]);
 				}
 			}
 
@@ -3024,14 +3030,14 @@ jsdomDescribe('vdom', () => {
 				assert.strictEqual(div.className, '');
 			});
 
-			it('should accept null as a class', () => {
-				const [Widget] = getWidget(v('div', { classes: null }));
+			it('should accept falsy as a class', () => {
+				const [Widget] = getWidget(v('div', { classes: ['my-class', null, undefined, false, 'other'] }));
 				const div = document.createElement('div');
 				const root = document.createElement('div');
 				root.appendChild(div);
 				const r = renderer(() => w(Widget, {}));
 				r.mount({ domNode: root, sync: true });
-				assert.strictEqual(div.className, '');
+				assert.strictEqual(div.className, 'my-class other');
 			});
 
 			it('can add and remove multiple classes in IE11', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ternaries are often used to conditionally render nodes or apply classes. This change supports `false` for nodes and classes so that instead of a ternary, a logical `&&` expression can be used.

Current:

```ts
render() {
    return v('div', { classes: [ applyClass ? 'my-class' : null ] }, [
        showWidget ? w(MyWidget, {}) : null
    ]);
}
```

Can become:

```ts
render() {
    return v('div', { classes: [ applyClass && 'my-class' ] }, [
        showWidget && w(MyWidget, {})
    ]);
}
```

Whilst in this simple example it doesn't look much different, as widgets and classes because more complex, especially with when using `tsx` it can make a significant difference.