### PR TITLE
Factor out a `MutableState` interface from the store and provide an ImmutableJS implementation

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -89,6 +89,5 @@
 			"!./dist/dev/tests/widget-core/unit/meta/WebAnimation.js",
 			"!./dist/dev/tests/widget-core/unit/meta/Intersection.js"
 		]
-	},
-	"benchmark": true
+	}
 }

--- a/intern.json
+++ b/intern.json
@@ -46,7 +46,12 @@
 				"shimPath": "./dist/dev/src/shim/util/amd.js",
 				"packages": [
 					{ "name": "src", "location": "dist/dev/src" },
-					{ "name": "tests", "location": "dist/dev/tests" }
+					{ "name": "tests", "location": "dist/dev/tests" },
+					{
+						"name":  "immutable",
+						"location":  "./node_modules/immutable/dist",
+						"main": "immutable.js"
+					}
 				],
 				"map": {
 					"*": {

--- a/intern.json
+++ b/intern.json
@@ -84,5 +84,6 @@
 			"!./dist/dev/tests/widget-core/unit/meta/WebAnimation.js",
 			"!./dist/dev/tests/widget-core/unit/meta/Intersection.js"
 		]
-	}
+	},
+	"benchmark": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3511,6 +3511,11 @@
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
+    "immutable": {
+      "version": "4.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
+      "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
+    },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "css-select-umd": "1.3.0-rc0",
     "diff": "3.5.0",
     "globalize": "1.4.0",
+    "immutable": "3.8.2",
     "intersection-observer": "0.4.2",
     "pepjs": "0.4.2",
     "resize-observer-polyfill": "1.5.0",
@@ -66,7 +67,6 @@
     "@types/selenium-webdriver": "^3.0.8",
     "@types/sinon": "~4.1.2",
     "benchmark": "^1.0.0",
-    "immutable": "3.8.2",
     "bootstrap": "^3.3.7",
     "chromedriver": "2.40.0",
     "cldr-data": "32.0.1",
@@ -83,9 +83,6 @@
     "selenium-webdriver": "3.6.0",
     "sinon": "~4.1.3",
     "typescript": "~2.6.2"
-  },
-  "optionalDependencies": {
-    "immutable": "3.8.2"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "css-select-umd": "1.3.0-rc0",
     "diff": "3.5.0",
     "globalize": "1.4.0",
-    "immutable": "^4.0.0-rc.12",
+    "immutable": "3.8.2",
     "intersection-observer": "0.4.2",
     "pepjs": "0.4.2",
     "resize-observer-polyfill": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "css-select-umd": "1.3.0-rc0",
     "diff": "3.5.0",
     "globalize": "1.4.0",
-    "immutable": "3.8.2",
     "intersection-observer": "0.4.2",
     "pepjs": "0.4.2",
     "resize-observer-polyfill": "1.5.0",
@@ -67,6 +66,7 @@
     "@types/selenium-webdriver": "^3.0.8",
     "@types/sinon": "~4.1.2",
     "benchmark": "^1.0.0",
+    "immutable": "3.8.2",
     "bootstrap": "^3.3.7",
     "chromedriver": "2.40.0",
     "cldr-data": "32.0.1",
@@ -83,6 +83,9 @@
     "selenium-webdriver": "3.6.0",
     "sinon": "~4.1.3",
     "typescript": "~2.6.2"
+  },
+  "optionalDependencies": {
+    "immutable": "3.8.2"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "css-select-umd": "1.3.0-rc0",
     "diff": "3.5.0",
     "globalize": "1.4.0",
+    "immutable": "^4.0.0-rc.12",
     "intersection-observer": "0.4.2",
     "pepjs": "0.4.2",
     "resize-observer-polyfill": "1.5.0",

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -589,9 +589,9 @@ const store = new Store({ state: myStateImpl });
 
 #### ImmutableState
 
-An implementation of the `MutableState` interface that leverages [ImmutableJS](https://github.com/immutable-js/immutable-js) under the hood is provided as
-an example. This implementation may provide better performance if there are frequent, deep updates to the store's state, but this should be tested and verified
-before switching to this implementation.
+An implementation of the `MutableState` interface that leverages [Immutable](https://github.com/immutable-js/immutable-js) under the hood is provided as
+an example. This implementation may provide better performance if there are frequent, deep updates to the store's state, but performance should be tested and verified
+for your app before switching to this implementation.
 
 ## Middleware
 

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -220,7 +220,7 @@ and will immediately throw an error.
 function calculateCountsCommand = createCommand(({ state }) => {
 	const todos = state.todos;
 	const completedTodos = todos.filter((todo: any) => todo.completed);
-	
+
 	state.activeCount = todos.length - completedTodos.length;
 	state.completedCount = completedTodos.length;
 });

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -568,15 +568,14 @@ In this example, `commandOne` is executed, then both `concurrentCommandOne` and 
 
 **Note:** Concurrent commands are always assumed to be asynchronous and resolved using `Promise.all`.
 
-
 ### Providing an alternative State implementation
 
 Processing operations and updating the store state is handled by an implementation of the `MutableState` interface
 defined in `Store.ts`. This interface defines four methods necessary to properly apply operations to the state.
 
 -   `get<S>(path: Path<M, S>): S` Takes a `Path` object and returns the value in the current state that that path points to
--   `at<S extends Path<M, Array<any>>>(path: S, index: number): Path<M, S['value'][0]>` Returns a `Path` object that 
-points to the provided `index` in the array at the provided `path`
+-   `at<S extends Path<M, Array<any>>>(path: S, index: number): Path<M, S['value'][0]>` Returns a `Path` object that
+    points to the provided `index` in the array at the provided `path`
 -   `path: StatePaths<M>` A typesafe way to generate a `Path` object for a given path in the state
 -   `apply(operations: PatchOperation<T>[]): PatchOperation<T>[]` Apply the provided operations to the current state
 

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -589,9 +589,7 @@ const store = new Store({ state: myStateImpl });
 
 #### ImmutableState
 
-An implementation of the `MutableState` interface that leverages [Immutable](https://github.com/immutable-js/immutable-js) under the hood is provided as
-an example. This implementation may provide better performance if there are frequent, deep updates to the store's state, but performance should be tested and verified
-for your app before switching to this implementation.
+An implementation of the `MutableState` interface that leverages [Immutable](https://github.com/immutable-js/immutable-js) under the hood is provided as an example. This implementation may provide better performance if there are frequent, deep updates to the store's state, but performance should be tested and verified for your app before switching to this implementation.
 
 ## Middleware
 

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -27,6 +27,7 @@ An application store for dojo.
     -   [Transforming Executor Arguments](#transforming-executor-arguments)
     -   [Optimistic Update Pattern](#optimistic-update-pattern)
     -   [Executing Concurrent Commands](#executing-concurrent-commands)
+    -   [Providing An Alternative State Implementation](#providing-an-alternative-state-implementation)
 -   [Middleware](#middleware)
     -   [After Middleware](#after-middleware)
     -   [Before Middleware](#before-middleware)
@@ -567,6 +568,31 @@ In this example, `commandOne` is executed, then both `concurrentCommandOne` and 
 
 **Note:** Concurrent commands are always assumed to be asynchronous and resolved using `Promise.all`.
 
+
+### Providing an alternative State implementation
+
+Processing operations and updating the store state is handled by an implementation of the `MutableState` interface
+defined in `Store.ts`. This interface defines four methods necessary to properly apply operations to the state.
+
+-   `get<S>(path: Path<M, S>): S`: Takes a `Path` object and returns the value in the current state that that path points to
+-   `at<S extends Path<M, Array<any>>>(path: S, index: number): Path<M, S['value'][0]>`: Returns a `Path` object that 
+points to the provided `index` in the array at the provided `path`
+-   `path: StatePaths<M>`: A typesafe way to generate a `Path` object for a given path in the state
+-   `apply(operations: PatchOperation<T>[]): PatchOperation<T>[]`: Apply the provided operations to the current state
+
+The default state implementation is reasonably optimized and in most circumstances will be sufficient.
+If a particular use case merits an alternative implementation it can be provided to the store constructor:
+
+```ts
+const store = new Store({ state: myStateImpl });
+```
+
+#### ImmutableState
+
+An implementation of the `MutableState` interface that leverages [ImmutableJS](https://github.com/immutable-js/immutable-js) under the hood is provided as
+an example. This implementation may provide better performance if there are frequent, deep updates to the store's state, but this should be tested and verified
+before switching to this implementation.
+
 ## Middleware
 
 Middleware provides a hook to apply generic/global functionality across multiple or all processes used within an application. Middleware is a function that returns an object with optional `before` and `after` callback functions.
@@ -698,27 +724,3 @@ import { Store } from '@dojo/framework/stores/Store';
 const store = new Store();
 load('my-process', store);
 ```
-
-## Providing an alternative `State` implementation
-
-Processing operations and updating the store state is handled by an implementation of the `MutableState` interface
-defined in `Store.ts`. This interface defines four methods necessary to properly apply operations to the state.
-
--   `get<S>(path: Path<M, S>): S`: Takes a `Path` object and returns the value in the current state that that path points to
--   `at<S extends Path<M, Array<any>>>(path: S, index: number): Path<M, S['value'][0]>`: Returns a `Path` object that 
-points to the provided `index` in the array at the provided `path`
--   `path: StatePaths<M>`: A typesafe way to generate a `Path` object for a given path in the state
--   `apply(operations: PatchOperation<T>[]): PatchOperation<T>[]`: Apply the provided operations to the current state
-
-The default state implementation is reasonably optimized and in most circumstances will be sufficient.
-If a particular use case merits an alternative implementation it can be provided to the store constructor:
-
-```ts
-const store = new Store({ state: myStateImpl });
-```
-
-### ImmutableState
-
-An implementation of the `MutableState` interface that leverages [ImmutableJS](https://github.com/immutable-js/immutable-js) under the hood is provided as
-an example. This implementation may provide better performance if there are frequent, deep updates to the store's state, but this should be tested and verified
-before switching to this implementation.

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -574,14 +574,14 @@ In this example, `commandOne` is executed, then both `concurrentCommandOne` and 
 Processing operations and updating the store state is handled by an implementation of the `MutableState` interface
 defined in `Store.ts`. This interface defines four methods necessary to properly apply operations to the state.
 
--   `get<S>(path: Path<M, S>): S`: Takes a `Path` object and returns the value in the current state that that path points to
--   `at<S extends Path<M, Array<any>>>(path: S, index: number): Path<M, S['value'][0]>`: Returns a `Path` object that 
+-   `get<S>(path: Path<M, S>): S` Takes a `Path` object and returns the value in the current state that that path points to
+-   `at<S extends Path<M, Array<any>>>(path: S, index: number): Path<M, S['value'][0]>` Returns a `Path` object that 
 points to the provided `index` in the array at the provided `path`
--   `path: StatePaths<M>`: A typesafe way to generate a `Path` object for a given path in the state
--   `apply(operations: PatchOperation<T>[]): PatchOperation<T>[]`: Apply the provided operations to the current state
+-   `path: StatePaths<M>` A typesafe way to generate a `Path` object for a given path in the state
+-   `apply(operations: PatchOperation<T>[]): PatchOperation<T>[]` Apply the provided operations to the current state
 
 The default state implementation is reasonably optimized and in most circumstances will be sufficient.
-If a particular use case merits an alternative implementation it can be provided to the store constructor:
+If a particular use case merits an alternative implementation it can be provided to the store constructor
 
 ```ts
 const store = new Store({ state: myStateImpl });

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -698,3 +698,27 @@ import { Store } from '@dojo/framework/stores/Store';
 const store = new Store();
 load('my-process', store);
 ```
+
+## Providing an alternative `State` implementation
+
+Processing operations and updating the store state is handled by an implementation of the `MutableState` interface
+defined in `Store.ts`. This interface defines four methods necessary to properly apply operations to the state.
+
+-   `get<S>(path: Path<M, S>): S`: Takes a `Path` object and returns the value in the current state that that path points to
+-   `at<S extends Path<M, Array<any>>>(path: S, index: number): Path<M, S['value'][0]>`: Returns a `Path` object that 
+points to the provided `index` in the array at the provided `path`
+-   `path: StatePaths<M>`: A typesafe way to generate a `Path` object for a given path in the state
+-   `apply(operations: PatchOperation<T>[]): PatchOperation<T>[]`: Apply the provided operations to the current state
+
+The default state implementation is reasonably optimized and in most circumstances will be sufficient.
+If a particular use case merits an alternative implementation it can be provided to the store constructor:
+
+```ts
+const store = new Store({ state: myStateImpl });
+```
+
+### ImmutableState
+
+An implementation of the `MutableState` interface that leverages [ImmutableJS](https://github.com/immutable-js/immutable-js) under the hood is provided as
+an example. This implementation may provide better performance if there are frequent, deep updates to the store's state, but this should be tested and verified
+before switching to this implementation.

--- a/src/stores/Store.ts
+++ b/src/stores/Store.ts
@@ -192,7 +192,7 @@ export class DefaultState<T = any> implements MutableState<T> {
  * Application state store
  */
 export class Store<T = any> extends Evented implements MutableState<T> {
-	private _state: MutableState<T> = new DefaultState<T>();
+	private _adapter: MutableState<T> = new DefaultState<T>();
 
 	private _changePaths = new Map<string, OnChangeValue>();
 
@@ -202,14 +202,14 @@ export class Store<T = any> extends Evented implements MutableState<T> {
 	 * Returns the state at a specific pointer path location.
 	 */
 	public get = <U = any>(path: Path<T, U>): U => {
-		return this._state.get(path);
+		return this._adapter.get(path);
 	};
 
 	constructor(options?: { state?: MutableState<T> }) {
 		super();
 		if (options && options.state) {
-			this._state = options.state;
-			this.path = this._state.path.bind(this._state);
+			this._adapter = options.state;
+			this.path = this._adapter.path.bind(this._adapter);
 		}
 	}
 
@@ -217,7 +217,7 @@ export class Store<T = any> extends Evented implements MutableState<T> {
 	 * Applies store operations to state and returns the undo operations
 	 */
 	public apply = (operations: PatchOperation<T>[], invalidate: boolean = false): PatchOperation<T>[] => {
-		const result = this._state.apply(operations);
+		const result = this._adapter.apply(operations);
 
 		if (invalidate) {
 			this.invalidate();
@@ -227,7 +227,7 @@ export class Store<T = any> extends Evented implements MutableState<T> {
 	};
 
 	public at = <U = any>(path: Path<T, Array<U>>, index: number): Path<T, U> => {
-		return this._state.at(path, index);
+		return this._adapter.at(path, index);
 	};
 
 	public onChange = <U = any>(paths: Path<T, U> | Path<T, U>[], callback: () => void) => {
@@ -266,7 +266,7 @@ export class Store<T = any> extends Evented implements MutableState<T> {
 			const { previousValue, callbacks } = value;
 			const pointer = new Pointer(path);
 			const newValue = pointer.segments.length
-				? this._state.path(pointer.segments[0] as keyof T, ...pointer.segments.slice(1)).value
+				? this._adapter.path(pointer.segments[0] as keyof T, ...pointer.segments.slice(1)).value
 				: undefined;
 			if (previousValue !== newValue) {
 				this._changePaths.set(path, { callbacks, previousValue: newValue });
@@ -289,7 +289,7 @@ export class Store<T = any> extends Evented implements MutableState<T> {
 		this.emit({ type: 'invalidate' });
 	}
 
-	public path: State<T>['path'] = this._state.path.bind(this._state);
+	public path: State<T>['path'] = this._adapter.path.bind(this._adapter);
 }
 
 export default Store;

--- a/src/stores/Store.ts
+++ b/src/stores/Store.ts
@@ -209,6 +209,7 @@ export class Store<T = any> extends Evented implements MutableState<T> {
 		super();
 		if (options && options.state) {
 			this._state = options.state;
+			this.path = this._state.path.bind(this._state);
 		}
 	}
 
@@ -263,7 +264,10 @@ export class Store<T = any> extends Evented implements MutableState<T> {
 		const callbackIdsCalled: number[] = [];
 		this._changePaths.forEach((value: OnChangeValue, path: string) => {
 			const { previousValue, callbacks } = value;
-			const newValue = new Pointer(path).get(this._state);
+			const pointer = new Pointer(path);
+			const newValue = pointer.segments.length
+				? this._state.path(pointer.segments[0] as keyof T, ...pointer.segments.slice(1)).value
+				: undefined;
 			if (previousValue !== newValue) {
 				this._changePaths.set(path, { callbacks, previousValue: newValue });
 				callbacks.forEach((callbackItem) => {

--- a/src/stores/state/ImmutableState.ts
+++ b/src/stores/state/ImmutableState.ts
@@ -7,14 +7,22 @@ import {
 } from './Patch';
 import { Pointer } from './Pointer';
 import { MutableState, Path, State } from '../Store';
-import { Map, List } from 'immutable';
+import { Map as _Map, List as _List } from 'immutable';
+let Map: typeof _Map;
+let List: typeof _List;
+try {
+	const immutable = require('immutable');
+	Map = immutable.Map;
+	List = immutable.List;
+} catch (ex) {}
+
 import { getFriendlyDifferenceMessage, isEqual } from './compare';
 
 function isString(segment?: string): segment is string {
 	return typeof segment === 'string';
 }
 
-function inverse(operation: PatchOperation, state: Map<any, any>): PatchOperation[] {
+function inverse(operation: PatchOperation, state: _Map<any, any>): PatchOperation[] {
 	if (operation.op === OperationType.ADD) {
 		const op: RemovePatchOperation = {
 			op: OperationType.REMOVE,
@@ -59,7 +67,7 @@ function inverse(operation: PatchOperation, state: Map<any, any>): PatchOperatio
 }
 
 export class ImmutableState<T = any> implements MutableState<T> {
-	private _state = Map();
+	private _state: _Map<any, any> = Map();
 
 	/**
 	 * Returns the state at a specific pointer path location.
@@ -140,7 +148,7 @@ export class ImmutableState<T = any> implements MutableState<T> {
 		return undoOperations;
 	}
 
-	private setIn(segments: string[], value: any, state: Map<any, any>, add = false) {
+	private setIn(segments: string[], value: any, state: _Map<any, any>, add = false) {
 		const updated = this.set(segments, value, state, add);
 		if (updated) {
 			return updated;
@@ -148,13 +156,13 @@ export class ImmutableState<T = any> implements MutableState<T> {
 
 		state = state.withMutations((map) => {
 			segments.slice(0, segments.length - 1).forEach((segment, index) => {
-				let nextSegment = '';
+				let nextSegment: any = '';
 				if (index + 1 < segments.length) {
 					nextSegment = segments[index + 1];
 				}
 				const value = state.getIn([...segments.slice(0, index), segment]);
 				if (!value || !(value instanceof List || value instanceof Map)) {
-					if (!isNaN(parseInt(nextSegment, 10))) {
+					if (!isNaN(nextSegment) && !isNaN(parseInt(nextSegment, 0))) {
 						map = map.setIn([...segments.slice(0, index), segment], List());
 					} else {
 						map = map.setIn([...segments.slice(0, index), segment], Map());
@@ -166,7 +174,7 @@ export class ImmutableState<T = any> implements MutableState<T> {
 		return this.set(segments, value, state, add) || state;
 	}
 
-	private set(segments: string[], value: any, state: Map<any, any>, add = false) {
+	private set(segments: string[], value: any, state: _Map<any, any>, add = false) {
 		if (typeof value === 'object' && value != null) {
 			if (Array.isArray(value)) {
 				value = List(value);

--- a/src/stores/state/ImmutableState.ts
+++ b/src/stores/state/ImmutableState.ts
@@ -8,6 +8,7 @@ import {
 import { Pointer } from './Pointer';
 import { MutableState, Path, State } from '../Store';
 import { Map, List } from 'immutable';
+import { getFriendlyDifferenceMessage, isEqual } from './compare';
 
 function isString(segment?: string): segment is string {
 	return typeof segment === 'string';
@@ -118,9 +119,15 @@ export class ImmutableState<T = any> implements MutableState<T> {
 					break;
 				case OperationType.TEST:
 					const current = state.getIn(next.path.segments);
-					if (!current === next.value && !(current && current.equals && current.equals(next.value))) {
+					const currentValue = current && current.toJS ? current.toJS() : current;
+					if (!isEqual(currentValue, next.value)) {
 						const location = next.path.path;
-						throw new Error(`Test operation failure at "${location}".`);
+						throw new Error(
+							`Test operation failure at "${location}". ${getFriendlyDifferenceMessage(
+								next.value,
+								currentValue
+							)}.`
+						);
 					}
 					return state;
 				default:

--- a/src/stores/state/ImmutableState.ts
+++ b/src/stores/state/ImmutableState.ts
@@ -1,0 +1,136 @@
+import {
+	PatchOperation,
+	OperationType,
+	RemovePatchOperation,
+	ReplacePatchOperation,
+	TestPatchOperation
+} from './Patch';
+import { Pointer } from './Pointer';
+import { MutableState, Path, State } from '../Store';
+import { Map, List } from 'immutable';
+
+function isString(segment?: string): segment is string {
+	return typeof segment === 'string';
+}
+
+function inverse(operation: PatchOperation, state: Map<any, any>): PatchOperation[] {
+	if (operation.op === OperationType.ADD) {
+		const op: RemovePatchOperation = {
+			op: OperationType.REMOVE,
+			path: operation.path
+		};
+		const test: TestPatchOperation = {
+			op: OperationType.TEST,
+			path: operation.path,
+			value: operation.value
+		};
+		return [test, op];
+	} else if (operation.op === OperationType.REPLACE) {
+		const value = state.getIn(operation.path.segments);
+		let op: RemovePatchOperation | ReplacePatchOperation;
+		if (value === undefined) {
+			op = {
+				op: OperationType.REMOVE,
+				path: operation.path
+			};
+		} else {
+			op = {
+				op: OperationType.REPLACE,
+				path: operation.path,
+				value: state.getIn(operation.path.segments)
+			};
+		}
+		const test: TestPatchOperation = {
+			op: OperationType.TEST,
+			path: operation.path,
+			value: operation.value
+		};
+		return [test, op];
+	} else {
+		return [
+			{
+				op: OperationType.ADD,
+				path: operation.path,
+				value: state.getIn(operation.path.segments)
+			}
+		];
+	}
+}
+
+export class ImmutableState<T = any> implements MutableState<T> {
+	private _state = Map();
+
+	/**
+	 * Returns the state at a specific pointer path location.
+	 */
+	public get = <U = any>(path: Path<T, U>): U => {
+		return path.value;
+	};
+
+	public at = <U = any>(path: Path<T, Array<U>>, index: number): Path<T, U> => {
+		const array = this.get(path);
+		const value = array && array[index];
+
+		return {
+			path: `${path.path}/${index}`,
+			state: path.state,
+			value
+		};
+	};
+
+	public path: State<T>['path'] = (path: string | Path<T, any>, ...segments: (string | undefined)[]) => {
+		if (typeof path === 'string') {
+			segments = [path, ...segments];
+		} else {
+			segments = [...new Pointer(path.path).segments, ...segments];
+		}
+
+		const stringSegments = segments.filter<string>(isString);
+		const hasMultipleSegments = stringSegments.length > 1;
+		const pointer = new Pointer(hasMultipleSegments ? stringSegments : stringSegments[0] || '');
+
+		return {
+			path: pointer.path,
+			state: this._state as any,
+			value: pointer.get(this._state)
+		};
+	};
+
+	public apply(operations: PatchOperation<T>[]): PatchOperation<T>[] {
+		let undoOperations: PatchOperation<T>[] = [];
+
+		const newState = operations.reduce((state, next) => {
+			switch (next.op) {
+				case OperationType.ADD:
+					const segments = next.path.segments.slice();
+					const lastSegment = segments.pop();
+					const parent = state.getIn(segments);
+					if (parent instanceof List) {
+						state = state.setIn(segments, parent.insert(lastSegment, next.value));
+					} else {
+						state = state.setIn([...segments, lastSegment], next.value);
+					}
+					break;
+				case OperationType.REPLACE:
+					state = state.setIn(next.path.segments, next.value);
+					break;
+				case OperationType.REMOVE:
+					state = state.removeIn(next.path.segments);
+					break;
+				case OperationType.TEST:
+					const current = state.getIn(next.path.segments);
+					if (current === next.value || (current && current.equals && current.equals(next.value))) {
+						const location = next.path.path;
+						throw new Error(`Test operation failure at "${location}".`);
+					}
+					return state;
+				default:
+					throw new Error('Unknown operation');
+			}
+			undoOperations = [...inverse(next, state), ...undoOperations];
+			return state;
+		}, this._state);
+		this._state = newState;
+		return undoOperations;
+	}
+}

--- a/src/stores/state/ImmutableState.ts
+++ b/src/stores/state/ImmutableState.ts
@@ -10,11 +10,10 @@ import { MutableState, Path, State } from '../Store';
 import { Map as _Map, List as _List } from 'immutable';
 let Map: typeof _Map;
 let List: typeof _List;
-try {
-	const immutable = require('immutable');
+import('immutable').then((immutable) => {
 	Map = immutable.Map;
 	List = immutable.List;
-} catch (ex) {}
+});
 
 import { getFriendlyDifferenceMessage, isEqual } from './compare';
 

--- a/src/stores/state/ImmutableState.ts
+++ b/src/stores/state/ImmutableState.ts
@@ -7,13 +7,7 @@ import {
 } from './Patch';
 import { Pointer } from './Pointer';
 import { MutableState, Path, State } from '../Store';
-import { Map as _Map, List as _List } from 'immutable';
-let Map: typeof _Map;
-let List: typeof _List;
-import('immutable').then((immutable) => {
-	Map = immutable.Map;
-	List = immutable.List;
-});
+import { Map, List } from 'immutable';
 
 import { getFriendlyDifferenceMessage, isEqual } from './compare';
 
@@ -21,7 +15,7 @@ function isString(segment?: string): segment is string {
 	return typeof segment === 'string';
 }
 
-function inverse(operation: PatchOperation, state: _Map<any, any>): PatchOperation[] {
+function inverse(operation: PatchOperation, state: Map<any, any>): PatchOperation[] {
 	if (operation.op === OperationType.ADD) {
 		const op: RemovePatchOperation = {
 			op: OperationType.REMOVE,
@@ -66,7 +60,7 @@ function inverse(operation: PatchOperation, state: _Map<any, any>): PatchOperati
 }
 
 export class ImmutableState<T = any> implements MutableState<T> {
-	private _state: _Map<any, any> = Map();
+	private _state: Map<any, any> = Map();
 
 	/**
 	 * Returns the state at a specific pointer path location.
@@ -147,7 +141,7 @@ export class ImmutableState<T = any> implements MutableState<T> {
 		return undoOperations;
 	}
 
-	private setIn(segments: string[], value: any, state: _Map<any, any>, add = false) {
+	private setIn(segments: string[], value: any, state: Map<any, any>, add = false) {
 		const updated = this.set(segments, value, state, add);
 		if (updated) {
 			return updated;
@@ -173,7 +167,7 @@ export class ImmutableState<T = any> implements MutableState<T> {
 		return this.set(segments, value, state, add) || state;
 	}
 
-	private set(segments: string[], value: any, state: _Map<any, any>, add = false) {
+	private set(segments: string[], value: any, state: Map<any, any>, add = false) {
 		if (typeof value === 'object' && value != null) {
 			if (Array.isArray(value)) {
 				value = List(value);

--- a/tests/stores/unit/middleware/localStorage.ts
+++ b/tests/stores/unit/middleware/localStorage.ts
@@ -62,12 +62,12 @@ describe('middleware - local storage', (suite) => {
 	it('should load from local storage', () => {
 		global.localStorage.setItem(LOCAL_STORAGE_TEST_ID, '[{"meta":{"path":"/counter"},"state":1}]');
 		load(LOCAL_STORAGE_TEST_ID, store);
-		assert.deepEqual((store as any)._state._state, { counter: 1 });
+		assert.deepEqual((store as any)._adapter._state, { counter: 1 });
 	});
 
 	it('should not load anything or throw an error if data does exist', () => {
 		global.localStorage.setItem('other-storage-id', '[{"meta":{"path":"/counter"},"state":1}]');
 		load(LOCAL_STORAGE_TEST_ID, store);
-		assert.deepEqual((store as any)._state._state, {});
+		assert.deepEqual((store as any)._adapter._state, {});
 	});
 });

--- a/tests/stores/unit/middleware/localStorage.ts
+++ b/tests/stores/unit/middleware/localStorage.ts
@@ -62,12 +62,12 @@ describe('middleware - local storage', (suite) => {
 	it('should load from local storage', () => {
 		global.localStorage.setItem(LOCAL_STORAGE_TEST_ID, '[{"meta":{"path":"/counter"},"state":1}]');
 		load(LOCAL_STORAGE_TEST_ID, store);
-		assert.deepEqual((store as any)._state, { counter: 1 });
+		assert.deepEqual((store as any)._state._state, { counter: 1 });
 	});
 
 	it('should not load anything or throw an error if data does exist', () => {
 		global.localStorage.setItem('other-storage-id', '[{"meta":{"path":"/counter"},"state":1}]');
 		load(LOCAL_STORAGE_TEST_ID, store);
-		assert.deepEqual((store as any)._state, {});
+		assert.deepEqual((store as any)._state._state, {});
 	});
 });

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -1,5 +1,7 @@
 const { beforeEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
+const { registerSuite } = intern.getPlugin('interface.benchmark');
+// import Test from 'intern/lib/Test';
 
 import { uuid } from '../../../src/core/util';
 import { Pointer } from './../../../src/stores/state/Pointer';
@@ -786,3 +788,104 @@ describe('process', () => {
 		return processExecutor({});
 	});
 });
+
+const performanceTestStore = new Store();
+const operations: PatchOperation[] = [];
+for (let i = 0; i < 100; i++) {
+	operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}`), value: {} });
+	for (let j = 0; j < 50; j++) {
+		operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}/${j}`), value: {} });
+		for (let k = 0; k < 10; k++) {
+			operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}/${j}/${k}`), value: k });
+		}
+	}
+}
+console.time('buildstore');
+performanceTestStore.apply(operations);
+console.timeEnd('buildstore');
+registerSuite('Normal performance', {
+	'update values'() {
+		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('foo/bar')]);
+		const processExecutor = process(performanceTestStore);
+		processExecutor({});
+	}
+});
+
+// registerSuite('Proxy performance', {
+// 	beforeEach() {
+// 		store = new Store();
+// 	},
+//
+// 	tests: {
+// 		'update values'() {
+// 			const process = createProcess('test', [
+// 				testProxyCommandFactory('foo'),
+// 				testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 				// testProxyCommandFactory('foo', 'bar'),
+// 			]);
+// 			const processExecutor = process(store);
+// 			processExecutor({});
+// 		}
+// 	}
+// });

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -1,6 +1,8 @@
+import { ImmutableState } from '../../../src/stores/state/ImmutableState';
+
 const { beforeEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
-const { registerSuite } = intern.getPlugin('interface.benchmark');
+// const { registerSuite } = intern.getPlugin('interface.benchmark');
 // import Test from 'intern/lib/Test';
 
 import { uuid } from '../../../src/core/util';
@@ -159,7 +161,7 @@ async function assertProxyError(test: () => void) {
 
 describe('process', () => {
 	beforeEach(() => {
-		store = new Store();
+		store = new Store({ state: new ImmutableState() });
 		promises = [];
 		promiseResolvers = [];
 	});
@@ -789,27 +791,29 @@ describe('process', () => {
 	});
 });
 
-const performanceTestStore = new Store();
-const operations: PatchOperation[] = [];
-for (let i = 0; i < 100; i++) {
-	operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}`), value: {} });
-	for (let j = 0; j < 50; j++) {
-		operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}/${j}`), value: {} });
-		for (let k = 0; k < 10; k++) {
-			operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}/${j}/${k}`), value: k });
-		}
-	}
-}
-console.time('buildstore');
-performanceTestStore.apply(operations);
-console.timeEnd('buildstore');
-registerSuite('Normal performance', {
-	'update values'() {
-		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('foo/bar')]);
-		const processExecutor = process(performanceTestStore);
-		processExecutor({});
-	}
-});
+// const performanceTestStore = new Store({
+// 	state: new ImmutableState()
+// });
+// const operations: PatchOperation[] = [];
+// for (let i = 0; i < 100; i++) {
+// 	operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}`), value: {} });
+// 	for (let j = 0; j < 50; j++) {
+// 		operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}/${j}`), value: {} });
+// 		for (let k = 0; k < 10; k++) {
+// 			operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}/${j}/${k}`), value: k });
+// 		}
+// 	}
+// }
+// console.time('buildstore');
+// performanceTestStore.apply(operations);
+// console.timeEnd('buildstore');
+// registerSuite('Normal performance', {
+// 	'update values'() {
+// 		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('foo/bar')]);
+// 		const processExecutor = process(performanceTestStore);
+// 		processExecutor({});
+// 	}
+// });
 
 // registerSuite('Proxy performance', {
 // 	beforeEach() {

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -2,8 +2,6 @@ import { ImmutableState } from '../../../src/stores/state/ImmutableState';
 
 const { beforeEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
-// const { registerSuite } = intern.getPlugin('interface.benchmark');
-// import Test from 'intern/lib/Test';
 
 import { uuid } from '../../../src/core/util';
 import { Pointer } from './../../../src/stores/state/Pointer';
@@ -19,7 +17,7 @@ import {
 	ProcessCallbackAfter,
 	createCallbackDecorator
 } from '../../../src/stores/process';
-import { Store } from '../../../src/stores/Store';
+import { Store, MutableState } from '../../../src/stores/Store';
 import { replace, add } from '../../../src/stores/state/operations';
 
 let store: Store;
@@ -159,737 +157,646 @@ async function assertProxyError(test: () => void) {
 	}
 }
 
-describe('process', () => {
-	beforeEach(() => {
-		store = new Store({ state: new ImmutableState() });
-		promises = [];
-		promiseResolvers = [];
-	});
+const tests = (stateType: string, state?: () => MutableState<any>) => {
+	describe(`process - ${stateType}`, () => {
+		beforeEach(() => {
+			store = new Store({ state: state ? state() : undefined });
+			promises = [];
+			promiseResolvers = [];
+		});
 
-	it('with synchronous commands running in order', () => {
-		const process = createProcess('test', [[testCommandFactory('foo')], testCommandFactory('foo/bar')]);
-		const processExecutor = process(store);
-		processExecutor({});
-		const foo = store.get(store.path('foo'));
-		const foobar = store.get(store.path('foo', 'bar'));
-		assert.deepEqual(foo, { bar: 'foo/bar' });
-		assert.strictEqual(foobar, 'foo/bar');
-	});
-
-	it('should handle optional properties for updates', () => {
-		type StateType = { a?: { b?: string }; foo?: number; bar: string };
-		const createCommand = createCommandFactory<StateType>();
-
-		createProcess('test', [
-			createCommand(({ path }) => [
-				{
-					op: OperationType.ADD,
-					path: new Pointer(path('foo').path),
-					value: 3
-				}
-			]),
-			createCommand(({ path }) => [
-				{
-					op: OperationType.ADD,
-					path: new Pointer(path('a', 'b').path),
-					value: 'foo'
-				}
-			])
-		])(store)({});
-
-		assert.equal(store.get(store.path('a', 'b')), 'foo');
-		assert.equal(store.get(store.path('foo')), 3);
-	});
-
-	it('handles commands modifying the state proxy directly', async () => {
-		await assertProxyError(async () => {
-			const process = createProcess('test', [
-				[testProxyCommandFactory('foo')],
-				testProxyCommandFactory('foo', 'bar')
-			]);
+		it('with synchronous commands running in order', () => {
+			const process = createProcess('test', [[testCommandFactory('foo')], testCommandFactory('foo/bar')]);
 			const processExecutor = process(store);
-			const promise = processExecutor({});
-
-			if (typeof Proxy !== 'undefined') {
-				const foo = store.get(store.path('foo'));
-				const foobar = store.get(store.path('foo', 'bar'));
-				assert.deepEqual(foo, { bar: 'foo/bar' });
-				assert.strictEqual(foobar, 'foo/bar');
-			} else {
-				await promise;
-			}
-		});
-	});
-
-	it('Can set a proxied property to itself', async () => {
-		await assertProxyError(async () => {
-			const process = createProcess('test', [
-				testSetCurrentTodo,
-				testSelfAssignment,
-				testUpdateTodoCountsCommand,
-				testUpdateCompletedFlagCommand
-			]);
-			const promises = [process(store)({ label: 'label-1' }), process(store)({ label: 'label-2' })];
-			if (typeof Proxy !== 'undefined') {
-				const todos = store.get(store.path('todos'));
-				const todoCount = store.get(store.path('todoCount'));
-				const completedCount = store.get(store.path('completedCount'));
-				assert.strictEqual(Object.keys(todos).length, 2);
-				assert.strictEqual(todoCount, 2);
-				assert.strictEqual(completedCount, 0);
-			} else {
-				await Promise.all(promises);
-			}
-		});
-	});
-
-	it('processes wait for asynchronous commands to complete before continuing', () => {
-		const process = createProcess('test', [
-			testCommandFactory('foo'),
-			testAsyncCommandFactory('bar'),
-			testCommandFactory('foo/bar')
-		]);
-		const processExecutor = process(store);
-		const promise = processExecutor({});
-		const foo = store.get(store.path('foo'));
-		const bar = store.get(store.path('bar'));
-		assert.strictEqual(foo, 'foo');
-		assert.isUndefined(bar);
-		promiseResolver();
-		return promise.then(() => {
+			processExecutor({});
 			const foo = store.get(store.path('foo'));
-			const bar = store.get(store.path('bar'));
 			const foobar = store.get(store.path('foo', 'bar'));
 			assert.deepEqual(foo, { bar: 'foo/bar' });
-			assert.strictEqual(bar, 'bar');
 			assert.strictEqual(foobar, 'foo/bar');
 		});
-	});
 
-	it('does not make updates till async processes that modify the proxy resolve', async () => {
-		await assertProxyError(async () => {
-			const process = createProcess('test', [testAsyncProxyCommandFactory('foo')]);
-			const processExecutor = process(store);
-			const promise = processExecutor({});
+		it('should handle optional properties for updates', () => {
+			type StateType = { a?: { b?: string }; foo?: number; bar: string };
+			const createCommand = createCommandFactory<StateType>();
 
-			let foo = store.get(store.path('foo'));
-			assert.isUndefined(foo);
+			createProcess('test', [
+				createCommand(({ path }) => [
+					{
+						op: OperationType.ADD,
+						path: new Pointer(path('foo').path),
+						value: 3
+					}
+				]),
+				createCommand(({ path }) => [
+					{
+						op: OperationType.ADD,
+						path: new Pointer(path('a', 'b').path),
+						value: 'foo'
+					}
+				])
+			])(store)({});
 
-			promiseResolver();
-			await promise;
-			foo = store.get(store.path('foo'));
-			assert.equal(foo, 'foo');
+			assert.equal(store.get(store.path('a', 'b')), 'foo');
+			assert.equal(store.get(store.path('foo')), 3);
 		});
-	});
 
-	it('waits for asynchronous commands to complete before continuing with proxy updates', async () => {
-		await assertProxyError(async () => {
-			const process = createProcess('test', [
-				testProxyCommandFactory('foo'),
-				testAsyncProxyCommandFactory('bar'),
-				testProxyCommandFactory('foo', 'bar')
-			]);
-			const processExecutor = process(store);
-			const promise = processExecutor({});
+		it('handles commands modifying the state proxy directly', async () => {
+			await assertProxyError(async () => {
+				const process = createProcess('test', [
+					[testProxyCommandFactory('foo')],
+					testProxyCommandFactory('foo', 'bar')
+				]);
+				const processExecutor = process(store);
+				const promise = processExecutor({});
 
-			let foo;
-			let bar;
-
-			if (typeof Proxy !== 'undefined') {
-				foo = store.get(store.path('foo'));
-				bar = store.get(store.path('bar'));
-				assert.strictEqual(foo, 'foo');
-				assert.isUndefined(bar);
-			}
-
-			promiseResolver();
-			await promise;
-			foo = store.get(store.path('foo'));
-			bar = store.get(store.path('bar'));
-			const foobar = store.get(store.path('foo', 'bar'));
-			assert.deepEqual(foo, { bar: 'foo/bar' });
-			assert.strictEqual(bar, 'bar');
-			assert.strictEqual(foobar, 'foo/bar');
-		});
-	});
-
-	it('updates the proxy as it is being modified', async () => {
-		await assertProxyError(async () => {
-			const process = createProcess('test', [testIterativeProxyCommand]);
-			const processExecutor = process(store);
-			const promise = processExecutor({});
-
-			if (typeof Proxy !== 'undefined') {
-				const itemCount = store.get(store.path('itemCount'));
-				assert.equal(itemCount, 10);
-				const finalCount = store.get(store.path('finalCount'));
-				assert.equal(finalCount, 9);
-				const items = store.get(store.path('items'));
-				assert.deepEqual(items, [0, 1, 2, 3, 4, { foo: { bar: 'baz' } }, { bar: 'baz' }, 8, 9]);
-				const temp = store.get(store.path('temp'));
-				assert.isUndefined(temp);
-			}
-
-			await promise;
-		});
-	});
-
-	it('support concurrent commands executed synchronously', () => {
-		const process = createProcess('test', [
-			testCommandFactory('foo'),
-			[testAsyncCommandFactory('bar'), testAsyncCommandFactory('baz')],
-			testCommandFactory('foo/bar')
-		]);
-		const processExecutor = process(store);
-		const promise = processExecutor({});
-		promiseResolvers[0]();
-		return promises[0].then(() => {
-			const bar = store.get(store.path('bar'));
-			const baz = store.get(store.path('baz'));
-			assert.isUndefined(bar);
-			assert.isUndefined(baz);
-			promiseResolver();
-			return promise.then(() => {
-				const bar = store.get(store.path('bar'));
-				const baz = store.get(store.path('baz'));
-				assert.strictEqual(bar, 'bar');
-				assert.strictEqual(baz, 'baz');
+				if (typeof Proxy !== 'undefined') {
+					const foo = store.get(store.path('foo'));
+					const foobar = store.get(store.path('foo', 'bar'));
+					assert.deepEqual(foo, { bar: 'foo/bar' });
+					assert.strictEqual(foobar, 'foo/bar');
+				} else {
+					await promise;
+				}
 			});
 		});
-	});
 
-	it('passes the payload to each command', () => {
-		const process = createProcess('test', [
-			testCommandFactory('foo'),
-			testCommandFactory('bar'),
-			testCommandFactory('baz')
-		]);
-		const processExecutor = process(store);
-		processExecutor({ payload: 'payload' });
-		const foo = store.get(store.path('foo'));
-		const bar = store.get(store.path('bar'));
-		const baz = store.get(store.path('baz'));
-		assert.deepEqual(foo, { payload: 'payload' });
-		assert.deepEqual(bar, { payload: 'payload' });
-		assert.deepEqual(baz, { payload: 'payload' });
-	});
-
-	it('can use a transformer for the arguments passed to the process executor', () => {
-		const process = createProcess<any, { foo: string }>('test', [
-			testCommandFactory('foo'),
-			testCommandFactory('bar'),
-			testCommandFactory('baz')
-		]);
-		const processExecutorOne = process(store, (payload: { foo: number }) => {
-			return { foo: 'changed' };
-		});
-
-		const processExecutorTwo = process(store);
-
-		processExecutorTwo({ foo: '' });
-		processExecutorOne({ foo: 1 });
-		// processExecutorOne({ foo: '' }); // doesn't compile
-
-		const foo = store.get(store.path('foo'));
-		const bar = store.get(store.path('bar'));
-		const baz = store.get(store.path('baz'));
-		assert.deepEqual(foo, { foo: 'changed' });
-		assert.deepEqual(bar, { foo: 'changed' });
-		assert.deepEqual(baz, { foo: 'changed' });
-	});
-
-	it('provides a command factory', () => {
-		const createCommand = createCommandFactory<{ foo: string }, { foo: string }>();
-
-		const command = createCommand(({ get, path, payload }) => {
-			// get(path('bar')); // shouldn't compile
-			payload.foo;
-			// payload.bar; // shouldn't compile
-			get(path('foo'));
-			return [];
-		});
-
-		assert.equal(typeof command, 'function');
-	});
-
-	it('should add object by integer like index key', () => {
-		const id = '3fe3c6d3-15e1-4d77-886f-daeb0ed63458';
-		const createCommand = createCommandFactory<any>();
-		const command = createCommand(({ get, path, payload }) => {
-			return [add(path('test', id), { foo: 'bar' })];
-		});
-		const process = createProcess('test', [command]);
-		const executor = process(store);
-		executor({});
-		assert.deepEqual(store.get(store.path('test')), { [id]: { foo: 'bar' } });
-	});
-
-	it('can type payload that extends an object', () => {
-		const createCommandOne = createCommandFactory<any, { foo: string }>();
-		const createCommandTwo = createCommandFactory<any, { bar: string }>();
-		const createCommandThree = createCommandFactory();
-		const commandOne = createCommandOne(({ get, path, payload }) => []);
-		const commandTwo = createCommandTwo(({ get, path, payload }) => []);
-		const commandThree = createCommandThree(({ get, path, payload }) => []);
-		const processOne = createProcess<any, { foo: string; bar: string }>('test', [commandOne, commandTwo]);
-		// createProcess('test', [commandOne, commandTwo]); // shouldn't compile
-		// createProcess<any, { bar: string }>([commandOne]); // shouldn't compile
-		const processTwo = createProcess('test', [commandTwo]);
-		const processThree = createProcess('test', [commandThree]);
-		const executorOne = processOne(store);
-		const executorTwo = processTwo(store);
-		const executorThree = processThree(store);
-
-		// executorOne({}); // shouldn't compile
-		// executorOne({ foo: 1 }); // shouldn't compile
-		executorOne({ foo: 'bar', bar: 'string' });
-		executorTwo({ bar: 'bar' });
-		// executorTwo({}); // shouldn't compile;
-		// executorTwo(1); // shouldn't compile
-		// executorTwo(''); // shouldn't compile
-		// executorThree(); // shouldn't compile
-		executorThree({});
-	});
-
-	it('if a transformer is provided it determines the payload type', () => {
-		const createCommandOne = createCommandFactory<any, { bar: number }>();
-		const createCommandTwo = createCommandFactory<any, { foo: number }>();
-		const commandOne = createCommandOne(({ get, path, payload }) => []);
-		const commandTwo = createCommandTwo(({ get, path, payload }) => []);
-		const transformerOne = (payload: { foo: string }): { bar: number } => {
-			return {
-				bar: 1
-			};
-		};
-		const transformerTwo = (payload: { foo: number }): { bar: number; foo: number } => {
-			return {
-				bar: 1,
-				foo: 2
-			};
-		};
-
-		const processOne = createProcess('test', [commandOne]);
-		const processTwo = createProcess<any, { bar: number; foo: number }>('test', [commandOne, commandTwo]);
-		const processOneResult = processOne(store, transformerOne)({ foo: '' });
-		// processTwo(store, transformerOne); // compile error
-		const processTwoResult = processTwo(store, transformerTwo)({ foo: 3 });
-		// processTwo(store)({ foo: 3 }); // compile error
-		processOneResult.then((result) => {
-			result.payload.bar.toPrecision();
-			result.executor(processTwo, { foo: 3, bar: 1 });
-			// result.executor(processTwo, { foo: 3, bar: '' }); // compile error
-			result.executor(processTwo, { foo: 1 }, transformerTwo);
-			// result.executor(processTwo, { foo: '' }, transformerTwo); // compile error
-			// result.payload.bar.toUpperCase(); // compile error
-			// result.payload.foo; // compile error
-		});
-		processTwoResult.then((result) => {
-			result.payload.bar.toPrecision();
-			result.payload.foo.toPrecision();
-			// result.payload.bar.toUpperCase(); // compile error
-			// result.payload.foo.toUpperCase(); // compile error
-		});
-	});
-
-	it('can provide a callback that gets called on process completion', () => {
-		let callbackCalled = false;
-		const process = createProcess('test', [testCommandFactory('foo')], () => ({
-			after: () => {
-				callbackCalled = true;
-			}
-		}));
-		const processExecutor = process(store);
-		processExecutor({});
-		assert.isTrue(callbackCalled);
-	});
-
-	it('when a command errors, the error and command is returned in the error argument of the callback', async () => {
-		const process = createProcess('test', [testCommandFactory('foo'), testErrorCommand], () => ({
-			after: (error) => {
-				assert.isNotNull(error);
-				assert.equal(error && error.error && error.error.message, 'Command Failed');
-				assert.strictEqual(error && error.command, testErrorCommand);
-			}
-		}));
-		const processExecutor = process(store);
-		await processExecutor({});
-	});
-
-	it('a command that does not return results does not break other commands', () => {
-		const process = createProcess('test', [testCommandFactory('foo'), testNoop], () => ({
-			after: (error) => {
-				assert.isNull(error);
-				assert.strictEqual(store.get(store.path('foo')), 'foo');
-			}
-		}));
-		const processExecutor = process(store);
-		processExecutor({});
-	});
-
-	it('executor can be used to programmatically run additional processes', () => {
-		const extraProcess = createProcess('test', [testCommandFactory('bar')]);
-		const process = createProcess('test', [testCommandFactory('foo')], () => ({
-			after: (error, result) => {
-				assert.isNull(error);
-				let bar = store.get(store.path('bar'));
-				assert.isUndefined(bar);
-				result.executor(extraProcess, {});
-				bar = store.get(store.path('bar'));
-				assert.strictEqual(bar, 'bar');
-			}
-		}));
-		const processExecutor = process(store);
-		processExecutor({});
-	});
-
-	it('process decorator should convert callbacks to after callback', () => {
-		let callbackArray: string[] = [];
-		const legacyCallbackOne: ProcessCallbackAfter = (error, result) => {
-			callbackArray.push('one');
-		};
-		const legacyCallbackTwo: ProcessCallbackAfter = (error, result) => {
-			callbackArray.push('two');
-		};
-
-		const decoratorOne = createCallbackDecorator(legacyCallbackOne);
-		const decoratorTwo = createCallbackDecorator(legacyCallbackTwo);
-
-		const callbackOne: ProcessCallback = () => ({
-			after: (error, result) => {
-				callbackArray.push('one');
-			}
-		});
-		const callbackTwo: ProcessCallback = () => ({
-			after: (error, result) => {
-				callbackArray.push('two');
-			}
-		});
-
-		const process = createProcess('decorator-test', [], [callbackOne, callbackTwo]);
-		const processWithLegacyMiddleware = createProcess(
-			'createCallbackDecorator-test',
-			[],
-			decoratorOne(decoratorTwo())
-		);
-		const processExecutor = process(store);
-		const legacyMiddlewareProcessExecutor = processWithLegacyMiddleware(store);
-		processExecutor({});
-		assert.deepEqual(callbackArray, ['one', 'two']);
-		callbackArray = [];
-		legacyMiddlewareProcessExecutor({});
-		assert.deepEqual(callbackArray, ['one', 'two']);
-	});
-
-	it('Creating a process returned automatically decorates all process callbacks', () => {
-		let results: string[] = [];
-
-		const callback: ProcessCallback = () => ({
-			after: (error, result): void => {
-				results.push('callback one');
-			}
-		});
-
-		const callbackTwo = () => ({
-			after: (error: ProcessError | null, result: ProcessResult): void => {
-				results.push('callback two');
-				result.payload;
-			}
-		});
-
-		const logPointerCallback = () => ({
-			after: (error: ProcessError | null, result: ProcessResult<{ logs: string[][] }>): void => {
-				const paths = result.operations.map((operation) => operation.path.path);
-				const logs = result.get(store.path('logs')) || [];
-
-				result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
-			}
-		});
-
-		const createProcess = createProcessFactoryWith([callback, callbackTwo, logPointerCallback]);
-
-		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('bar')]);
-		const executor = process(store);
-		executor({});
-		assert.lengthOf(results, 2);
-		assert.strictEqual(results[0], 'callback one');
-		assert.strictEqual(results[1], 'callback two');
-		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar']]);
-		executor({});
-		assert.lengthOf(results, 4);
-		assert.strictEqual(results[0], 'callback one');
-		assert.strictEqual(results[1], 'callback two');
-		assert.strictEqual(results[2], 'callback one');
-		assert.strictEqual(results[3], 'callback two');
-		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
-	});
-
-	it('Creating a process automatically decorates all process initializers', async () => {
-		let initialization: string[] = [];
-		let firstCall = true;
-
-		const initializer: ProcessCallback = () => ({
-			before: async (payload, store) => {
-				initialization.push('initializer one');
-				const initLog = store.get(store.path('initLogs')) || [];
-				store.apply([
-					{ op: OperationType.ADD, path: new Pointer(`/initLogs/${initLog.length}`), value: 'initial value' }
+		it('Can set a proxied property to itself', async () => {
+			await assertProxyError(async () => {
+				const process = createProcess('test', [
+					testSetCurrentTodo,
+					testSelfAssignment,
+					testUpdateTodoCountsCommand,
+					testUpdateCompletedFlagCommand
 				]);
-			}
+				const promises = [process(store)({ label: 'label-1' }), process(store)({ label: 'label-2' })];
+				if (typeof Proxy !== 'undefined') {
+					const todos = store.get(store.path('todos'));
+					const todoCount = store.get(store.path('todoCount'));
+					const completedCount = store.get(store.path('completedCount'));
+					assert.strictEqual(Object.keys(todos).length, 2);
+					assert.strictEqual(todoCount, 2);
+					assert.strictEqual(completedCount, 0);
+				} else {
+					await Promise.all(promises);
+				}
+			});
 		});
 
-		const initializerTwo = () => ({
-			before: async (payload: any) => {
-				initialization.push('initializer two');
-				payload.foo;
-				await new Promise((resolve) => {
-					setTimeout(resolve, 100);
+		it('processes wait for asynchronous commands to complete before continuing', () => {
+			const process = createProcess('test', [
+				testCommandFactory('foo'),
+				testAsyncCommandFactory('bar'),
+				testCommandFactory('foo/bar')
+			]);
+			const processExecutor = process(store);
+			const promise = processExecutor({});
+			const foo = store.get(store.path('foo'));
+			const bar = store.get(store.path('bar'));
+			assert.strictEqual(foo, 'foo');
+			assert.isUndefined(bar);
+			promiseResolver();
+			return promise.then(() => {
+				const foo = store.get(store.path('foo'));
+				const bar = store.get(store.path('bar'));
+				const foobar = store.get(store.path('foo', 'bar'));
+				assert.deepEqual(foo, { bar: 'foo/bar' });
+				assert.strictEqual(bar, 'bar');
+				assert.strictEqual(foobar, 'foo/bar');
+			});
+		});
+
+		it('does not make updates till async processes that modify the proxy resolve', async () => {
+			await assertProxyError(async () => {
+				const process = createProcess('test', [testAsyncProxyCommandFactory('foo')]);
+				const processExecutor = process(store);
+				const promise = processExecutor({});
+
+				let foo = store.get(store.path('foo'));
+				assert.isUndefined(foo);
+
+				promiseResolver();
+				await promise;
+				foo = store.get(store.path('foo'));
+				assert.equal(foo, 'foo');
+			});
+		});
+
+		it('waits for asynchronous commands to complete before continuing with proxy updates', async () => {
+			await assertProxyError(async () => {
+				const process = createProcess('test', [
+					testProxyCommandFactory('foo'),
+					testAsyncProxyCommandFactory('bar'),
+					testProxyCommandFactory('foo', 'bar')
+				]);
+				const processExecutor = process(store);
+				const promise = processExecutor({});
+
+				let foo;
+				let bar;
+
+				if (typeof Proxy !== 'undefined') {
+					foo = store.get(store.path('foo'));
+					bar = store.get(store.path('bar'));
+					assert.strictEqual(foo, 'foo');
+					assert.isUndefined(bar);
+				}
+
+				promiseResolver();
+				await promise;
+				foo = store.get(store.path('foo'));
+				bar = store.get(store.path('bar'));
+				const foobar = store.get(store.path('foo', 'bar'));
+				assert.deepEqual(foo, { bar: 'foo/bar' });
+				assert.strictEqual(bar, 'bar');
+				assert.strictEqual(foobar, 'foo/bar');
+			});
+		});
+
+		it('updates the proxy as it is being modified', async () => {
+			await assertProxyError(async () => {
+				const process = createProcess('test', [testIterativeProxyCommand]);
+				const processExecutor = process(store);
+				const promise = processExecutor({});
+
+				if (typeof Proxy !== 'undefined') {
+					const itemCount = store.get(store.path('itemCount'));
+					assert.equal(itemCount, 10);
+					const finalCount = store.get(store.path('finalCount'));
+					assert.equal(finalCount, 9);
+					const items = store.get(store.path('items'));
+					assert.deepEqual(items, [0, 1, 2, 3, 4, { foo: { bar: 'baz' } }, { bar: 'baz' }, 8, 9]);
+					const temp = store.get(store.path('temp'));
+					assert.isUndefined(temp);
+				}
+
+				await promise;
+			});
+		});
+
+		it('support concurrent commands executed synchronously', () => {
+			const process = createProcess('test', [
+				testCommandFactory('foo'),
+				[testAsyncCommandFactory('bar'), testAsyncCommandFactory('baz')],
+				testCommandFactory('foo/bar')
+			]);
+			const processExecutor = process(store);
+			const promise = processExecutor({});
+			promiseResolvers[0]();
+			return promises[0].then(() => {
+				const bar = store.get(store.path('bar'));
+				const baz = store.get(store.path('baz'));
+				assert.isUndefined(bar);
+				assert.isUndefined(baz);
+				promiseResolver();
+				return promise.then(() => {
+					const bar = store.get(store.path('bar'));
+					const baz = store.get(store.path('baz'));
+					assert.strictEqual(bar, 'bar');
+					assert.strictEqual(baz, 'baz');
 				});
-			}
+			});
 		});
 
-		const initializerThree = () => ({
-			before: () => {
-				initialization.push('initializer three');
-			}
+		it('passes the payload to each command', () => {
+			const process = createProcess('test', [
+				testCommandFactory('foo'),
+				testCommandFactory('bar'),
+				testCommandFactory('baz')
+			]);
+			const processExecutor = process(store);
+			processExecutor({ payload: 'payload' });
+			const foo = store.get(store.path('foo'));
+			const bar = store.get(store.path('bar'));
+			const baz = store.get(store.path('baz'));
+			assert.deepEqual(foo, { payload: 'payload' });
+			assert.deepEqual(bar, { payload: 'payload' });
+			assert.deepEqual(baz, { payload: 'payload' });
 		});
 
-		const logPointerCallback = () => ({
-			after: (error: ProcessError | null, result: ProcessResult<{ logs: string[][] }>): void => {
-				assert.lengthOf(initialization, firstCall ? 3 : 6);
-				firstCall = false;
+		it('can use a transformer for the arguments passed to the process executor', () => {
+			const process = createProcess<any, { foo: string }>('test', [
+				testCommandFactory('foo'),
+				testCommandFactory('bar'),
+				testCommandFactory('baz')
+			]);
+			const processExecutorOne = process(store, (payload: { foo: number }) => {
+				return { foo: 'changed' };
+			});
+
+			const processExecutorTwo = process(store);
+
+			processExecutorTwo({ foo: '' });
+			processExecutorOne({ foo: 1 });
+			// processExecutorOne({ foo: '' }); // doesn't compile
+
+			const foo = store.get(store.path('foo'));
+			const bar = store.get(store.path('bar'));
+			const baz = store.get(store.path('baz'));
+			assert.deepEqual(foo, { foo: 'changed' });
+			assert.deepEqual(bar, { foo: 'changed' });
+			assert.deepEqual(baz, { foo: 'changed' });
+		});
+
+		it('provides a command factory', () => {
+			const createCommand = createCommandFactory<{ foo: string }, { foo: string }>();
+
+			const command = createCommand(({ get, path, payload }) => {
+				// get(path('bar')); // shouldn't compile
+				payload.foo;
+				// payload.bar; // shouldn't compile
+				get(path('foo'));
+				return [];
+			});
+
+			assert.equal(typeof command, 'function');
+		});
+
+		it('should add object by integer like index key', () => {
+			const id = '3fe3c6d3-15e1-4d77-886f-daeb0ed63458';
+			const createCommand = createCommandFactory<any>();
+			const command = createCommand(({ get, path, payload }) => {
+				return [add(path('test', id), { foo: 'bar' })];
+			});
+			const process = createProcess('test', [command]);
+			const executor = process(store);
+			executor({});
+			assert.deepEqual(store.get(store.path('test')), { [id]: { foo: 'bar' } });
+		});
+
+		it('can type payload that extends an object', () => {
+			const createCommandOne = createCommandFactory<any, { foo: string }>();
+			const createCommandTwo = createCommandFactory<any, { bar: string }>();
+			const createCommandThree = createCommandFactory();
+			const commandOne = createCommandOne(({ get, path, payload }) => []);
+			const commandTwo = createCommandTwo(({ get, path, payload }) => []);
+			const commandThree = createCommandThree(({ get, path, payload }) => []);
+			const processOne = createProcess<any, { foo: string; bar: string }>('test', [commandOne, commandTwo]);
+			// createProcess('test', [commandOne, commandTwo]); // shouldn't compile
+			// createProcess<any, { bar: string }>([commandOne]); // shouldn't compile
+			const processTwo = createProcess('test', [commandTwo]);
+			const processThree = createProcess('test', [commandThree]);
+			const executorOne = processOne(store);
+			const executorTwo = processTwo(store);
+			const executorThree = processThree(store);
+
+			// executorOne({}); // shouldn't compile
+			// executorOne({ foo: 1 }); // shouldn't compile
+			executorOne({ foo: 'bar', bar: 'string' });
+			executorTwo({ bar: 'bar' });
+			// executorTwo({}); // shouldn't compile;
+			// executorTwo(1); // shouldn't compile
+			// executorTwo(''); // shouldn't compile
+			// executorThree(); // shouldn't compile
+			executorThree({});
+		});
+
+		it('if a transformer is provided it determines the payload type', () => {
+			const createCommandOne = createCommandFactory<any, { bar: number }>();
+			const createCommandTwo = createCommandFactory<any, { foo: number }>();
+			const commandOne = createCommandOne(({ get, path, payload }) => []);
+			const commandTwo = createCommandTwo(({ get, path, payload }) => []);
+			const transformerOne = (payload: { foo: string }): { bar: number } => {
+				return {
+					bar: 1
+				};
+			};
+			const transformerTwo = (payload: { foo: number }): { bar: number; foo: number } => {
+				return {
+					bar: 1,
+					foo: 2
+				};
+			};
+
+			const processOne = createProcess('test', [commandOne]);
+			const processTwo = createProcess<any, { bar: number; foo: number }>('test', [commandOne, commandTwo]);
+			const processOneResult = processOne(store, transformerOne)({ foo: '' });
+			// processTwo(store, transformerOne); // compile error
+			const processTwoResult = processTwo(store, transformerTwo)({ foo: 3 });
+			// processTwo(store)({ foo: 3 }); // compile error
+			processOneResult.then((result) => {
+				result.payload.bar.toPrecision();
+				result.executor(processTwo, { foo: 3, bar: 1 });
+				// result.executor(processTwo, { foo: 3, bar: '' }); // compile error
+				result.executor(processTwo, { foo: 1 }, transformerTwo);
+				// result.executor(processTwo, { foo: '' }, transformerTwo); // compile error
+				// result.payload.bar.toUpperCase(); // compile error
+				// result.payload.foo; // compile error
+			});
+			processTwoResult.then((result) => {
+				result.payload.bar.toPrecision();
+				result.payload.foo.toPrecision();
+				// result.payload.bar.toUpperCase(); // compile error
+				// result.payload.foo.toUpperCase(); // compile error
+			});
+		});
+
+		it('can provide a callback that gets called on process completion', () => {
+			let callbackCalled = false;
+			const process = createProcess('test', [testCommandFactory('foo')], () => ({
+				after: () => {
+					callbackCalled = true;
+				}
+			}));
+			const processExecutor = process(store);
+			processExecutor({});
+			assert.isTrue(callbackCalled);
+		});
+
+		it('when a command errors, the error and command is returned in the error argument of the callback', async () => {
+			const process = createProcess('test', [testCommandFactory('foo'), testErrorCommand], () => ({
+				after: (error) => {
+					assert.isNotNull(error);
+					assert.equal(error && error.error && error.error.message, 'Command Failed');
+					assert.strictEqual(error && error.command, testErrorCommand);
+				}
+			}));
+			const processExecutor = process(store);
+			await processExecutor({});
+		});
+
+		it('a command that does not return results does not break other commands', () => {
+			const process = createProcess('test', [testCommandFactory('foo'), testNoop], () => ({
+				after: (error) => {
+					assert.isNull(error);
+					assert.strictEqual(store.get(store.path('foo')), 'foo');
+				}
+			}));
+			const processExecutor = process(store);
+			processExecutor({});
+		});
+
+		it('executor can be used to programmatically run additional processes', () => {
+			const extraProcess = createProcess('test', [testCommandFactory('bar')]);
+			const process = createProcess('test', [testCommandFactory('foo')], () => ({
+				after: (error, result) => {
+					assert.isNull(error);
+					let bar = store.get(store.path('bar'));
+					assert.isUndefined(bar);
+					result.executor(extraProcess, {});
+					bar = store.get(store.path('bar'));
+					assert.strictEqual(bar, 'bar');
+				}
+			}));
+			const processExecutor = process(store);
+			processExecutor({});
+		});
+
+		it('process decorator should convert callbacks to after callback', () => {
+			let callbackArray: string[] = [];
+			const legacyCallbackOne: ProcessCallbackAfter = (error, result) => {
+				callbackArray.push('one');
+			};
+			const legacyCallbackTwo: ProcessCallbackAfter = (error, result) => {
+				callbackArray.push('two');
+			};
+
+			const decoratorOne = createCallbackDecorator(legacyCallbackOne);
+			const decoratorTwo = createCallbackDecorator(legacyCallbackTwo);
+
+			const callbackOne: ProcessCallback = () => ({
+				after: (error, result) => {
+					callbackArray.push('one');
+				}
+			});
+			const callbackTwo: ProcessCallback = () => ({
+				after: (error, result) => {
+					callbackArray.push('two');
+				}
+			});
+
+			const process = createProcess('decorator-test', [], [callbackOne, callbackTwo]);
+			const processWithLegacyMiddleware = createProcess(
+				'createCallbackDecorator-test',
+				[],
+				decoratorOne(decoratorTwo())
+			);
+			const processExecutor = process(store);
+			const legacyMiddlewareProcessExecutor = processWithLegacyMiddleware(store);
+			processExecutor({});
+			assert.deepEqual(callbackArray, ['one', 'two']);
+			callbackArray = [];
+			legacyMiddlewareProcessExecutor({});
+			assert.deepEqual(callbackArray, ['one', 'two']);
+		});
+
+		it('Creating a process returned automatically decorates all process callbacks', () => {
+			let results: string[] = [];
+
+			const callback: ProcessCallback = () => ({
+				after: (error, result): void => {
+					results.push('callback one');
+				}
+			});
+
+			const callbackTwo = () => ({
+				after: (error: ProcessError | null, result: ProcessResult): void => {
+					results.push('callback two');
+					result.payload;
+				}
+			});
+
+			const logPointerCallback = () => ({
+				after: (error: ProcessError | null, result: ProcessResult<{ logs: string[][] }>): void => {
+					const paths = result.operations.map((operation) => operation.path.path);
+					const logs = result.get(store.path('logs')) || [];
+
+					result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
+				}
+			});
+
+			const createProcess = createProcessFactoryWith([callback, callbackTwo, logPointerCallback]);
+
+			const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('bar')]);
+			const executor = process(store);
+			executor({});
+			assert.lengthOf(results, 2);
+			assert.strictEqual(results[0], 'callback one');
+			assert.strictEqual(results[1], 'callback two');
+			assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar']]);
+			executor({});
+			assert.lengthOf(results, 4);
+			assert.strictEqual(results[0], 'callback one');
+			assert.strictEqual(results[1], 'callback two');
+			assert.strictEqual(results[2], 'callback one');
+			assert.strictEqual(results[3], 'callback two');
+			assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
+		});
+
+		it('Creating a process automatically decorates all process initializers', async () => {
+			let initialization: string[] = [];
+			let firstCall = true;
+
+			const initializer: ProcessCallback = () => ({
+				before: async (payload, store) => {
+					initialization.push('initializer one');
+					const initLog = store.get(store.path('initLogs')) || [];
+					store.apply([
+						{
+							op: OperationType.ADD,
+							path: new Pointer(`/initLogs/${initLog.length}`),
+							value: 'initial value'
+						}
+					]);
+				}
+			});
+
+			const initializerTwo = () => ({
+				before: async (payload: any) => {
+					initialization.push('initializer two');
+					payload.foo;
+					await new Promise((resolve) => {
+						setTimeout(resolve, 100);
+					});
+				}
+			});
+
+			const initializerThree = () => ({
+				before: () => {
+					initialization.push('initializer three');
+				}
+			});
+
+			const logPointerCallback = () => ({
+				after: (error: ProcessError | null, result: ProcessResult<{ logs: string[][] }>): void => {
+					assert.lengthOf(initialization, firstCall ? 3 : 6);
+					firstCall = false;
+					const paths = result.operations.map((operation) => operation.path.path);
+					const logs = result.get(store.path('logs')) || [];
+
+					result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
+				}
+			});
+
+			const createProcess = createProcessFactoryWith([initializer, initializerTwo, initializerThree]);
+
+			const process = createProcess(
+				'test',
+				[
+					(): PatchOperation[] => {
+						assert.lengthOf(initialization, firstCall ? 3 : 6);
+						return [];
+					},
+					testCommandFactory('foo'),
+					testCommandFactory('bar')
+				],
+				logPointerCallback
+			);
+			const executor = process(store);
+			await executor({});
+			assert.lengthOf(initialization, 3);
+			assert.strictEqual(initialization[0], 'initializer one');
+			assert.strictEqual(initialization[1], 'initializer two');
+			assert.strictEqual(initialization[2], 'initializer three');
+			assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar']]);
+			assert.deepEqual(store.get(store.path('initLogs')), ['initial value']);
+			await executor({});
+			assert.lengthOf(initialization, 6);
+			assert.strictEqual(initialization[0], 'initializer one');
+			assert.strictEqual(initialization[1], 'initializer two');
+			assert.strictEqual(initialization[2], 'initializer three');
+			assert.strictEqual(initialization[3], 'initializer one');
+			assert.strictEqual(initialization[4], 'initializer two');
+			assert.strictEqual(initialization[5], 'initializer three');
+			assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
+			assert.deepEqual(store.get(store.path('initLogs')), ['initial value', 'initial value']);
+		});
+
+		it('Should work with a single initializer', async () => {
+			let initialization: string[] = [];
+
+			const initializer = async () => {
+				initialization.push('initializer');
+			};
+
+			const logPointerCallback = (
+				error: ProcessError | null,
+				result: ProcessResult<{ logs: string[][] }>
+			): void => {
 				const paths = result.operations.map((operation) => operation.path.path);
 				const logs = result.get(store.path('logs')) || [];
 
 				result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
-			}
+			};
+
+			const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('bar')], () => ({
+				before: initializer,
+				after: logPointerCallback
+			}));
+			const executor = process(store);
+			await executor({});
+			assert.lengthOf(initialization, 1);
+			assert.strictEqual(initialization[0], 'initializer');
+			assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar']]);
+			await executor({});
+			assert.lengthOf(initialization, 2);
+			assert.strictEqual(initialization[0], 'initializer');
+			assert.strictEqual(initialization[1], 'initializer');
+			assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
 		});
 
-		const createProcess = createProcessFactoryWith([initializer, initializerTwo, initializerThree]);
-
-		const process = createProcess(
-			'test',
-			[
-				(): PatchOperation[] => {
-					assert.lengthOf(initialization, firstCall ? 3 : 6);
-					return [];
-				},
-				testCommandFactory('foo'),
-				testCommandFactory('bar')
-			],
-			logPointerCallback
-		);
-		const executor = process(store);
-		await executor({});
-		assert.lengthOf(initialization, 3);
-		assert.strictEqual(initialization[0], 'initializer one');
-		assert.strictEqual(initialization[1], 'initializer two');
-		assert.strictEqual(initialization[2], 'initializer three');
-		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar']]);
-		assert.deepEqual(store.get(store.path('initLogs')), ['initial value']);
-		await executor({});
-		assert.lengthOf(initialization, 6);
-		assert.strictEqual(initialization[0], 'initializer one');
-		assert.strictEqual(initialization[1], 'initializer two');
-		assert.strictEqual(initialization[2], 'initializer three');
-		assert.strictEqual(initialization[3], 'initializer one');
-		assert.strictEqual(initialization[4], 'initializer two');
-		assert.strictEqual(initialization[5], 'initializer three');
-		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
-		assert.deepEqual(store.get(store.path('initLogs')), ['initial value', 'initial value']);
-	});
-
-	it('Should work with a single initializer', async () => {
-		let initialization: string[] = [];
-
-		const initializer = async () => {
-			initialization.push('initializer');
-		};
-
-		const logPointerCallback = (error: ProcessError | null, result: ProcessResult<{ logs: string[][] }>): void => {
-			const paths = result.operations.map((operation) => operation.path.path);
-			const logs = result.get(store.path('logs')) || [];
-
-			result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
-		};
-
-		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('bar')], () => ({
-			before: initializer,
-			after: logPointerCallback
-		}));
-		const executor = process(store);
-		await executor({});
-		assert.lengthOf(initialization, 1);
-		assert.strictEqual(initialization[0], 'initializer');
-		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar']]);
-		await executor({});
-		assert.lengthOf(initialization, 2);
-		assert.strictEqual(initialization[0], 'initializer');
-		assert.strictEqual(initialization[1], 'initializer');
-		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
-	});
-
-	it('process can be undone using the undo function provided via the callback', () => {
-		const command = ({ payload }: CommandRequest): PatchOperation[] => {
-			return [{ op: OperationType.REPLACE, path: new Pointer('/foo'), value: 'bar' }];
-		};
-		const process = createProcess('foo', [testCommandFactory('foo'), command], () => ({
-			after: (error, result) => {
-				let foo = store.get(result.store.path('foo'));
-				assert.strictEqual(foo, 'bar');
-				store.apply(result.undoOperations);
-				foo = store.get(result.store.path('foo'));
-				assert.isUndefined(foo);
-			}
-		}));
-		const processExecutor = process(store);
-		return processExecutor({});
-	});
-
-	it('Can undo operations for commands that modify the same section of state', () => {
-		const commandOne = (): PatchOperation[] => {
-			return [{ op: OperationType.REPLACE, path: new Pointer('/state'), value: { b: 'b' } }];
-		};
-		const commandTwo = (): PatchOperation[] => {
-			return [{ op: OperationType.REPLACE, path: new Pointer('/state/a'), value: 'a' }];
-		};
-
-		const process = createProcess('foo', [commandOne, commandTwo], () => ({
-			after: (error, result) => {
-				let state = store.get(result.store.path('state'));
-				assert.deepEqual(state, { a: 'a', b: 'b' });
-				store.apply(result.undoOperations);
-				state = store.get(result.store.path('state'));
-				assert.isUndefined(state);
-			}
-		}));
-		const processExecutor = process(store);
-		return processExecutor({});
-	});
-
-	it('Can undo operations for commands that return multiple operations', () => {
-		const commandFactory = createCommandFactory<any>();
-		const commandOne = commandFactory(({ path }) => {
-			return [
-				replace(path('state'), {}),
-				replace(path('state', 'foo'), 'foo'),
-				replace(path('state', 'bar'), 'bar'),
-				replace(path('state', 'baz'), 'baz')
-			];
+		it('process can be undone using the undo function provided via the callback', () => {
+			const command = ({ payload }: CommandRequest): PatchOperation[] => {
+				return [{ op: OperationType.REPLACE, path: new Pointer('/foo'), value: 'bar' }];
+			};
+			const process = createProcess('foo', [testCommandFactory('foo'), command], () => ({
+				after: (error, result) => {
+					let foo = store.get(result.store.path('foo'));
+					assert.strictEqual(foo, 'bar');
+					store.apply(result.undoOperations);
+					foo = store.get(result.store.path('foo'));
+					assert.isUndefined(foo);
+				}
+			}));
+			const processExecutor = process(store);
+			return processExecutor({});
 		});
 
-		const process = createProcess('foo', [commandOne], () => ({
-			after: (error, result) => {
-				let state = store.get(result.store.path('state'));
-				assert.deepEqual(state, { foo: 'foo', bar: 'bar', baz: 'baz' });
-				store.apply(result.undoOperations);
-				state = store.get(result.store.path('state'));
-				assert.isUndefined(state);
-			}
-		}));
-		const processExecutor = process(store);
-		return processExecutor({});
+		it('Can undo operations for commands that modify the same section of state', () => {
+			const commandOne = (): PatchOperation[] => {
+				return [{ op: OperationType.REPLACE, path: new Pointer('/state'), value: { b: 'b' } }];
+			};
+			const commandTwo = (): PatchOperation[] => {
+				return [{ op: OperationType.REPLACE, path: new Pointer('/state/a'), value: 'a' }];
+			};
+
+			const process = createProcess('foo', [commandOne, commandTwo], () => ({
+				after: (error, result) => {
+					let state = store.get(result.store.path('state'));
+					assert.deepEqual(state, { a: 'a', b: 'b' });
+					store.apply(result.undoOperations);
+					state = store.get(result.store.path('state'));
+					assert.isUndefined(state);
+				}
+			}));
+			const processExecutor = process(store);
+			return processExecutor({});
+		});
+
+		it('Can undo operations for commands that return multiple operations', () => {
+			const commandFactory = createCommandFactory<any>();
+			const commandOne = commandFactory(({ path }) => {
+				return [
+					replace(path('state'), {}),
+					replace(path('state', 'foo'), 'foo'),
+					replace(path('state', 'bar'), 'bar'),
+					replace(path('state', 'baz'), 'baz')
+				];
+			});
+
+			const process = createProcess('foo', [commandOne], () => ({
+				after: (error, result) => {
+					let state = store.get(result.store.path('state'));
+					assert.deepEqual(state, { foo: 'foo', bar: 'bar', baz: 'baz' });
+					store.apply(result.undoOperations);
+					state = store.get(result.store.path('state'));
+					assert.isUndefined(state);
+				}
+			}));
+			const processExecutor = process(store);
+			return processExecutor({});
+		});
 	});
-});
+};
 
-// const performanceTestStore = new Store({
-// 	state: new ImmutableState()
-// });
-// const operations: PatchOperation[] = [];
-// for (let i = 0; i < 100; i++) {
-// 	operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}`), value: {} });
-// 	for (let j = 0; j < 50; j++) {
-// 		operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}/${j}`), value: {} });
-// 		for (let k = 0; k < 10; k++) {
-// 			operations.push({ op: OperationType.ADD, path: new Pointer(`/${i}/${j}/${k}`), value: k });
-// 		}
-// 	}
-// }
-// console.time('buildstore');
-// performanceTestStore.apply(operations);
-// console.timeEnd('buildstore');
-// registerSuite('Normal performance', {
-// 	'update values'() {
-// 		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('foo/bar')]);
-// 		const processExecutor = process(performanceTestStore);
-// 		processExecutor({});
-// 	}
-// });
-
-// registerSuite('Proxy performance', {
-// 	beforeEach() {
-// 		store = new Store();
-// 	},
-//
-// 	tests: {
-// 		'update values'() {
-// 			const process = createProcess('test', [
-// 				testProxyCommandFactory('foo'),
-// 				testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 				// testProxyCommandFactory('foo', 'bar'),
-// 			]);
-// 			const processExecutor = process(store);
-// 			processExecutor({});
-// 		}
-// 	}
-// });
+tests('default');
+tests('immutableJS', () => new ImmutableState());

--- a/tests/stores/unit/state/ImmutableState.ts
+++ b/tests/stores/unit/state/ImmutableState.ts
@@ -6,7 +6,7 @@ import { Pointer } from '../../../../src/stores/state/Pointer';
 import { OperationType } from '../../../../src/stores/state/Patch';
 import * as ops from './../../../../src/stores/state/operations';
 
-describe('state/Patch', () => {
+describe('state/ImmutableState', () => {
 	describe('add', () => {
 		it('value to new path', () => {
 			const state = new ImmutableState();
@@ -107,7 +107,7 @@ describe('state/Patch', () => {
 			const state = new ImmutableState();
 			state.apply([ops.add({ path: '/test', state: null, value: null }, true)]);
 			const result = state.apply([ops.remove({ path: '/test', state: null, value: null })]);
-			assert.deepEqual(state.path('/test'), undefined);
+			assert.deepEqual(state.path('/test').value, undefined);
 			assert.deepEqual(result, [{ op: OperationType.ADD, path: new Pointer('/test'), value: true }]);
 		});
 
@@ -156,7 +156,7 @@ describe('state/Patch', () => {
 
 		it('nested path failure', () => {
 			const state = new ImmutableState();
-			state.apply([ops.add({ path: '/foo/0/bar/baz', state: null, value: null }, { thing: 'one' })]);
+			state.apply([ops.add({ path: '/foo/0/bar/baz', state: null, value: null }, { thing: 'two' })]);
 			assert.throws(
 				() => {
 					state.apply([ops.test({ path: '/foo/0/bar/baz', state: null, value: null }, { thing: 'one' })]);

--- a/tests/stores/unit/state/ImmutableState.ts
+++ b/tests/stores/unit/state/ImmutableState.ts
@@ -1,0 +1,226 @@
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+import { ImmutableState } from '../../../../src/stores/state/ImmutableState';
+import { Pointer } from '../../../../src/stores/state/Pointer';
+import { OperationType } from '../../../../src/stores/state/Patch';
+import * as ops from './../../../../src/stores/state/operations';
+
+describe('state/Patch', () => {
+	describe('add', () => {
+		it('value to new path', () => {
+			const state = new ImmutableState();
+			const result = state.apply([ops.add({ path: 'test', state: null, value: null }, 'test')]);
+			assert.equal(state.path('/test').value, 'test');
+			assert.deepEqual(result, [
+				{ op: OperationType.TEST, path: new Pointer('/test'), value: 'test' },
+				{ op: OperationType.REMOVE, path: new Pointer('/test') }
+			]);
+		});
+
+		it('value to new nested path', () => {
+			const state = new ImmutableState();
+			const result = state.apply([ops.add({ path: '/foo/bar/qux', state: null, value: null }, 'test')]);
+			assert.deepEqual(state.path('/foo').value, { bar: { qux: 'test' } });
+			assert.deepEqual(result, [
+				{ op: OperationType.TEST, path: new Pointer('/foo/bar/qux'), value: 'test' },
+				{ op: OperationType.REMOVE, path: new Pointer('/foo/bar/qux') }
+			]);
+		});
+
+		it('value to existing path', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/test', state: null, value: null }, true)]);
+			const result = state.apply([ops.add({ path: '/test', state: null, value: null }, 'test')]);
+			assert.deepEqual(state.path('/test').value, 'test');
+			assert.deepEqual(result, [
+				{ op: OperationType.TEST, path: new Pointer('/test'), value: 'test' },
+				{ op: OperationType.REMOVE, path: new Pointer('/test') }
+			]);
+		});
+
+		it('value to array index path', () => {
+			const state = new ImmutableState();
+			const result = state.apply([ops.add({ path: '/test/0', state: null, value: null }, 'test')]);
+			assert.deepEqual(state.path('/test').value, ['test']);
+			assert.deepEqual(result, [
+				{ op: OperationType.TEST, path: new Pointer('/test/0'), value: 'test' },
+				{ op: OperationType.REMOVE, path: new Pointer('/test/0') }
+			]);
+		});
+	});
+
+	describe('replace', () => {
+		it('new path', () => {
+			const state = new ImmutableState();
+			const result = state.apply([ops.replace({ path: '/test', state: null, value: null }, 'test')]);
+			assert.deepEqual(state.path('/test').value, 'test');
+			assert.deepEqual(result, [
+				{ op: OperationType.TEST, path: new Pointer('/test'), value: 'test' },
+				{ op: OperationType.REMOVE, path: new Pointer('/test') }
+			]);
+		});
+
+		it('value to new nested path', () => {
+			const state = new ImmutableState();
+			const result = state.apply([ops.replace({ path: '/foo/bar/qux', state: null, value: null }, 'test')]);
+			assert.deepEqual(state.path('/foo').value, { bar: { qux: 'test' } });
+			assert.deepEqual(result, [
+				{ op: OperationType.TEST, path: new Pointer('/foo/bar/qux'), value: 'test' },
+				{ op: OperationType.REMOVE, path: new Pointer('/foo/bar/qux') }
+			]);
+		});
+
+		it('existing path', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/test', state: null, value: null }, true)]);
+			const result = state.apply([ops.replace({ path: '/test', state: null, value: null }, 'test')]);
+			assert.deepEqual(state.path('/test').value, 'test');
+			assert.deepEqual(result, [
+				{ op: OperationType.TEST, path: new Pointer('/test'), value: 'test' },
+				{ op: OperationType.REPLACE, path: new Pointer('/test'), value: true }
+			]);
+		});
+
+		it('array index path', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/test', value: null, state: null }, ['test', 'foo'])]);
+			const result = state.apply([ops.replace({ path: '/test/1', state: null, value: null }, 'test')]);
+			assert.deepEqual(state.path('/test').value, ['test', 'test']);
+			assert.deepEqual(result, [
+				{ op: OperationType.TEST, path: new Pointer('/test/1'), value: 'test' },
+				{ op: OperationType.REPLACE, path: new Pointer('/test/1'), value: 'foo' }
+			]);
+		});
+	});
+
+	describe('remove', () => {
+		it('new path', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/other', state: null, value: null }, true)]);
+			const result = state.apply([ops.remove({ path: '/test', state: null, value: null })]);
+			assert.deepEqual(state.path('/other').value, true);
+			assert.deepEqual(result, [{ op: OperationType.ADD, path: new Pointer('/test'), value: undefined }]);
+		});
+
+		it('existing path', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/test', state: null, value: null }, true)]);
+			const result = state.apply([ops.remove({ path: '/test', state: null, value: null })]);
+			assert.deepEqual(state.path('/test'), undefined);
+			assert.deepEqual(result, [{ op: OperationType.ADD, path: new Pointer('/test'), value: true }]);
+		});
+
+		it('array index path', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/test', state: null, value: null }, ['test', 'foo'])]);
+			const result = state.apply([ops.remove({ path: '/test/1', state: null, value: null })]);
+			assert.deepEqual(state.path('test').value, ['test']);
+			assert.deepEqual(result, [{ op: OperationType.ADD, path: new Pointer('/test/1'), value: 'foo' }]);
+		});
+	});
+
+	describe('test', () => {
+		it('success', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/test', state: null, value: null }, 'test')]);
+			const result = state.apply([ops.test({ path: '/test', state: null, value: null }, 'test')]);
+			assert.deepEqual(result, []);
+			assert.equal(state.path('test').value, 'test');
+		});
+
+		function assertTestFailure(initial: any, value: any, errorMessage: string) {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/test', state: null, value: null }, value)]);
+			assert.throws(
+				() => {
+					state.apply([ops.test({ path: '/test', state: null, value: null }, initial)]);
+				},
+				Error,
+				errorMessage
+			);
+		}
+
+		it('failure', () => {
+			assertTestFailure(
+				true,
+				'true',
+				'Test operation failure at "/test". Expected boolean "true" but got string "true" instead.'
+			);
+			assertTestFailure(
+				{},
+				[],
+				'Test operation failure at "/test". Expected object "[object Object]" but got array "" instead.'
+			);
+		});
+
+		it('nested path failure', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/foo/0/bar/baz', state: null, value: null }, { thing: 'one' })]);
+			assert.throws(
+				() => {
+					state.apply([ops.test({ path: '/foo/0/bar/baz', state: null, value: null }, { thing: 'one' })]);
+				},
+				Error,
+				'Test operation failure at "/foo/0/bar/baz". Expected "one" for object property thing but got "two" instead.'
+			);
+		});
+
+		it('nested path', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/foo/0/bar/baz/0/qux', state: null, value: null }, true)]);
+			const result = state.apply([ops.test({ path: '/foo/0/bar/baz/0/qux', state: null, value: null }, true)]);
+			assert.deepEqual(result, []);
+			assert.deepEqual(state.path('/foo').value, [{ bar: { baz: [{ qux: true }] } }]);
+		});
+
+		it('complex value', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/foo/0/bar/baz/0/qux', state: null, value: null }, true)]);
+			const result = state.apply([
+				ops.test({ path: '/foo', state: null, value: null }, [
+					{
+						bar: {
+							baz: [
+								{
+									qux: true
+								}
+							]
+						}
+					}
+				])
+			]);
+			assert.deepEqual(result, []);
+			assert.deepEqual(state.path('/foo').value, [
+				{
+					bar: {
+						baz: [
+							{
+								qux: true
+							}
+						]
+					}
+				}
+			]);
+		});
+
+		it('no value', () => {
+			const state = new ImmutableState();
+			state.apply([ops.add({ path: '/test', state: null, value: null }, 'test')]);
+
+			const result = state.apply([ops.test({ path: '/test', state: null, value: null }, 'test')]);
+			assert.deepEqual(result, []);
+			assert.equal(state.path('/test').value, 'test');
+		});
+	});
+
+	it('unknown', () => {
+		assert.throws(
+			() => {
+				new ImmutableState().apply([{} as any]);
+			},
+			Error,
+			'Unknown operation'
+		);
+	});
+});

--- a/tests/stores/unit/state/all.ts
+++ b/tests/stores/unit/state/all.ts
@@ -1,4 +1,5 @@
 import './compare';
+import './ImmutableState';
 import './operations';
 import './Patch';
 import './Pointer';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Related to #48 

This creates a `MutableState` interface that has the properties of `State` as well as the `apply` function. It then breaks out the parts of store that implemented the `MutableState` interface into a default implementation, and allows an alternative implementation to be passed in to the constructor.

Includes an implementation using ImmutableJS. So far testing the performance impact of using ImmutableJS has not shown significant differences but I have not thoroughly tested it. 