### PR TITLE
Adding stackable customElement decorators

### DIFF
--- a/src/widget-core/decorators/customElement.ts
+++ b/src/widget-core/decorators/customElement.ts
@@ -38,13 +38,6 @@ export interface CustomElementConfig<P extends object = { [index: string]: any }
  * registers that custom element.
  */
 export function customElement<P extends object = { [index: string]: any }>(config: CustomElementConfig<P>) {
-	const defaults = {
-		properties: [],
-		attributes: [],
-		events: [],
-		childType: CustomElementChildType.DOJO,
-		registryFactory: () => new Registry()
-	};
 	// rename "tag" to "tagName"
 	const { tag: tagName, ...configRest } = config;
 	const userDefinedConfig: CustomElementConfig & { tagName?: string } = configRest;
@@ -55,7 +48,6 @@ export function customElement<P extends object = { [index: string]: any }>(confi
 
 	return function<T extends Constructor<any>>(target: T) {
 		target.prototype.__customElementDescriptor = {
-			...defaults,
 			...target.prototype.__customElementDescriptor,
 			...userDefinedConfig
 		};

--- a/src/widget-core/decorators/customElement.ts
+++ b/src/widget-core/decorators/customElement.ts
@@ -45,14 +45,18 @@ export function customElement<P extends object = { [index: string]: any }>(confi
 		childType: CustomElementChildType.DOJO,
 		registryFactory: () => new Registry()
 	};
+	// rename "tag" to "tagName"
 	const { tag: tagName, ...configRest } = config;
-	const updatedConfig = { ...(tagName ? { tagName } : {}), ...configRest };
+	const userDefinedConfig = {
+		tagName,
+		...configRest
+	};
 
 	return function<T extends Constructor<any>>(target: T) {
 		target.prototype.__customElementDescriptor = {
 			...defaults,
 			...target.prototype.__customElementDescriptor,
-			...updatedConfig
+			...userDefinedConfig
 		};
 	};
 }

--- a/src/widget-core/decorators/customElement.ts
+++ b/src/widget-core/decorators/customElement.ts
@@ -11,7 +11,7 @@ export interface CustomElementConfig<P extends object = { [index: string]: any }
 	/**
 	 * The tag of the custom element
 	 */
-	tag: string;
+	tag?: string;
 
 	/**
 	 * List of widget properties to expose as properties on the custom element
@@ -37,22 +37,22 @@ export interface CustomElementConfig<P extends object = { [index: string]: any }
  * This Decorator is provided properties that define the behavior of a custom element, and
  * registers that custom element.
  */
-export function customElement<P extends object = { [index: string]: any }>({
-	tag,
-	properties = [],
-	attributes = [],
-	events = [],
-	childType = CustomElementChildType.DOJO,
-	registryFactory = () => new Registry()
-}: CustomElementConfig<P>) {
+export function customElement<P extends object = { [index: string]: any }>(config: CustomElementConfig<P>) {
+	const defaults = {
+		properties: [],
+		attributes: [],
+		events: [],
+		childType: CustomElementChildType.DOJO,
+		registryFactory: () => new Registry()
+	};
+	const { tag: tagName, ...configRest } = config;
+	const updatedConfig = { ...(tagName ? { tagName } : {}), ...configRest };
+
 	return function<T extends Constructor<any>>(target: T) {
 		target.prototype.__customElementDescriptor = {
-			tagName: tag,
-			attributes,
-			properties,
-			events,
-			childType,
-			registryFactory
+			...defaults,
+			...target.prototype.__customElementDescriptor,
+			...updatedConfig
 		};
 	};
 }

--- a/src/widget-core/decorators/customElement.ts
+++ b/src/widget-core/decorators/customElement.ts
@@ -47,10 +47,11 @@ export function customElement<P extends object = { [index: string]: any }>(confi
 	};
 	// rename "tag" to "tagName"
 	const { tag: tagName, ...configRest } = config;
-	const userDefinedConfig = {
-		tagName,
-		...configRest
-	};
+	const userDefinedConfig: CustomElementConfig & { tagName?: string } = configRest;
+
+	if (tagName) {
+		userDefinedConfig.tagName = tagName;
+	}
 
 	return function<T extends Constructor<any>>(target: T) {
 		target.prototype.__customElementDescriptor = {

--- a/src/widget-core/registerCustomElement.ts
+++ b/src/widget-core/registerCustomElement.ts
@@ -1,3 +1,4 @@
+import Registry from './Registry';
 import { WidgetBase } from './WidgetBase';
 import { renderer } from './vdom';
 import { from } from '../shim/array';
@@ -39,7 +40,11 @@ export function DomToWidgetWrapper(domNode: HTMLElement): any {
 }
 
 export function create(descriptor: any, WidgetConstructor: any): any {
-	const { attributes, childType, registryFactory } = descriptor;
+	const {
+		attributes = [],
+		childType = CustomElementChildType.DOJO,
+		registryFactory = () => new Registry()
+	} = descriptor;
 	const attributeMap: any = {};
 
 	attributes.forEach((propertyName: string) => {
@@ -60,7 +65,7 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 			}
 
 			const domProperties: any = {};
-			const { attributes, properties, events } = descriptor;
+			const { properties = [], events = [] } = descriptor;
 
 			this._properties = { ...this._properties, ...this._attributesToProperties(attributes) };
 

--- a/tests/widget-core/unit/decorators/customElement.ts
+++ b/tests/widget-core/unit/decorators/customElement.ts
@@ -3,7 +3,6 @@ const { assert } = intern.getPlugin('chai');
 
 import { customElement } from '../../../../src/widget-core/decorators/customElement';
 import { WidgetBase } from '../../../../src/widget-core/WidgetBase';
-import { CustomElementChildType } from '../../../../src/widget-core/registerCustomElement';
 
 export interface CustomElementWidgetProperties {
 	label: string;
@@ -37,7 +36,6 @@ describe('@customElement', () => {
 			attributes: ['key', 'label', 'labelSuffix'],
 			properties: ['label'],
 			events: ['onClick2'],
-			childType: CustomElementChildType.DOJO,
 			registryFactory
 		});
 	});

--- a/tests/widget-core/unit/decorators/customElement.ts
+++ b/tests/widget-core/unit/decorators/customElement.ts
@@ -15,6 +15,12 @@ function registryFactory() {
 	return {} as any;
 }
 
+@customElement({
+	events: ['onClick2']
+})
+@customElement<CustomElementWidgetProperties>({
+	tag: 'test-element'
+})
 @customElement<CustomElementWidgetProperties>({
 	tag: 'custom-element',
 	attributes: ['key', 'label', 'labelSuffix'],
@@ -27,10 +33,10 @@ export class CustomElementWidget extends WidgetBase<CustomElementWidgetPropertie
 describe('@customElement', () => {
 	it('Should add the descriptor to the widget prototype', () => {
 		assert.deepEqual((CustomElementWidget.prototype as any).__customElementDescriptor, {
-			tagName: 'custom-element',
+			tagName: 'test-element',
 			attributes: ['key', 'label', 'labelSuffix'],
 			properties: ['label'],
-			events: ['onClick'],
+			events: ['onClick2'],
 			childType: CustomElementChildType.DOJO,
 			registryFactory
 		});


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

In preparation for https://github.com/dojo/webpack-contrib/issues/43 we need to make the `customElement` decorator stackable.  By default, everything that inherits `WidgetBase` will get a `@customElement` decorator with sensible defaults. So,

```ts
export interface MyProps {
    prop: string;
}

class WorstWidgetEver extends WidgetBase<MyProps> { }
```

would become,

```ts
export interface MyProps {
    prop: string;
}

@customElement({
   tag: 'worst-widget-ever',
   attributes: ['prop']
})
class WorstWidgetEver extends WidgetBase<MyProps> { }
```

To customize the declaration, you could add your own custom element decorator, which would look like this,


```ts
export interface MyProps {
    prop: string;
}

@customElement({ tag: 'best-widget-ever' })
class WorstWidgetEver extends WidgetBase<MyProps> { }
```

and after transformation would look like this,

```ts
export interface MyProps {
    prop: string;
}

@customElement({ tag: 'best-widget-ever' })
@customElement({
   tag: 'worst-widget-ever',
   attributes: ['prop']
})
class WorstWidgetEver extends WidgetBase<MyProps> { }
```

This PR specifically changes the `customElement` decorator to not clobber any previously set values, but instead merge them in.  

Additionally, this PR also moves the default values out of the `customElement` decorator and into the `registerCustomElement` function. When `cli-build-widget` adds the decorator manually, it doesn't actually add the decorator, but instead adds the property to the prototype chain directly. This is done to avoid adding imports to the file, but has a downside of not being able to apply the same defaults that the decorator can. The fix of course is just to apply the defaults somewhere else (where the values are _used_ rather than where they are defined)

Doesn't resolve, but is related to https://github.com/dojo/webpack-contrib/issues/43
