### PR TITLE
Add insertChildren to assertion template

### DIFF
--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -320,6 +320,7 @@ Here we're using the `setChildren()` api on the baseAssertion, and we're using t
 Assertion Template has the following api's:
 
 ```
+insertChildren(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
 getChildren(selector: string): DNode[];

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -4,6 +4,7 @@ import { VNode, WNode, DNode } from '../widget-core/interfaces';
 
 export interface AssertionTemplateResult {
 	(): DNode | DNode[];
+	insert(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 	setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 	setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
 	getChildren(selector: string): DNode[];
@@ -69,6 +70,24 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 				break;
 			case 'replace':
 				node.children = [...children];
+				break;
+		}
+		return assertionTemplate(() => render);
+	};
+	assertionTemplateResult.insert = (selector: string, children: DNode[], type: 'before' | 'after' = 'after') => {
+		const render = renderFunc();
+		const node = guard(findOne(render, selector));
+		const parent = (node as any).parent;
+		const index = parent.children.indexOf(node);
+		let newChildren = [...parent.children];
+		switch (type) {
+			case 'before':
+				newChildren.splice(index, 0, ...children);
+				parent.children = newChildren;
+				break;
+			case 'after':
+				newChildren.splice(index + 1, 0, ...children);
+				parent.children = newChildren;
 				break;
 		}
 		return assertionTemplate(() => render);

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -4,7 +4,7 @@ import { VNode, WNode, DNode } from '../widget-core/interfaces';
 
 export interface AssertionTemplateResult {
 	(): DNode | DNode[];
-	insert(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
+	insertChildren(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 	setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 	setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
 	getChildren(selector: string): DNode[];
@@ -74,7 +74,11 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		}
 		return assertionTemplate(() => render);
 	};
-	assertionTemplateResult.insert = (selector: string, children: DNode[], type: 'before' | 'after' = 'after') => {
+	assertionTemplateResult.insertChildren = (
+		selector: string,
+		children: DNode[],
+		type: 'before' | 'after' = 'after'
+	) => {
 		const render = renderFunc();
 		const node = guard(findOne(render, selector));
 		const parent = (node as any).parent;

--- a/src/testing/harness.ts
+++ b/src/testing/harness.ts
@@ -1,8 +1,7 @@
 import assertRender from './support/assertRender';
-import { select } from './support/selector';
+import { decorateNodes, select } from './support/selector';
 import { WNode, DNode, WidgetBaseInterface, Constructor, VNode } from '../widget-core/interfaces';
 import { WidgetBase } from '../widget-core/WidgetBase';
-import { decorate, isVNode, isWNode } from '../widget-core/d';
 
 export interface CustomComparator {
 	selector: string;
@@ -12,11 +11,6 @@ export interface CustomComparator {
 
 export interface FunctionalSelector {
 	(node: VNode | WNode): undefined | Function;
-}
-
-export interface DecoratorResult<T> {
-	hasDeferredProperties: boolean;
-	nodes: T;
 }
 
 export interface ExpectedRender {
@@ -47,26 +41,6 @@ export interface HarnessAPI {
 	expectPartial: ExpectPartial;
 	trigger: Trigger;
 	getRender: GetRender;
-}
-
-function decorateNodes(dNode: DNode[]): DecoratorResult<DNode[]>;
-function decorateNodes(dNode: DNode): DecoratorResult<DNode>;
-function decorateNodes(dNode: DNode | DNode[]): DecoratorResult<DNode | DNode[]>;
-function decorateNodes(dNode: any): DecoratorResult<DNode | DNode[]> {
-	let hasDeferredProperties = false;
-	function addParent(parent: WNode | VNode): void {
-		(parent.children || []).forEach((child) => {
-			if (isVNode(child) || isWNode(child)) {
-				(child as any).parent = parent;
-			}
-		});
-		if (isVNode(parent) && typeof parent.deferredPropertiesCallback === 'function') {
-			hasDeferredProperties = true;
-			parent.properties = { ...parent.properties, ...parent.deferredPropertiesCallback(false) };
-		}
-	}
-	const nodes = decorate(dNode, addParent, (node: DNode): node is WNode | VNode => isWNode(node) || isVNode(node));
-	return { hasDeferredProperties, nodes };
 }
 
 export function harness(

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -104,13 +104,13 @@ describe('assertionTemplate', () => {
 
 	it('can set children after with insert', () => {
 		const h = harness(() => w(MyWidget, { after: true }));
-		const childAssertion = baseAssertion.insert('ul', [v('span', ['after'])]);
+		const childAssertion = baseAssertion.insertChildren('ul', [v('span', ['after'])]);
 		h.expect(childAssertion);
 	});
 
 	it('can set children before with insert', () => {
 		const h = harness(() => w(MyWidget, { before: true }));
-		const childAssertion = baseAssertion.insert('ul', [v('span', ['before'])], 'before');
+		const childAssertion = baseAssertion.insertChildren('ul', [v('span', ['before'])], 'before');
 		h.expect(childAssertion);
 	});
 

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -12,9 +12,11 @@ class MyWidget extends WidgetBase<{
 	prependChild?: boolean;
 	appendChild?: boolean;
 	replaceChild?: boolean;
+	before?: boolean;
+	after?: boolean;
 }> {
 	render() {
-		const { toggleProperty, prependChild, appendChild, replaceChild } = this.properties;
+		const { toggleProperty, prependChild, appendChild, replaceChild, before, after } = this.properties;
 		let children = ['hello'];
 		if (prependChild) {
 			children = ['prepend', ...children];
@@ -27,7 +29,9 @@ class MyWidget extends WidgetBase<{
 		}
 		return v('div', { classes: ['root'] }, [
 			v('h2', children),
-			v('ul', [v('li', { foo: toggleProperty ? 'b' : 'a' }, ['one']), v('li', ['two']), v('li', ['three'])])
+			before ? v('span', ['before']) : undefined,
+			v('ul', [v('li', { foo: toggleProperty ? 'b' : 'a' }, ['one']), v('li', ['two']), v('li', ['three'])]),
+			after ? v('span', ['after']) : undefined
 		]);
 	}
 }
@@ -95,6 +99,18 @@ describe('assertionTemplate', () => {
 	it('can set a child with append', () => {
 		const h = harness(() => w(MyWidget, { appendChild: true }));
 		const childAssertion = baseAssertion.setChildren('~header', ['append'], 'append');
+		h.expect(childAssertion);
+	});
+
+	it('can set children after with insert', () => {
+		const h = harness(() => w(MyWidget, { after: true }));
+		const childAssertion = baseAssertion.insert('ul', [v('span', ['after'])]);
+		h.expect(childAssertion);
+	});
+
+	it('can set children before with insert', () => {
+		const h = harness(() => w(MyWidget, { before: true }));
+		const childAssertion = baseAssertion.insert('ul', [v('span', ['before'])], 'before');
 		h.expect(childAssertion);
 	});
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Adds an insertChildren (before and after) to the assertion template. This allows adding nodes in places that `setChildren` doesn't easily allow.
