### PR TITLE
Assertion Template should be immutable

### DIFF
--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -48,53 +48,59 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		return render;
 	};
 	assertionTemplateResult.setProperty = (selector: string, property: string, value: any) => {
-		const render = renderFunc();
-		const node = guard(findOne(render, selector));
-		node.properties[property] = value;
-		return assertionTemplate(() => render);
+		return assertionTemplate(() => {
+			const render = renderFunc();
+			const node = guard(findOne(render, selector));
+			node.properties[property] = value;
+			return render;
+		});
 	};
 	assertionTemplateResult.setChildren = (
 		selector: string,
 		children: DNode[],
 		type: 'prepend' | 'replace' | 'append' = 'replace'
 	) => {
-		const render = renderFunc();
-		const node = guard(findOne(render, selector));
-		node.children = node.children || [];
-		switch (type) {
-			case 'prepend':
-				node.children = [...children, ...node.children];
-				break;
-			case 'append':
-				node.children = [...node.children, ...children];
-				break;
-			case 'replace':
-				node.children = [...children];
-				break;
-		}
-		return assertionTemplate(() => render);
+		return assertionTemplate(() => {
+			const render = renderFunc();
+			const node = guard(findOne(render, selector));
+			node.children = node.children || [];
+			switch (type) {
+				case 'prepend':
+					node.children = [...children, ...node.children];
+					break;
+				case 'append':
+					node.children = [...node.children, ...children];
+					break;
+				case 'replace':
+					node.children = [...children];
+					break;
+			}
+			return render;
+		});
 	};
 	assertionTemplateResult.insertChildren = (
 		selector: string,
 		children: DNode[],
 		type: 'before' | 'after' = 'after'
 	) => {
-		const render = renderFunc();
-		const node = guard(findOne(render, selector));
-		const parent = (node as any).parent;
-		const index = parent.children.indexOf(node);
-		let newChildren = [...parent.children];
-		switch (type) {
-			case 'before':
-				newChildren.splice(index, 0, ...children);
-				parent.children = newChildren;
-				break;
-			case 'after':
-				newChildren.splice(index + 1, 0, ...children);
-				parent.children = newChildren;
-				break;
-		}
-		return assertionTemplate(() => render);
+		return assertionTemplate(() => {
+			const render = renderFunc();
+			const node = guard(findOne(render, selector));
+			const parent = (node as any).parent;
+			const index = parent.children.indexOf(node);
+			let newChildren = [...parent.children];
+			switch (type) {
+				case 'before':
+					newChildren.splice(index, 0, ...children);
+					parent.children = newChildren;
+					break;
+				case 'after':
+					newChildren.splice(index + 1, 0, ...children);
+					parent.children = newChildren;
+					break;
+			}
+			return render;
+		});
 	};
 	assertionTemplateResult.getProperty = (selector: string, property: string) => {
 		const render = renderFunc();

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -119,4 +119,24 @@ describe('assertionTemplate', () => {
 		const propertyAssertion = tsxAssertion.setProperty('~li-one', 'foo', 'b');
 		h.expect(propertyAssertion);
 	});
+
+	it('should be immutable', () => {
+		const fooAssertion = baseAssertion
+			.setChildren(':root', ['foo'])
+			.setProperty(':root', 'foo', true)
+			.setProperty(':root', 'bar', false);
+		const barAssertion = fooAssertion
+			.setChildren(':root', ['bar'])
+			.setProperty(':root', 'foo', false)
+			.setProperty(':root', 'bar', true);
+
+		const foo = fooAssertion() as any;
+		const bar = barAssertion() as any;
+		assert.equal(foo!.children[0], 'foo');
+		assert.equal(bar!.children[0], 'bar');
+		assert.equal(foo!.properties.foo, true);
+		assert.equal(foo!.properties.bar, false);
+		assert.equal(bar!.properties.foo, false);
+		assert.equal(bar!.properties.bar, true);
+	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
The Assertion Template is meant to be immutable on setting, but currently only the first/base assertion is immutable.
