### PR TITLE
Add convenience methods for children setting in Assertion Templates

### DIFF
--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -389,4 +389,3 @@ formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 
 -   `formatUnit` => [`Globalize.formatUnit`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)
 -   `getUnitFormatter` => [`Globalize.unitFormatter`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)
-

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -389,3 +389,4 @@ formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 
 -   `formatUnit` => [`Globalize.formatUnit`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)
 -   `getUnitFormatter` => [`Globalize.unitFormatter`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)
+

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -320,7 +320,12 @@ Here we're using the `setChildren()` api on the baseAssertion, and we're using t
 Assertion Template has the following api's:
 
 ```
+insertBefore(selector: string, children: DNode[]): AssertionTemplateResult;
+insertAfter(selector: string, children: DNode[]): AssertionTemplateResult;
 insertChildren(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
+append(selector: string, children: DNode[]): AssertionTemplateResult;
+prepend(selector: string, children: DNode[]): AssertionTemplateResult;
+replace(selector: string, children: DNode[]): AssertionTemplateResult;
 setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
 getChildren(selector: string): DNode[];

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -322,7 +322,7 @@ Assertion Template has the following api's:
 ```
 insertBefore(selector: string, children: DNode[]): AssertionTemplateResult;
 insertAfter(selector: string, children: DNode[]): AssertionTemplateResult;
-insertChildren(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
+insertSiblings(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 append(selector: string, children: DNode[]): AssertionTemplateResult;
 prepend(selector: string, children: DNode[]): AssertionTemplateResult;
 replace(selector: string, children: DNode[]): AssertionTemplateResult;

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -4,7 +4,6 @@ import { VNode, WNode, DNode } from '../widget-core/interfaces';
 
 export interface AssertionTemplateResult {
 	(): DNode | DNode[];
-	(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 	append(selector: string, children: DNode[]): AssertionTemplateResult;
 	prepend(selector: string, children: DNode[]): AssertionTemplateResult;
 	replace(selector: string, children: DNode[]): AssertionTemplateResult;

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -4,6 +4,12 @@ import { VNode, WNode, DNode } from '../widget-core/interfaces';
 
 export interface AssertionTemplateResult {
 	(): DNode | DNode[];
+	(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
+	append(selector: string, children: DNode[]): AssertionTemplateResult;
+	prepend(selector: string, children: DNode[]): AssertionTemplateResult;
+	replace(selector: string, children: DNode[]): AssertionTemplateResult;
+	insertBefore(selector: string, children: DNode[]): AssertionTemplateResult;
+	insertAfter(selector: string, children: DNode[]): AssertionTemplateResult;
 	insertChildren(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 	setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 	setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
@@ -55,6 +61,15 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			return render;
 		});
 	};
+	assertionTemplateResult.append = (selector: string, children: DNode[]) => {
+		return assertionTemplateResult.setChildren(selector, children, 'append');
+	};
+	assertionTemplateResult.prepend = (selector: string, children: DNode[]) => {
+		return assertionTemplateResult.setChildren(selector, children, 'prepend');
+	};
+	assertionTemplateResult.replace = (selector: string, children: DNode[]) => {
+		return assertionTemplateResult.setChildren(selector, children, 'replace');
+	};
 	assertionTemplateResult.setChildren = (
 		selector: string,
 		children: DNode[],
@@ -77,6 +92,12 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			}
 			return render;
 		});
+	};
+	assertionTemplateResult.insertBefore = (selector: string, children: DNode[]) => {
+		return assertionTemplateResult.insertChildren(selector, children, 'before');
+	};
+	assertionTemplateResult.insertAfter = (selector: string, children: DNode[]) => {
+		return assertionTemplateResult.insertChildren(selector, children, 'after');
 	};
 	assertionTemplateResult.insertChildren = (
 		selector: string,

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -9,7 +9,7 @@ export interface AssertionTemplateResult {
 	replace(selector: string, children: DNode[]): AssertionTemplateResult;
 	insertBefore(selector: string, children: DNode[]): AssertionTemplateResult;
 	insertAfter(selector: string, children: DNode[]): AssertionTemplateResult;
-	insertChildren(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
+	insertSiblings(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 	setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 	setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
 	getChildren(selector: string): DNode[];
@@ -93,12 +93,12 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		});
 	};
 	assertionTemplateResult.insertBefore = (selector: string, children: DNode[]) => {
-		return assertionTemplateResult.insertChildren(selector, children, 'before');
+		return assertionTemplateResult.insertSiblings(selector, children, 'before');
 	};
 	assertionTemplateResult.insertAfter = (selector: string, children: DNode[]) => {
-		return assertionTemplateResult.insertChildren(selector, children, 'after');
+		return assertionTemplateResult.insertSiblings(selector, children, 'after');
 	};
-	assertionTemplateResult.insertChildren = (
+	assertionTemplateResult.insertSiblings = (
 		selector: string,
 		children: DNode[],
 		type: 'before' | 'after' = 'after'

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -86,31 +86,31 @@ describe('assertionTemplate', () => {
 
 	it('can set a child with replace', () => {
 		const h = harness(() => w(MyWidget, { replaceChild: true }));
-		const childAssertion = baseAssertion.setChildren('~header', ['replace'], 'replace');
+		const childAssertion = baseAssertion.replace('~header', ['replace']);
 		h.expect(childAssertion);
 	});
 
 	it('can set a child with prepend', () => {
 		const h = harness(() => w(MyWidget, { prependChild: true }));
-		const childAssertion = baseAssertion.setChildren('~header', ['prepend'], 'prepend');
+		const childAssertion = baseAssertion.prepend('~header', ['prepend']);
 		h.expect(childAssertion);
 	});
 
 	it('can set a child with append', () => {
 		const h = harness(() => w(MyWidget, { appendChild: true }));
-		const childAssertion = baseAssertion.setChildren('~header', ['append'], 'append');
+		const childAssertion = baseAssertion.append('~header', ['append']);
 		h.expect(childAssertion);
 	});
 
 	it('can set children after with insert', () => {
 		const h = harness(() => w(MyWidget, { after: true }));
-		const childAssertion = baseAssertion.insertChildren('ul', [v('span', ['after'])]);
+		const childAssertion = baseAssertion.insertAfter('ul', [v('span', ['after'])]);
 		h.expect(childAssertion);
 	});
 
 	it('can set children before with insert', () => {
 		const h = harness(() => w(MyWidget, { before: true }));
-		const childAssertion = baseAssertion.insertChildren('ul', [v('span', ['before'])], 'before');
+		const childAssertion = baseAssertion.insertBefore('ul', [v('span', ['before'])]);
 		h.expect(childAssertion);
 	});
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Adds convenience methods (insertBefore, insertAfter, prepend, append and replace) to the Assertion Template api. This should make the api a little more discoverable over the third argument on `setChildren` and `insertChildren`, but functionally no different.

I've also renamed `insertChildren` to `insertSiblings` as the former was incorrect technically.