### PR TITLE
Expand false type to boolean for supported class names

### DIFF
--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -81,7 +81,7 @@ export interface Projection {
 	readonly domNode: Element;
 }
 
-export type SupportedClassName = string | null | undefined | false;
+export type SupportedClassName = string | null | undefined | boolean;
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 

--- a/src/widget-core/mixins/Themed.ts
+++ b/src/widget-core/mixins/Themed.ts
@@ -170,7 +170,7 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 		}
 
 		private _getThemeClass(className: SupportedClassName): SupportedClassName {
-			if (className === undefined || className === null || className === false) {
+			if (className === undefined || className === null || className === false || className === true) {
 				return className;
 			}
 
@@ -190,7 +190,7 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 							const extraClass = this._classes[key][classNames[i]];
 							if (classNames[i] === themeClassName && extraClass) {
 								extraClass.forEach((className) => {
-									if (className) {
+									if (className && className !== true) {
 										classes.push(className);
 									}
 								});

--- a/tests/widget-core/unit/mixins/Themed.ts
+++ b/tests/widget-core/unit/mixins/Themed.ts
@@ -108,8 +108,8 @@ registerSuite('ThemedMixin', {
 			'should return null and undefineds unprocessed'() {
 				const ThemedInstance = new TestWidget();
 				const { class1, class2 } = baseThemeClasses1;
-				const flaggedClasses = ThemedInstance.theme([class1, null, class2, undefined]);
-				assert.deepEqual(flaggedClasses, [class1, null, class2, undefined]);
+				const flaggedClasses = ThemedInstance.theme([class1, null, class2, true, false, undefined]);
+				assert.deepEqual(flaggedClasses, [class1, null, class2, true, false, undefined]);
 				assert.isFalse(consoleStub.called);
 			}
 		},

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -3031,7 +3031,7 @@ jsdomDescribe('vdom', () => {
 			});
 
 			it('should accept falsy as a class', () => {
-				const [Widget] = getWidget(v('div', { classes: ['my-class', null, undefined, false, 'other'] }));
+				const [Widget] = getWidget(v('div', { classes: ['my-class', null, undefined, false, true, 'other'] }));
 				const div = document.createElement('div');
 				const root = document.createElement('div');
 				root.appendChild(div);
@@ -4828,6 +4828,28 @@ jsdomDescribe('vdom', () => {
 				r.mount({ domNode: div, sync: true, transition });
 				assert.isTrue(transition.enter.notCalled);
 			});
+			it('Does not invoke transition when false passed as enterAnimation', () => {
+				const transition = {
+					enter: stub(),
+					exit: stub()
+				};
+				const [Widget] = getWidget(v('div', [v('span', { enterAnimation: false })]));
+				const r = renderer(() => w(Widget, {}));
+				const div = document.createElement('div');
+				r.mount({ domNode: div, sync: true, transition });
+				assert.isTrue(transition.enter.notCalled);
+			});
+			it('Does not invoke transition when true passed as enterAnimation', () => {
+				const transition = {
+					enter: stub(),
+					exit: stub()
+				};
+				const [Widget] = getWidget(v('div', [v('span', { enterAnimation: true })]));
+				const r = renderer(() => w(Widget, {}));
+				const div = document.createElement('div');
+				r.mount({ domNode: div, sync: true, transition });
+				assert.isTrue(transition.enter.notCalled);
+			});
 		});
 		describe('exitAnimation', () => {
 			it('is invoked when a node is removed from an existing parent node', () => {
@@ -4862,6 +4884,30 @@ jsdomDescribe('vdom', () => {
 					exit: stub()
 				};
 				const [Widget, meta] = getWidget(v('div', [v('span', { exitAnimation: undefined })]));
+				const r = renderer(() => w(Widget, {}));
+				const div = document.createElement('div');
+				r.mount({ domNode: div, sync: true, transition });
+				meta.setRenderResult(v('div', []));
+				assert.isTrue(transition.exit.notCalled);
+			});
+			it('Does not invoke transition when false passed as exitAnimation', () => {
+				const transition = {
+					enter: stub(),
+					exit: stub()
+				};
+				const [Widget, meta] = getWidget(v('div', [v('span', { exitAnimation: false })]));
+				const r = renderer(() => w(Widget, {}));
+				const div = document.createElement('div');
+				r.mount({ domNode: div, sync: true, transition });
+				meta.setRenderResult(v('div', []));
+				assert.isTrue(transition.exit.notCalled);
+			});
+			it('Does not invoke transition when true passed as exitAnimation', () => {
+				const transition = {
+					enter: stub(),
+					exit: stub()
+				};
+				const [Widget, meta] = getWidget(v('div', [v('span', { exitAnimation: true })]));
 				const r = renderer(() => w(Widget, {}));
 				const div = document.createElement('div');
 				r.mount({ domNode: div, sync: true, transition });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The `false` returned for classes for the `SupportedClassName` type is expanded to `boolean` by TS in certain circumstances, which can cause errors when passing the result from `this.theme(` to `classes` on `VNodeProperties`. To deal with this we need to change the type to `boolean` and deal with `true` as a possible type (deal with in the same way as `false`, filter out).