### PR TITLE
`ThemeSwitcher`, `LocaleSwitcher` and generic `Provider` widgets

### DIFF
--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -389,4 +389,3 @@ formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 
 -   `formatUnit` => [`Globalize.formatUnit`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)
 -   `getUnitFormatter` => [`Globalize.unitFormatter`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)
-

--- a/src/widget-core/Provider.ts
+++ b/src/widget-core/Provider.ts
@@ -1,0 +1,44 @@
+import alwaysRender from './decorators/alwaysRender';
+import WidgetBase from './WidgetBase';
+import { DNode } from './interfaces';
+import diffProperty from './decorators/diffProperty';
+import has from '../has/has';
+
+export interface ProviderProperties<I> {
+	registryLabel: string;
+	renderer(injector: I): DNode | DNode[];
+}
+
+@alwaysRender()
+export class Provider<I = any> extends WidgetBase<ProviderProperties<I>> {
+	private _injector: I | undefined;
+	private _injectorHandle: any;
+
+	@diffProperty('registryLabel')
+	diffLabelChange(oldProps: ProviderProperties<I>, newProps: ProviderProperties<I>) {
+		const { registryLabel } = newProps;
+		const item = this.registry.getInjector<I>(registryLabel);
+		if (item) {
+			const { injector, invalidator } = item;
+			if (this._injectorHandle) {
+				this._injectorHandle.destroy();
+			}
+			this._injectorHandle = invalidator.on('invalidate', () => {
+				this.invalidate();
+			});
+			this.own(this._injectorHandle);
+			this._injector = injector();
+		}
+	}
+
+	protected render(): DNode | DNode[] {
+		const { renderer, registryLabel } = this.properties;
+		if (this._injector) {
+			return renderer(this._injector);
+		}
+		has('dojo-debug') && console.warn(`Injector has not been registered with label: '${registryLabel}'`);
+		return null;
+	}
+}
+
+export default Provider;

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -26,7 +26,7 @@ widget-core is a library to create powerful, composable user interface widgets.
     -   [Registry](#registry)
     -   [Decorator Lifecycle Hooks](#decorator-lifecycle-hooks)
     -   [Method Lifecycle Hooks](#method-lifecycle-hooks)
-    -   [Injectors, Providers and Containers](#injectors,-providers--containers)
+    -   [Injectors, Providers and Containers](#injectors-providers--containers)
     -   [Decorators](#decorators)
     -   [Meta Configuration](#meta-configuration)
     -   [Inserting DOM Nodes Into The VDom Tree](#inserting-dom-nodes-into-the-vdom-tree)
@@ -559,7 +559,7 @@ render() {
 
 #### Managing Themes Throughout an Application
 
-To manage themes throughout an application, the `ThemedMixin` leverages the [`Containers` and `Injectors`](#containers--injectors) to set an application's locale and inject the locale data into all widgets using the `ThemedMixin`. When the locale is updated in the theme `Injector` all themed widgets will be invalidated and re-rendered with the updated locale.
+To manage themes throughout an application, the `ThemedMixin` leverages the [Injectors, Providers & Containers](#injectors-providers--containers) to set an application's locale and inject the locale data into all widgets using the `ThemedMixin`. When the locale is updated in the theme `Injector` all themed widgets will be invalidated and re-rendered with the updated locale.
 
 `@dojo/framework/widget-core/mixins/Themed` exposes a convenience method, `registerThemeInjector`, for registering the `theme` injector with a registry.
 
@@ -745,7 +745,7 @@ export class MyWidget extends WidgetBase {
 
 #### Managing I18n throughout an Application
 
-To manage the i18n locale data throughout an application, the `I18nMixin` leverages the [`Containers` and `Injectors`](#containers--injectors) to set an application's locale and inject the locale data into all widgets using the `I18nMixin`. When the locale is updated in the i18n `Injector` all i18n widgets will be invalidated and re-rendered with the updated locale.
+To manage the i18n locale data throughout an application, the `I18nMixin` leverages the [Injectors, Providers & Containers](#injectors-providers--containers) to set an application's locale and inject the locale data into all widgets using the `I18nMixin`. When the locale is updated in the i18n `Injector` all i18n widgets will be invalidated and re-rendered with the updated locale.
 
 `@dojo/framework/widget-core/mixins/I18n` exposes a convenience method, `registerI18nInjector` for registering the `i18n` injector with a registry.
 
@@ -1028,7 +1028,7 @@ class MyWidget extends WidgetBase {
 
 ### Registry
 
-The `Registry` provides a mechanism to define widgets and injectors (see the [`Containers & Injectors`](#containers--injectors) section), that can be dynamically/lazily loaded on request. Once the registry widget is loaded all widgets that need the newly loaded widget will be invalidated and re-rendered automatically.
+The `Registry` provides a mechanism to define widgets and injectors (see the [Injectors, Providers & Containers](#injectors-providers--containers) section), that can be dynamically/lazily loaded on request. Once the registry widget is loaded all widgets that need the newly loaded widget will be invalidated and re-rendered automatically.
 
 A main registry can be provided to the `renderer`, which will be automatically passed to all widgets within the tree (referred to as `baseRegistry`). Each widget also gets access to a private `Registry` instance that can be used to define registry items that are scoped to the widget. The locally defined registry items are considered a higher precedence than an item registered in the `baseRegistry`.
 

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -586,9 +586,9 @@ To change the theme a widget `ThemeSwitcher` is available from `@dojo/framework/
 ##### Properties
 
 -   `renderer`: (updateTheme(theme: Theme) => void): DNode | DNode[]
-  -   The `renderer` that is called with the `updateTheme` function and returns `DNode | DNode[]` that will be rendered
+     -   The `renderer` that is called with the `updateTheme` function and returns `DNode | DNode[]` that will be rendered
 -   `registryLabel`(optional): string
-  -   The registry label used to register the theme injector. When using the `registerThemeInjector` this does not need to be set.
+     -   The registry label used to register the theme injector. When using the `registerThemeInjector` this does not need to be set.
 
 ##### Example Usage
 
@@ -771,9 +771,9 @@ When using the `Registry` to inject i18n properties to widgets using the `I18nMi
 ##### Properties
 
 -   `renderer`: (updateLocale(localeData: LocaleData) => void): DNode | DNode[]
-  -   The `renderer` that is called with the `updateLocale` function and returns `DNode | DNode[]` that will be rendered
+    -   The `renderer` that is called with the `updateLocale` function and returns `DNode | DNode[]` that will be rendered
 -   `registryLabel`(optional): string
-  -   The registry label used to register the i18n injector. When using the `registerI18nInjector` this does not need to be set.
+    -   The registry label used to register the i18n injector. When using the `registerI18nInjector` this does not need to be set.
 
 ##### Example Usage
 

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -559,7 +559,7 @@ render() {
 
 #### Managing Themes Throughout an Application
 
-To manage themes throughout an application, the `ThemedMixin` leverages the [Injectors, Providers & Containers](#injectors-providers--containers) to set an application's locale and inject the locale data into all widgets using the `ThemedMixin`. When the locale is updated in the theme `Injector` all themed widgets will be invalidated and re-rendered with the updated locale.
+To manage themes throughout an application, the `ThemedMixin` leverages the [Injectors, Providers & Containers](#injectors-providers--containers) to set an application's locale and inject the locale data into all widgets using the `ThemedMixin`. When the locale is updated in the theme `Injector` all themed widgets will be invalidated and re-rendered with the updated theme.
 
 `@dojo/framework/widget-core/mixins/Themed` exposes a convenience method, `registerThemeInjector`, for registering the `theme` injector with a registry.
 

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -586,9 +586,9 @@ To change the theme a widget `ThemeSwitcher` is available from `@dojo/framework/
 ##### Properties
 
 -   `renderer`: (updateTheme(theme: Theme) => void): DNode | DNode[]
--   The renderer that is called with the `updateTheme` function and returns `DNode | DNode[]` that will be rendered
+  -   The `renderer` that is called with the `updateTheme` function and returns `DNode | DNode[]` that will be rendered
 -   `registryLabel`(optional): string
--   The registry label used to register the theme injector. When using the `registerThemeInjector` this does not need to be set.
+  -   The registry label used to register the theme injector. When using the `registerThemeInjector` this does not need to be set.
 
 ##### Example Usage
 
@@ -771,9 +771,9 @@ When using the `Registry` to inject i18n properties to widgets using the `I18nMi
 ##### Properties
 
 -   `renderer`: (updateLocale(localeData: LocaleData) => void): DNode | DNode[]
--   The renderer that is called with the `updateLocale` function and returns `DNode | DNode[]` that will be rendered
+  -   The `renderer` that is called with the `updateLocale` function and returns `DNode | DNode[]` that will be rendered
 -   `registryLabel`(optional): string
--   The registry label used to register the i18n injector. When using the `registerI18nInjector` this does not need to be set.
+  -   The registry label used to register the i18n injector. When using the `registerI18nInjector` this does not need to be set.
 
 ##### Example Usage
 

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -557,6 +557,49 @@ render() {
 }
 ```
 
+#### Changing Theme
+
+To change a theme a widget `ThemeSwitcher` is available from `@dojo/framework/widget-core/mixins/Themed`, the `ThemeSwitcher` widget has a `renderer` property that injects an `updateTheme` function and returns `DNode | DNode[]` to render.
+
+##### Properties
+
+ * `renderer`: (updateTheme(theme: Theme) => void): DNode | DNode[]
+  * The renderer that is called with the `updateTheme` function and returns `DNode | DNode[]` that will be rendered
+ * `registryLabel`(optional): string
+  * The registry label used to register the theme injector. When using the `registerThemeInjector` this does not need to be set.
+
+##### Example Usage
+
+```ts
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import ThemedMixin, { ThemeSwitcher, theme, UpdateTheme } from '@dojo/framework/widget-core/mixins/Themed';
+
+import lightTheme from '../light-theme';
+import darkTheme from '../dark-theme';
+import * as css from './style/MyApp.m.css';
+
+@theme(css)
+class MyApp extends ThemedMixin(WidgetBase) {
+	protected render() {
+		return v('div', [
+			w(ThemeSwitcher, { renderer: (updateTheme: UpdateTheme) => {
+				return v('div', [
+					v('button', { onclick: () => {
+						updateTheme(lightTheme);
+					}}, ['light']),
+					v('button', { onclick: () => {
+						updateTheme(darkTheme);
+					}}, ['dark'])
+				]);
+			}}),
+			v('div', { classes: this.theme(css.container )})
+		]);
+	}
+}
+```
+
+The above example shows a themed widget, with the `ThemeSwitcher` used to render two buttons that will switch between a `light` and `dark` theme.
+
 #### Passing extra classes to widgets
 
 The theming mechanism is great for consistently applying custom styles across every widget, but isn't flexible enough for individual cases when a user wants to apply additional styles for a specific widget or widgets.

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -779,11 +779,11 @@ When using the `Registry` to inject i18n properties to widgets using the `I18nMi
 
 ```ts
 import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import I18ndMixin, { LocaleSwitcher, UpdateLocale } from '@dojo/framework/widget-core/mixins/I18n';
+import I18nMixin, { LocaleSwitcher, UpdateLocale } from '@dojo/framework/widget-core/mixins/I18n';
 
 import nlsBundle from '../nls/main';
 
-class MyApp extends I18ndMixin(WidgetBase) {
+class MyApp extends I18nMixin(WidgetBase) {
 	protected render() {
 		const { messages } = this.localizeBundle(nlsBundle);
 

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -557,11 +557,11 @@ render() {
 }
 ```
 
-#### Managing Themes throughout an Application
+#### Managing Themes Throughout an Application
 
 To manage themes throughout an application, the `ThemedMixin` leverages the [`Containers` and `Injectors`](#containers--injectors) to set an application's locale and inject the locale data into all widgets using the `ThemedMixin`. When the locale is updated in the theme `Injector` all themed widgets will be invalidated and re-rendered with the updated locale.
 
-`@dojo/framework/widget-core/mixins/Themed` exposes a convenience method, `registerThemeInjector` for registering the `theme` injector with a registry.
+`@dojo/framework/widget-core/mixins/Themed` exposes a convenience method, `registerThemeInjector`, for registering the `theme` injector with a registry.
 
 ```ts
 import renderer from '@dojo/framework/widget-core/vdom';
@@ -579,9 +579,9 @@ const r = renderer(() => w(App, {}));
 r.mount({ registry });
 ```
 
-#### Changing Theme
+#### Changing the Theme
 
-To change a theme a widget `ThemeSwitcher` is available from `@dojo/framework/widget-core/mixins/Themed`, the `ThemeSwitcher` widget has a `renderer` property that injects an `updateTheme` function and returns `DNode | DNode[]` to render.
+To change the theme a widget `ThemeSwitcher` is available from `@dojo/framework/widget-core/mixins/Themed`. The `ThemeSwitcher` widget has a `renderer` property that injects an `updateTheme` function and returns `DNode | DNode[]` to render.
 
 ##### Properties
 
@@ -1224,7 +1224,7 @@ registry.defineInjector('my-injector', (invalidator) => {
 });
 ```
 
-To connect (inject) the registered values to a widget there are two options. The first is the `Provider` which is a widget that is designed to be used inline the a widgets `render`. The `Provider` takes a `registryLabel` property and a `renderer` property that received the values from the registry. The second is the `Container` HOC (higher order component).
+To connect (inject) the registered values to a widget there are two options. The first is the `Provider` which is a widget that is designed to be used inline the widgets `render`. The `Provider` takes a `registryLabel` property and a `renderer` property that received the values from the registry. The second is the `Container` HOC (higher order component).
 
 #### Provider
 

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -557,6 +557,28 @@ render() {
 }
 ```
 
+#### Managing Theming throughout an Application
+
+To manage themes throughout an application, the `ThemedMixin` leverages the [`Containers` and `Injectors`](#containers--injectors) to set an application's locale and inject the locale data into all widgets using the `ThemedMixin`. When the locale is updated in the theme `Injector` all themed widgets will be invalidated and re-rendered with the updated locale.
+
+`@dojo/framework/widget-core/mixins/Themed` exposes a convenience method, `registerThemeInjector` for registering the `theme` injector with a registry.
+
+```ts
+import renderer from '@dojo/framework/widget-core/vdom';
+import { w } from '@dojo/framework/widget-core/d';
+import Registry from '@dojo/framework/widget-core/Registry';
+import { registerThemeInjector } from '@dojo/framework/widget-core/mixins/Themed';
+
+import myTheme from './theme';
+import App from './App';
+
+const registry = new Registry();
+registerThemeInjector(myTheme, registry);
+
+const r = renderer(() => w(App, {}));
+r.mount({ registry });
+```
+
 #### Changing Theme
 
 To change a theme a widget `ThemeSwitcher` is available from `@dojo/framework/widget-core/mixins/Themed`, the `ThemeSwitcher` widget has a `renderer` property that injects an `updateTheme` function and returns `DNode | DNode[]` to render.
@@ -720,6 +742,83 @@ export class MyWidget extends WidgetBase {
 	}
 }
 ```
+
+#### Managing I18n throughout an Application
+
+To manage the i18n locale data throughout an application, the `I18nMixin` leverages the [`Containers` and `Injectors`](#containers--injectors) to set an application's locale and inject the locale data into all widgets using the `I18nMixin`. When the locale is updated in the i18n `Injector` all i18n widgets will be invalidated and re-rendered with the updated locale.
+
+`@dojo/framework/widget-core/mixins/I18n` exposes a convenience method, `registerI18nInjector` for registering the `i18n` injector with a registry.
+
+```ts
+import renderer from '@dojo/framework/widget-core/vdom';
+import { w } from '@dojo/framework/widget-core/d';
+import Registry from '@dojo/framework/widget-core/Registry';
+import { registerI18nInjector } from '@dojo/framework/widget-core/mixins/I18n';
+
+import App from './App';
+
+const registry = new Registry();
+registerI18nInjector({ locale: 'us', rtl: false }, registry);
+
+const r = renderer(() => w(App, {}));
+r.mount({ registry });
+```
+
+#### Changing LocaleData
+
+When using the `Registry` to inject i18n properties to widgets using the `I18nMixin`, `@dojo/framework/widget-core/mixins/I18n` provides a widget, `LocaleSwitcher` that can be used to inject a function for changing the applications locale. The widget has a `renderer` property that injects an `updateLocale` function and returns `DNode | DNode[]` to render.
+
+##### Properties
+
+-   `renderer`: (updateLocale(localeData: LocaleData) => void): DNode | DNode[]
+-   The renderer that is called with the `updateLocale` function and returns `DNode | DNode[]` that will be rendered
+-   `registryLabel`(optional): string
+-   The registry label used to register the i18n injector. When using the `registerI18nInjector` this does not need to be set.
+
+##### Example Usage
+
+```ts
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import I18ndMixin, { LocaleSwitcher, UpdateLocale } from '@dojo/framework/widget-core/mixins/I18n';
+
+import nlsBundle from '../nls/main';
+
+class MyApp extends I18ndMixin(WidgetBase) {
+	protected render() {
+		const { messages } = this.localizeBundle(nlsBundle);
+
+		return v('div', [
+			w(LocaleSwitcher, {
+				renderer: (updateLocale: UpdateLocale) => {
+					return v('div', [
+						v(
+							'button',
+							{
+								onclick: () => {
+									updateLocale({ locale: 'gb' });
+								}
+							},
+							['English']
+						),
+						v(
+							'button',
+							{
+								onclick: () => {
+									updateLocale({ locale: 'fr' });
+								}
+							},
+							['French']
+						)
+					]);
+				}
+			}),
+			v('div', [messages.greetings])
+		]);
+	}
+}
+```
+
+The above example shows a I18n widget, with the `LocaleSwitcher` used to render two buttons that will switch the locale between a english and french.
 
 ## Key Principles
 

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -563,10 +563,10 @@ To change a theme a widget `ThemeSwitcher` is available from `@dojo/framework/wi
 
 ##### Properties
 
- * `renderer`: (updateTheme(theme: Theme) => void): DNode | DNode[]
-  * The renderer that is called with the `updateTheme` function and returns `DNode | DNode[]` that will be rendered
- * `registryLabel`(optional): string
-  * The registry label used to register the theme injector. When using the `registerThemeInjector` this does not need to be set.
+-   `renderer`: (updateTheme(theme: Theme) => void): DNode | DNode[]
+-   The renderer that is called with the `updateTheme` function and returns `DNode | DNode[]` that will be rendered
+-   `registryLabel`(optional): string
+-   The registry label used to register the theme injector. When using the `registerThemeInjector` this does not need to be set.
 
 ##### Example Usage
 
@@ -582,17 +582,31 @@ import * as css from './style/MyApp.m.css';
 class MyApp extends ThemedMixin(WidgetBase) {
 	protected render() {
 		return v('div', [
-			w(ThemeSwitcher, { renderer: (updateTheme: UpdateTheme) => {
-				return v('div', [
-					v('button', { onclick: () => {
-						updateTheme(lightTheme);
-					}}, ['light']),
-					v('button', { onclick: () => {
-						updateTheme(darkTheme);
-					}}, ['dark'])
-				]);
-			}}),
-			v('div', { classes: this.theme(css.container )})
+			w(ThemeSwitcher, {
+				renderer: (updateTheme: UpdateTheme) => {
+					return v('div', [
+						v(
+							'button',
+							{
+								onclick: () => {
+									updateTheme(lightTheme);
+								}
+							},
+							['light']
+						),
+						v(
+							'button',
+							{
+								onclick: () => {
+									updateTheme(darkTheme);
+								}
+							},
+							['dark']
+						)
+					]);
+				}
+			}),
+			v('div', { classes: this.theme(css.container) })
 		]);
 	}
 }

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -557,7 +557,7 @@ render() {
 }
 ```
 
-#### Managing Theming throughout an Application
+#### Managing Themes throughout an Application
 
 To manage themes throughout an application, the `ThemedMixin` leverages the [`Containers` and `Injectors`](#containers--injectors) to set an application's locale and inject the locale data into all widgets using the `ThemedMixin`. When the locale is updated in the theme `Injector` all themed widgets will be invalidated and re-rendered with the updated locale.
 

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -26,7 +26,7 @@ widget-core is a library to create powerful, composable user interface widgets.
     -   [Registry](#registry)
     -   [Decorator Lifecycle Hooks](#decorator-lifecycle-hooks)
     -   [Method Lifecycle Hooks](#method-lifecycle-hooks)
-    -   [Containers](#containers--injectors)
+    -   [Injectors, Providers and Containers](#injectors,-providers--containers)
     -   [Decorators](#decorators)
     -   [Meta Configuration](#meta-configuration)
     -   [Inserting DOM Nodes Into The VDom Tree](#inserting-dom-nodes-into-the-vdom-tree)
@@ -1200,7 +1200,7 @@ class MyClass extends WidgetBase {
 }
 ```
 
-### Containers & Injectors
+### Injectors, Providers & Containers
 
 There is built-in support for side-loading/injecting values into sections of the widget tree and mapping them to a widget's properties. This is achieved by registering an injector factory with a `registry` and setting the registry on the application's `renderer` to ensure the registry instance is available to your application.
 
@@ -1224,7 +1224,22 @@ registry.defineInjector('my-injector', (invalidator) => {
 });
 ```
 
-To connect the registered `payload` to a widget, we can use the `Container` HOC (higher order component) provided by `widget-core`. The `Container` accepts a widget `constructor`, `injector` label, and `getProperties` mapping function as arguments and returns a new class that returns the passed widget from its `render` function.
+To connect (inject) the registered values to a widget there are two options. The first is the `Provider` which is a widget that is designed to be used inline the a widgets `render`. The `Provider` takes a `registryLabel` property and a `renderer` property that received the values from the registry. The second is the `Container` HOC (higher order component).
+
+#### Provider
+
+The `Provider` is a standard widget, but has no visual output. Instead the visual aspect is provided by the `renderer` function property, the renderer function will receive the injector value from the registry.
+
+```ts
+w(Provider, { registryLabel: 'my-injector', renderer: (myInjector: MyInjector) => {
+	// do something with `myInjector` and return widgets and/or nodes.
+	return v('div', [ w(MyWidget, { text: myInjector.text })]);
+} })
+```
+
+#### Container
+
+The `Container` accepts a widget `constructor`, `injector` label, and `getProperties` mapping function as arguments and returns a new class that returns the passed widget from its `render` function.
 
 `getProperties` receives the `payload` returned from the injector function and the `properties` passed to the container HOC component. These are used to map into the wrapped widget's properties.
 

--- a/src/widget-core/mixins/I18n.ts
+++ b/src/widget-core/mixins/I18n.ts
@@ -97,7 +97,7 @@ export function registerI18nInjector(localeData: LocaleData, registry: Registry)
 	const injector = new Injector(localeData);
 	registry.defineInjector(INJECTOR_KEY, (invalidator) => {
 		injector.setInvalidator(invalidator);
-		return () => injector.get();
+		return () => injector;
 	});
 	return injector;
 }
@@ -105,7 +105,8 @@ export function registerI18nInjector(localeData: LocaleData, registry: Registry)
 export function I18nMixin<T extends Constructor<WidgetBase<any>>>(Base: T): T & Constructor<I18nMixin> {
 	@inject({
 		name: INJECTOR_KEY,
-		getProperties: (localeData: LocaleData, properties: I18nProperties) => {
+		getProperties: (injector: Injector<LocaleData>, properties: I18nProperties) => {
+			const localeData = injector.get();
 			const { locale = localeData.locale, rtl = localeData.rtl } = properties;
 			return { locale, rtl };
 		}

--- a/src/widget-core/mixins/Themed.ts
+++ b/src/widget-core/mixins/Themed.ts
@@ -7,6 +7,7 @@ import { handleDecorator } from './../decorators/handleDecorator';
 import { diffProperty } from './../decorators/diffProperty';
 import { shallow } from './../diff';
 import alwaysRender from '../decorators/alwaysRender';
+import has from '../../has/has';
 
 /**
  * A lookup object for available class names
@@ -105,21 +106,22 @@ export interface UpdateTheme {
 
 export interface ThemeSwitcherProperties {
 	registryLabel?: string;
-	renderer(updateTheme?: UpdateTheme): DNode | DNode[];
+	renderer(updateTheme: UpdateTheme): DNode | DNode[];
 }
 
 @alwaysRender()
 export class ThemeSwitcher extends WidgetBase<ThemeSwitcherProperties> {
 	protected render(): DNode | DNode[] {
 		const { renderer, registryLabel = INJECTED_THEME_KEY } = this.properties;
-		const injector = this.registry.getInjector<Injector>(registryLabel);
-		if (injector) {
-			const themeContext = injector.injector();
+		const injectorItem = this.registry.getInjector<Injector>(registryLabel);
+		if (injectorItem) {
+			const injector = injectorItem.injector();
 			return renderer((theme: Theme) => {
-				themeContext.set(theme);
+				injector.set(theme);
 			});
 		}
-		return renderer();
+		has('dojo-debug') && console.warn(`Theme injector has not been registered with label: '${registryLabel}'`);
+		return renderer(() => {});
 	}
 }
 

--- a/src/widget-core/mixins/Themed.ts
+++ b/src/widget-core/mixins/Themed.ts
@@ -1,4 +1,4 @@
-import { Constructor, WidgetProperties, SupportedClassName } from './../interfaces';
+import { Constructor, WidgetProperties, SupportedClassName, DNode } from './../interfaces';
 import { Registry } from './../Registry';
 import { Injector } from './../Injector';
 import { inject } from './../decorators/inject';
@@ -6,6 +6,7 @@ import { WidgetBase } from './../WidgetBase';
 import { handleDecorator } from './../decorators/handleDecorator';
 import { diffProperty } from './../decorators/diffProperty';
 import { shallow } from './../diff';
+import alwaysRender from '../decorators/alwaysRender';
 
 /**
  * A lookup object for available class names
@@ -96,6 +97,30 @@ export function registerThemeInjector(theme: any, themeRegistry: Registry): Inje
 		return () => themeInjector;
 	});
 	return themeInjector;
+}
+
+export interface UpdateTheme {
+	(theme: Theme): void;
+}
+
+export interface ThemeSwitcherProperties {
+	registryLabel?: string;
+	renderer(updateTheme?: UpdateTheme): DNode | DNode[];
+}
+
+@alwaysRender()
+export class ThemeSwitcher extends WidgetBase<ThemeSwitcherProperties> {
+	protected render(): DNode | DNode[] {
+		const { renderer, registryLabel = INJECTED_THEME_KEY } = this.properties;
+		const injector = this.registry.getInjector<Injector>(registryLabel);
+		if (injector) {
+			const themeContext = injector.injector();
+			return renderer((theme: Theme) => {
+				themeContext.set(theme);
+			});
+		}
+		return renderer();
+	}
 }
 
 /**

--- a/src/widget-core/mixins/Themed.ts
+++ b/src/widget-core/mixins/Themed.ts
@@ -93,7 +93,7 @@ export function registerThemeInjector(theme: any, themeRegistry: Registry): Inje
 	const themeInjector = new Injector(theme);
 	themeRegistry.defineInjector(INJECTED_THEME_KEY, (invalidator) => {
 		themeInjector.setInvalidator(invalidator);
-		return () => themeInjector.get();
+		return () => themeInjector;
 	});
 	return themeInjector;
 }
@@ -107,9 +107,9 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 ): Constructor<ThemedMixin<E>> & T {
 	@inject({
 		name: INJECTED_THEME_KEY,
-		getProperties: (theme: Theme, properties: ThemedProperties): ThemedProperties => {
+		getProperties: (injector: Injector<Theme>, properties: ThemedProperties): ThemedProperties => {
 			if (!properties.theme) {
-				return { theme };
+				return { theme: injector.get() };
 			}
 			return {};
 		}

--- a/tests/widget-core/unit/Provider.ts
+++ b/tests/widget-core/unit/Provider.ts
@@ -1,0 +1,120 @@
+const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+import Registry from '../../../src/widget-core/Registry';
+import Provider from '../../../src/widget-core/Provider';
+import { VNode } from '../../../src/widget-core/interfaces';
+import { SinonStub, stub } from 'sinon';
+import { add } from '../../../src/has/has';
+import { Injector } from '../../../src/widget-core/Injector';
+
+let consoleWarnStub: SinonStub;
+
+describe('Provider', () => {
+	beforeEach(() => {
+		add('dojo-debug', true, true);
+		consoleWarnStub = stub(console, 'warn');
+	});
+
+	afterEach(() => {
+		consoleWarnStub.restore();
+	});
+
+	it('Should inject custom injector into renderer', () => {
+		const registry = new Registry();
+		registry.defineInjector('test', () => {
+			return () => 'injected value';
+		});
+		const widget = new Provider();
+		widget.registry.base = registry;
+		widget.__setProperties__({
+			registryLabel: 'test',
+			renderer: (injector) => {
+				return injector;
+			}
+		});
+		const result = widget.__render__() as VNode;
+		assert.strictEqual(result.text, 'injected value');
+	});
+
+	it('Should warn in debug mode and return null when injector is not found', () => {
+		const widget = new Provider();
+		widget.__setProperties__({
+			registryLabel: 'test',
+			renderer: (injector) => {
+				return injector;
+			}
+		});
+		const result = widget.__render__() as VNode;
+		assert.isUndefined(result);
+		assert.isTrue(consoleWarnStub.calledOnce);
+		assert.strictEqual(consoleWarnStub.firstCall.args[0], "Injector has not been registered with label: 'test'");
+	});
+
+	it('Should not warn in non debug mode and return null when injector is not found', () => {
+		add('dojo-debug', false, true);
+		const widget = new Provider();
+		widget.__setProperties__({
+			registryLabel: 'test',
+			renderer: (injector) => {
+				return injector;
+			}
+		});
+		const result = widget.__render__() as VNode;
+		assert.isUndefined(result);
+		assert.isTrue(consoleWarnStub.notCalled);
+	});
+
+	it('should handle registry label change and ensure the initial injector is detached from the Provider', () => {
+		const registry = new Registry();
+		const injectorOne = new Injector('injected value');
+		const injectorTwo = new Injector('other injected value');
+		registry.defineInjector('testOne', (i) => {
+			injectorOne.setInvalidator(i);
+			return () => injectorOne;
+		});
+		registry.defineInjector('testTwo', (i) => {
+			injectorOne.setInvalidator(i);
+			return () => injectorTwo;
+		});
+
+		let invalidateCount = 0;
+
+		class TestProvider extends Provider {
+			invalidate() {
+				super.invalidate();
+				invalidateCount++;
+			}
+		}
+		const widget = new TestProvider();
+		widget.registry.base = registry;
+		widget.__setProperties__({
+			registryLabel: 'testOne',
+			renderer: (injector) => {
+				return injector.get();
+			}
+		});
+		let result = widget.__render__() as VNode;
+		assert.strictEqual(result.text, 'injected value');
+
+		widget.__setProperties__({
+			registryLabel: 'testTwo',
+			renderer: (injector) => {
+				return injector.get();
+			}
+		});
+		result = widget.__render__() as VNode;
+		assert.strictEqual(result.text, 'other injected value');
+		assert.strictEqual(invalidateCount, 4);
+
+		injectorOne.set('hello world');
+		// this would have increased by 2 if the injector was still connected
+		assert.strictEqual(invalidateCount, 5);
+		result = widget.__render__() as VNode;
+		assert.strictEqual(result.text, 'other injected value');
+
+		injectorTwo.set('new text');
+		result = widget.__render__() as VNode;
+		assert.strictEqual(result.text, 'new text');
+	});
+});

--- a/tests/widget-core/unit/all.ts
+++ b/tests/widget-core/unit/all.ts
@@ -1,4 +1,5 @@
 import './Container';
+import './Provider';
 import './WidgetBase';
 import './Registry';
 import './d';

--- a/tests/widget-core/unit/mixins/I18n.ts
+++ b/tests/widget-core/unit/mixins/I18n.ts
@@ -2,7 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import i18n, { invalidate, switchLocale, systemLocale } from '../../../../src/i18n/i18n';
 import Map from '../../../../src/shim/Map';
-import { INJECTOR_KEY, I18nMixin, I18nProperties, registerI18nInjector } from '../../../../src/widget-core/mixins/I18n';
+import { I18nMixin, I18nProperties, registerI18nInjector } from '../../../../src/widget-core/mixins/I18n';
 import { Registry } from '../../../../src/widget-core/Registry';
 import { WidgetBase } from '../../../../src/widget-core/WidgetBase';
 import bundle from '../../support/nls/greetings';
@@ -190,10 +190,9 @@ registerSuite('mixins/I18nMixin', {
 		},
 		'locale data can be injected by defining an Injector with a registry': {
 			'defaults to the injector data'() {
-				const injector = () => () => ({ locale: 'ar', rtl: true });
 				const registry = new Registry();
+				registerI18nInjector({ locale: 'ar', rtl: true }, registry);
 
-				registry.defineInjector(INJECTOR_KEY, injector);
 				localized = new Localized();
 				localized.registry.base = registry;
 				localized.__setProperties__({});
@@ -204,10 +203,9 @@ registerSuite('mixins/I18nMixin', {
 			},
 
 			'does not override property values'() {
-				const injector = () => () => ({ locale: 'ar', rtl: true });
 				const registry = new Registry();
+				registerI18nInjector({ locale: 'ar', rtl: true }, registry);
 
-				registry.defineInjector(INJECTOR_KEY, injector);
 				localized = new Localized();
 				localized.registry.base = registry;
 				localized.__setProperties__({ locale: 'fr', rtl: false });

--- a/tests/widget-core/unit/mixins/Themed.ts
+++ b/tests/widget-core/unit/mixins/Themed.ts
@@ -1,12 +1,6 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
-import {
-	ThemedMixin,
-	theme,
-	ThemedProperties,
-	INJECTED_THEME_KEY,
-	registerThemeInjector
-} from '../../../../src/widget-core/mixins/Themed';
+import { ThemedMixin, theme, ThemedProperties, registerThemeInjector } from '../../../../src/widget-core/mixins/Themed';
 import { WidgetBase } from '../../../../src/widget-core/WidgetBase';
 import { Registry } from '../../../../src/widget-core/Registry';
 import { v } from '../../../../src/widget-core/d';
@@ -238,8 +232,7 @@ registerSuite('ThemedMixin', {
 		},
 		'injecting a theme': {
 			'theme can be injected by defining a ThemeInjector with registry'() {
-				const injector = () => () => testTheme1;
-				testRegistry.defineInjector(INJECTED_THEME_KEY, injector);
+				registerThemeInjector(testTheme1, testRegistry);
 				class InjectedTheme extends TestWidget {
 					render() {
 						return v('div', { classes: this.theme(baseThemeClasses1.class1) });
@@ -252,8 +245,7 @@ registerSuite('ThemedMixin', {
 				assert.deepEqual(renderResult.properties.classes, 'theme1Class1');
 			},
 			'theme will not be injected if a theme has been passed via a property'() {
-				const injector = () => () => testTheme1;
-				testRegistry.defineInjector(INJECTED_THEME_KEY, injector);
+				registerThemeInjector(testTheme1, testRegistry);
 				class InjectedTheme extends TestWidget {
 					render() {
 						return v('div', { classes: this.theme(baseThemeClasses1.class1) });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

This pull requests adds a collection of similar widgets that can be used to work with injector values from an applications registry.

* ThemeSwitcher - Injects a function that can be used to change an the theme set in the theme injector
* LocaleSwitcher - Injects a function that can be used to change an the locale data set in the i18n injector
* Provider - A generic provider that enables consumers to work with injectors.

Resolves #258 
Resolves #257 
Resolves #256 
