### PR TITLE
V5 - Support integer like index keys in stores

### DIFF
--- a/src/stores/state/Pointer.ts
+++ b/src/stores/state/Pointer.ts
@@ -30,7 +30,7 @@ export function walk(segments: string[], object: any, clone = true, continueOnUn
 			segment = String(pointerTarget.target.length - 1);
 		}
 		if (index + 1 < segments.length) {
-			const nextSegment = segments[index + 1];
+			const nextSegment: any = segments[index + 1];
 			let target = pointerTarget.target[segment];
 
 			if (target === undefined && !continueOnUndefined) {
@@ -43,7 +43,7 @@ export function walk(segments: string[], object: any, clone = true, continueOnUn
 					target = [...target];
 				} else if (typeof target === 'object') {
 					target = { ...target };
-				} else if (isNaN(parseInt(nextSegment, 0))) {
+				} else if (isNaN(nextSegment) || isNaN(parseInt(nextSegment, 0))) {
 					target = {};
 				} else {
 					target = [];

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -15,7 +15,7 @@ import {
 	createCallbackDecorator
 } from '../../../src/stores/process';
 import { Store } from '../../../src/stores/Store';
-import { replace } from '../../../src/stores/state/operations';
+import { replace, add } from '../../../src/stores/state/operations';
 
 let store: Store;
 let promises: Promise<any>[] = [];
@@ -167,6 +167,18 @@ describe('process', () => {
 		});
 
 		assert.equal(typeof command, 'function');
+	});
+
+	it('should add object by integer like index key', () => {
+		const id = '3fe3c6d3-15e1-4d77-886f-daeb0ed63458';
+		const createCommand = createCommandFactory<any>();
+		const command = createCommand(({ get, path, payload }) => {
+			return [add(path('test', id), { foo: 'bar' })];
+		});
+		const process = createProcess('test', [command]);
+		const executor = process(store);
+		executor({});
+		assert.deepEqual(store.get(store.path('test')), { [id]: { foo: 'bar' } });
 	});
 
 	it('can type payload that extends an object', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fixes a bug where using index keys for an object in stores that starts with a number.

Resolves #260 