### PR TITLE
add validation meta

### DIFF
--- a/src/widget-core/meta/InputValidity.ts
+++ b/src/widget-core/meta/InputValidity.ts
@@ -1,0 +1,22 @@
+import Base from './Base';
+
+export class InputValidity extends Base {
+	get(key: string | number, value: string) {
+		const node = this.getNode(key) as HTMLFormElement | undefined;
+
+		if (!node) {
+			return { valid: undefined, message: '' };
+		}
+
+		if (value !== node.value) {
+			setTimeout(() => this.invalidate());
+		}
+
+		return {
+			valid: node.validity.valid,
+			message: node.validationMessage
+		};
+	}
+}
+
+export default InputValidity;

--- a/src/widget-core/meta/InputValidity.ts
+++ b/src/widget-core/meta/InputValidity.ts
@@ -13,7 +13,6 @@ export class InputValidity extends Base {
 			// validation check will be one render behind.
 			// Call invalidate on the next loop.
 			setTimeout(() => this.invalidate());
-			return { valid: undefined, message: '' };
 		}
 
 		return {

--- a/src/widget-core/meta/InputValidity.ts
+++ b/src/widget-core/meta/InputValidity.ts
@@ -9,7 +9,11 @@ export class InputValidity extends Base {
 		}
 
 		if (value !== node.value) {
+			// if the vdom is out of sync with the real dom our
+			// validation check will be one render behind.
+			// Call invalidate on the next loop.
 			setTimeout(() => this.invalidate());
+			return { valid: undefined, message: '' };
 		}
 
 		return {

--- a/tests/widget-core/unit/meta/InputValidity.ts
+++ b/tests/widget-core/unit/meta/InputValidity.ts
@@ -1,6 +1,5 @@
 const { registerSuite } = intern.getPlugin('jsdom');
 const { assert } = intern.getPlugin('chai');
-// import global from '../../../../src/shim/global';
 import { createSandbox, SinonStub } from 'sinon';
 import InputValidity from '../../../../src/widget-core/meta/InputValidity';
 

--- a/tests/widget-core/unit/meta/InputValidity.ts
+++ b/tests/widget-core/unit/meta/InputValidity.ts
@@ -1,0 +1,87 @@
+const { registerSuite } = intern.getPlugin('jsdom');
+const { assert } = intern.getPlugin('chai');
+// import global from '../../../../src/shim/global';
+import { createSandbox, SinonStub } from 'sinon';
+import InputValidity from '../../../../src/widget-core/meta/InputValidity';
+
+import NodeHandler from '../../../../src/widget-core/NodeHandler';
+import WidgetBase from '../../../../src/widget-core/WidgetBase';
+
+const sandbox = createSandbox();
+let bindInstance: WidgetBase;
+let invalidateStub: SinonStub;
+let nodeHandler: NodeHandler;
+
+registerSuite('meta - InputValidity', {
+	async before() {
+		bindInstance = new WidgetBase();
+	},
+
+	beforeEach() {
+		invalidateStub = sandbox.stub();
+		nodeHandler = new NodeHandler();
+	},
+
+	afterEach() {
+		sandbox.restore();
+	},
+
+	tests: {
+		'returns default values when node is not found'() {
+			sandbox.stub(nodeHandler, 'get').returns(undefined);
+			const validity = new InputValidity({
+				invalidate: invalidateStub,
+				nodeHandler,
+				bind: bindInstance
+			});
+
+			const { message, valid } = validity.get('test', 'testValue');
+			assert.strictEqual(message, '');
+			assert.isUndefined(valid);
+		},
+
+		'returns the validity and message for the element'() {
+			sandbox.stub(nodeHandler, 'get').returns({
+				validity: { valid: false },
+				value: 'testValue',
+				validationMessage: 'test validation message'
+			});
+			const validity = new InputValidity({
+				invalidate: invalidateStub,
+				nodeHandler,
+				bind: bindInstance
+			});
+
+			const { message, valid } = validity.get('test', 'testValue');
+			assert.strictEqual(message, 'test validation message');
+			assert.isFalse(valid);
+		},
+
+		async 'calls invalidate if node values do not match'() {
+			const nodeHandler = new NodeHandler();
+			const nodeStub = sandbox
+				.stub(nodeHandler, 'get')
+				.withArgs('input')
+				.returns({
+					validity: { valid: true },
+					value: 'test1',
+					validationMessage: ''
+				});
+
+			const validity = new InputValidity({
+				invalidate: invalidateStub,
+				nodeHandler,
+				bind: bindInstance
+			});
+
+			validity.get('input', 'test2');
+			return new Promise((resolve) => {
+				setTimeout(() => {
+					assert.isTrue(invalidateStub.calledOnce);
+					nodeStub.reset();
+					resolve();
+				}, 10);
+			});
+		}
+	}
+});

--- a/tests/widget-core/unit/meta/all.ts
+++ b/tests/widget-core/unit/meta/all.ts
@@ -3,6 +3,7 @@ import './meta';
 import './Dimensions';
 import './Drag';
 import './Focus';
+import './InputValidity';
 import './Intersection';
 import './Resize';
 import './WebAnimation';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue (dojo/widgets#664)
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR adds a new meta that specifically returns information from the browser's form validation API. This can be used to target HTML form elements, such as `<input type="email">`, and will return an object containing information about whether the element passes validation and whether it contains a message.

#### Invalid Example

Given the following:

```tsx
render() {
    const value = 'test';
    const validity = this.meta(InputValidity).get('input', value);
    render (
        <input type="email" key="input" value={value}/>
    )
}
```
This meta will return the following:

```typescript
{
    valid: false,
    message: "Please include an '@' in the email address. 'test' is missing an '@'."
}
```

#### Valid Example

Given the following:

```tsx
render() {
    const value = 'test@example.com';
    const validity = this.meta(InputValidity).get('input', value);
    render (
        <input type="email" key="input" value={value}/>
    )
}
```
This meta will return the following:

```typescript
{
    valid: true,
    message: ""
}
```