### PR TITLE
Assertion Template enhancements

### DIFF
--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -1,6 +1,9 @@
 import select from './support/selector';
 import { isWNode, isVNode, decorate } from '../widget-core/d';
 import { VNode, WNode, DNode } from '../widget-core/interfaces';
+import WidgetBase from '../widget-core/WidgetBase';
+
+export type PropertiesComparatorFunction = (expectedProperties: any, actualProperties: any) => any;
 
 export interface AssertionTemplateResult {
 	(): DNode | DNode[];
@@ -12,8 +15,10 @@ export interface AssertionTemplateResult {
 	insertSiblings(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 	setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 	setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
+	setProperties(selector: string, value: any | PropertiesComparatorFunction): AssertionTemplateResult;
 	getChildren(selector: string): DNode[];
 	getProperty(selector: string, property: string): any;
+	getProperties(selector: string): any;
 }
 
 const findOne = (nodes: DNode | DNode[], selector: string): DNode | undefined => {
@@ -41,6 +46,8 @@ const guard = (node: DNode): NodeWithProperties => {
 	return node;
 };
 
+export class Mimic extends WidgetBase {}
+
 export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 	const assertionTemplateResult: any = () => {
 		const render = renderFunc();
@@ -57,6 +64,14 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			const render = renderFunc();
 			const node = guard(findOne(render, selector));
 			node.properties[property] = value;
+			return render;
+		});
+	};
+	assertionTemplateResult.setProperties = (selector: string, value: any | PropertiesComparatorFunction) => {
+		return assertionTemplate(() => {
+			const render = renderFunc();
+			const node = guard(findOne(render, selector));
+			node.properties = value;
 			return render;
 		});
 	};
@@ -126,6 +141,11 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		const render = renderFunc();
 		const node = guard(findOne(render, selector));
 		return node.properties[property];
+	};
+	assertionTemplateResult.getProperties = (selector: string, property: string) => {
+		const render = renderFunc();
+		const node = guard(findOne(render, selector));
+		return node.properties;
 	};
 	assertionTemplateResult.getChildren = (selector: string) => {
 		const render = renderFunc();

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -5,6 +5,7 @@ import WeakMap from '../../shim/WeakMap';
 import Set from '../../shim/Set';
 import Map from '../../shim/Map';
 import { from as arrayFrom } from '../../shim/array';
+import { Mimic } from '../assertionTemplate';
 
 let widgetClassCounter = 0;
 const widgetMap = new WeakMap<Constructor<DefaultWidgetBaseInterface>, number>();
@@ -98,9 +99,55 @@ function formatNode(node: WNode | VNode, tabs: any): string {
 	return `v("${node.tag}", ${properties}`;
 }
 
+const assertionWidgets = [
+	{
+		type: Mimic,
+		value(actual: DNode, expected: DNode) {
+			return [actual, actual];
+		}
+	}
+];
+
+function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[], DNode[]] {
+	actual = Array.isArray(actual) ? actual : [actual];
+	expected = Array.isArray(expected) ? expected : [expected];
+	let actualDecoratedNodes = [];
+	let expectedDecoratedNodes = [];
+	for (let i = 0; i < expected.length; i++) {
+		let actualNode = actual[i];
+		let expectedNode = expected[i];
+
+		if (isWNode(expectedNode)) {
+			[actualNode, expectedNode] = assertionWidgets.reduce(
+				(result, assertionWidget) => {
+					if ((expectedNode as any).widgetConstructor === assertionWidget.type) {
+						return assertionWidget.value(result[0], result[1]);
+					}
+					return [result[0], result[1]];
+				},
+				[actualNode, expectedNode]
+			);
+		}
+		if ((isWNode(actualNode) || isVNode(actualNode)) && (isWNode(expectedNode) || isVNode(expectedNode))) {
+			if (typeof expectedNode.properties === 'function') {
+				expectedNode.properties = expectedNode.properties(expectedNode.properties, actualNode.properties);
+			}
+			if (actualNode.children && expectedNode.children) {
+				const [actualChildren, expectedChildren] = decorate(actualNode.children, expectedNode.children);
+				actualNode.children = actualChildren;
+				expectedNode.children = expectedChildren;
+			}
+		}
+		actualDecoratedNodes.push(actualNode);
+		expectedDecoratedNodes.push(expectedNode);
+	}
+	return [actualDecoratedNodes, expectedDecoratedNodes];
+}
+
 export function assertRender(actual: DNode | DNode[], expected: DNode | DNode[], message?: string): void {
-	const parsedActual = formatDNodes(actual);
-	const parsedExpected = formatDNodes(expected);
+	const [decoratedActual, decoratedExpected] = decorate(actual, expected);
+	const parsedActual = formatDNodes(Array.isArray(actual) ? decoratedActual : decoratedActual[0]);
+	const parsedExpected = formatDNodes(Array.isArray(expected) ? decoratedExpected : decoratedExpected[0]);
 	const diffResult = diff.diffLines(parsedActual, parsedExpected);
 	let diffFound = false;
 	const parsedDiff = diffResult.reduce((result: string, part, index) => {

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -103,7 +103,8 @@ const assertionWidgets = [
 	{
 		type: Mimic,
 		value(actual: DNode, expected: DNode) {
-			return [actual, actual];
+			const node = actual ? actual : expected;
+			return [actual, node];
 		}
 	}
 ];

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -109,7 +109,7 @@ const assertionWidgets = [
 	}
 ];
 
-function isWNodeOrVNode(node: any): node is VNode | WNode {
+function isNode(node: any): node is VNode | WNode {
 	return isVNode(node) || isWNode(node);
 }
 
@@ -134,20 +134,20 @@ function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[],
 				[actualNode, expectedNode]
 			);
 		}
-		if (isWNodeOrVNode(expectedNode)) {
+		if (isNode(expectedNode)) {
 			if (typeof expectedNode.properties === 'function') {
-				const actualProperties = isWNodeOrVNode(actualNode) ? actualNode.properties : {};
+				const actualProperties = isNode(actualNode) ? actualNode.properties : {};
 				expectedNode.properties = expectedNode.properties(expectedNode.properties, actualProperties);
 			}
 		}
-		const childrenA = isWNodeOrVNode(actualNode) ? actualNode.children : [];
-		const childrenB = isWNodeOrVNode(expectedNode) ? expectedNode.children : [];
+		const childrenA = isNode(actualNode) ? actualNode.children : [];
+		const childrenB = isNode(expectedNode) ? expectedNode.children : [];
 
 		const [actualChildren, expectedChildren] = decorate(childrenA, childrenB);
-		if (isWNodeOrVNode(actualNode)) {
+		if (isNode(actualNode)) {
 			actualNode.children = actualChildren;
 		}
-		if (isWNodeOrVNode(expectedNode)) {
+		if (isNode(expectedNode)) {
 			expectedNode.children = expectedChildren;
 		}
 		actualDecoratedNodes.push(actualNode);

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -5,7 +5,7 @@ import { harness } from '../../../src/testing/harness';
 import { WidgetBase } from '../../../src/widget-core/WidgetBase';
 import { v, w } from '../../../src/widget-core/d';
 import { tsx } from '../../../src/widget-core/tsx';
-import assertionTemplate from '../../../src/testing/assertionTemplate';
+import assertionTemplate, { Mimic } from '../../../src/testing/assertionTemplate';
 
 class MyWidget extends WidgetBase<{
 	toggleProperty?: boolean;
@@ -62,6 +62,11 @@ describe('assertionTemplate', () => {
 		assert.deepEqual(classes, ['root']);
 	});
 
+	it('can get properties', () => {
+		const properties = baseAssertion.getProperties('~root');
+		assert.deepEqual(properties, { '~key': 'root', classes: ['root'] });
+	});
+
 	it('can get a child', () => {
 		const children = baseAssertion.getChildren('~header');
 		assert.equal(children[0], 'hello');
@@ -75,6 +80,20 @@ describe('assertionTemplate', () => {
 	it('can set a property', () => {
 		const h = harness(() => w(MyWidget, { toggleProperty: true }));
 		const propertyAssertion = baseAssertion.setProperty('~li-one', 'foo', 'b');
+		h.expect(propertyAssertion);
+	});
+
+	it('can set properties', () => {
+		const h = harness(() => w(MyWidget, { toggleProperty: true }));
+		const propertyAssertion = baseAssertion.setProperties('~li-one', { foo: 'b' });
+		h.expect(propertyAssertion);
+	});
+
+	it('can set properties and use the actual properties', () => {
+		const h = harness(() => w(MyWidget, { toggleProperty: true }));
+		const propertyAssertion = baseAssertion.setProperties('~li-one', (expectedProps: any, actualProps: any) => {
+			return actualProps;
+		});
 		h.expect(propertyAssertion);
 	});
 
@@ -118,6 +137,12 @@ describe('assertionTemplate', () => {
 		const h = harness(() => <MyWidget toggleProperty={true} />);
 		const propertyAssertion = tsxAssertion.setProperty('~li-one', 'foo', 'b');
 		h.expect(propertyAssertion);
+	});
+
+	it('can use mimic', () => {
+		const h = harness(() => w(MyWidget, {}));
+		const childAssertion = baseAssertion.replace('~header', [w(Mimic, {})]);
+		h.expect(childAssertion);
 	});
 
 	it('should be immutable', () => {

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -43,6 +43,18 @@ const baseAssertion = assertionTemplate(() =>
 	])
 );
 
+class ListWidget extends WidgetBase {
+	render() {
+		let children = [];
+		for (let i = 0; i < 30; i++) {
+			children.push(v('li', [`item: ${i}`]));
+		}
+		return v('div', { classes: ['root'] }, [v('ul', children)]);
+	}
+}
+
+const baseListAssertion = assertionTemplate(() => v('div', { classes: ['root'] }, [v('ul', [])]));
+
 const tsxAssertion = assertionTemplate(() => (
 	<div classes={['root']}>
 		<h2>hello</h2>
@@ -140,9 +152,12 @@ describe('assertionTemplate', () => {
 	});
 
 	it('can use mimic', () => {
-		const h = harness(() => w(MyWidget, {}));
-		const childAssertion = baseAssertion.replace('~header', [w(Mimic, {})]);
-		h.expect(childAssertion);
+		const h = harness(() => w(ListWidget, {}));
+		const childListAssertion = baseListAssertion.replace('ul', [
+			v('li', ['item: 0']),
+			...new Array(29).fill(w(Mimic, {}))
+		]);
+		h.expect(childListAssertion);
 	});
 
 	it('should be immutable', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for a new testing widget called `Mimic`. This can be used in Assertion Templates to explicitly ignore/match children against the actual render. This is extremely useful in scenario's with N number of items, as you can assert say the first one and mimic the remaining N items.

Adds `getProperties` and `setProperties` to complement the existing `getProperty` and `setProperties` api. The `setProperties` has one useful addition, if you pass it a function rather than an object, the function will be called with both the expected properties and the actual properties of that node. This allows you to emulate partial assertion on properties while still asserting the entire property set.
