### PR TITLE
Prefer deferred render callback over idle callback for user impacting actions

### DIFF
--- a/tests/widget-core/support/util.ts
+++ b/tests/widget-core/support/util.ts
@@ -24,14 +24,14 @@ export function createResolvers() {
 	let rAFStub: SinonStub;
 	let rICStub: SinonStub;
 
-	function resolveRAF() {
+	function resolveRAFCallbacks() {
 		for (let i = 0; i < rAFStub.callCount; i++) {
 			rAFStub.getCall(i).callArg(0);
 		}
 		rAFStub.resetHistory();
 	}
 
-	function resolveRIC() {
+	function resolveRICCallbacks() {
 		for (let i = 0; i < rICStub.callCount; i++) {
 			rICStub.getCall(i).callArg(0);
 		}
@@ -40,8 +40,14 @@ export function createResolvers() {
 
 	return {
 		resolve() {
-			resolveRAF();
-			resolveRIC();
+			resolveRAFCallbacks();
+			resolveRICCallbacks();
+		},
+		resolveRIC() {
+			resolveRICCallbacks();
+		},
+		resolveRAF() {
+			resolveRAFCallbacks();
 		},
 		stub() {
 			rAFStub = stub(global, 'requestAnimationFrame').returns(1);

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -2083,9 +2083,13 @@ jsdomDescribe('vdom', () => {
 				assert.isTrue(onDetachStub.notCalled);
 				return remove(child);
 			};
-			r.mount({ domNode: div, sync: true });
+			r.mount({ domNode: div });
 			toggleShow();
-			assert.isTrue(onDetachStub.called);
+			resolvers.resolveRAF();
+			assert.isTrue(onDetachStub.calledOnce);
+			assert.strictEqual(removeChildCount, 1);
+			resolvers.resolveRIC();
+			assert.isTrue(onDetachStub.calledOnce);
 			assert.strictEqual(removeChildCount, 1);
 		});
 
@@ -2337,8 +2341,8 @@ jsdomDescribe('vdom', () => {
 
 			const r = renderer(() => w(Foo, {}));
 			const div = document.createElement('div');
-			r.mount({ domNode: div, sync: true });
-			resolvers.resolve();
+			r.mount({ domNode: div });
+			resolvers.resolveRAF();
 			assert.strictEqual(deferredPropertyCallCount, 8);
 			const root = div.childNodes[0] as Element;
 			assert.lengthOf(root.childNodes, 2);
@@ -2352,8 +2356,12 @@ jsdomDescribe('vdom', () => {
 			assert.lengthOf(barContainer.childNodes, 1);
 			const barLabel = barContainer.childNodes[0] as Text;
 			assert.strictEqual(barLabel.data, 'bar-container');
+			resolvers.resolveRIC();
+			assert.strictEqual(deferredPropertyCallCount, 8);
 			invalidate();
-			resolvers.resolve();
+			resolvers.resolveRAF();
+			assert.strictEqual(deferredPropertyCallCount, 12);
+			resolvers.resolveRIC();
 			assert.strictEqual(deferredPropertyCallCount, 12);
 		});
 
@@ -5036,9 +5044,14 @@ jsdomDescribe('vdom', () => {
 			r.mount();
 			const input = document.body.lastChild as HTMLElement;
 			const focusSpy = spy(input, 'focus');
-			resolvers.resolve();
+			resolvers.resolveRAF();
+			assert.isTrue(focusSpy.calledOnce);
+			resolvers.resolveRIC();
 			assert.isTrue(focusSpy.calledOnce);
 			meta.setRenderResult(v('input', { focus: true }));
+			resolvers.resolveRAF();
+			assert.isTrue(focusSpy.calledOnce);
+			resolvers.resolveRIC();
 			assert.isTrue(focusSpy.calledOnce);
 			document.body.removeChild(input);
 		});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Deferred callbacks that impact the user, should be scheduled on the RAF over the RIC. Currently running detach on orphaned widgets, applying special VDom properties such as `focus` and executing deferred properties is done on the RIC. However as they are important for visual feedback these should be scheduled with a higher priority (therefore use the RAF).

Leaves the distinguishable node check on the RIC as it is acceptable to only run that when the browser is idle.