### PR TITLE
Default `stateKey` property for `StoreProvider`

### DIFF
--- a/src/stores/StoreProvider.ts
+++ b/src/stores/StoreProvider.ts
@@ -12,7 +12,7 @@ export interface GetPaths<S = any> {
 
 export interface StoreProviderProperties<S = any> {
 	renderer: (store: Store<S>) => DNode | DNode[];
-	stateKey: string;
+	stateKey?: string;
 	paths?: GetPaths<S>;
 }
 
@@ -41,10 +41,14 @@ export class StoreProvider<S = any> extends WidgetBase<StoreProviderProperties<S
 		}
 	}
 
+	private _getProperties() {
+		return { stateKey: 'state', ...this.properties };
+	}
+
 	@diffProperty('stateKey')
 	@diffProperty('paths', pathDiff)
-	protected onChange(previousProperties: StoreProviderProperties, currentProperties: StoreProviderProperties) {
-		const { stateKey, paths } = currentProperties;
+	protected onChange(previousProperties: any, currentProperties: StoreProviderProperties) {
+		const { stateKey = 'state', paths } = currentProperties;
 		if (this._handle) {
 			this._handle.destroy();
 			this._handle = undefined;
@@ -68,8 +72,11 @@ export class StoreProvider<S = any> extends WidgetBase<StoreProviderProperties<S
 	}
 
 	protected render(): DNode | DNode[] {
-		const { stateKey, renderer } = this.properties;
+		const { stateKey, renderer } = this._getProperties();
 		const store = this._getStore(stateKey);
+		if (!this._handle) {
+			this.onChange({}, this._getProperties());
+		}
 		if (store) {
 			return renderer(store);
 		}

--- a/tests/stores/unit/StoreProvider.ts
+++ b/tests/stores/unit/StoreProvider.ts
@@ -88,12 +88,12 @@ describe('StoreProvider', () => {
 		const container = new TestContainer();
 		container.registry.base = registry;
 		container.__setProperties__({
-			stateKey: 'state',
 			renderer(injectedStore) {
 				assert.strictEqual<any>(injectedStore, store);
 				return v('div');
 			}
 		});
+		container.__render__();
 		invalidateCount = 0;
 		fooProcess(store)({});
 		assert.strictEqual(invalidateCount, 1);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Default the `stateKey` property to the default store registry label.

Resolves #261 
