### PR TITLE
No longer throw by default on unregistered has() checks 

### DIFF
--- a/src/has/has.ts
+++ b/src/has/has.ts
@@ -173,7 +173,7 @@ export function add(feature: string, value: FeatureTest | FeatureTestResult, ove
  *
  * @param feature The name of the feature to test.
  */
-export default function has(feature: string): FeatureTestResult {
+export default function has(feature: string, strict: boolean = false): FeatureTestResult {
 	let result: FeatureTestResult;
 
 	const normalizedFeature = feature.toLowerCase();
@@ -185,7 +185,7 @@ export default function has(feature: string): FeatureTestResult {
 		delete testFunctions[normalizedFeature];
 	} else if (normalizedFeature in testCache) {
 		result = testCache[normalizedFeature];
-	} else {
+	} else if (strict) {
 		throw new TypeError(`Attempt to detect unregistered has feature "${feature}"`);
 	}
 

--- a/src/shim/support/decorators.ts
+++ b/src/shim/support/decorators.ts
@@ -10,6 +10,6 @@ import has from '../../has/has';
 export function hasClass(feature: string, trueClass: Function, falseClass: Function): ClassDecorator {
 	return function(target: Function) {
 		/* Return type generics aren't catching the fact that Function is assignable to the generic */
-		return (has(feature) ? trueClass : falseClass) as any;
+		return (has(feature, true) ? trueClass : falseClass) as any;
 	};
 }

--- a/tests/has/unit/has.ts
+++ b/tests/has/unit/has.ts
@@ -59,15 +59,22 @@ registerSuite('has', {
 				assert.isTrue(hasCache['abc']);
 				hasAdd('def', false);
 				assert.isFalse(hasCache['def']);
-
 				delete hasCache['abc'];
+			},
+
+			'throws when unregistered in strict mode'() {
 				assert.throws(
 					() => {
-						has('abc');
+						has('abc', true);
 					},
 					TypeError,
 					'Attempt to detect unregistered has feature'
 				);
+			},
+
+			'returns undefined when unregistered'() {
+				const abc = has('abc');
+				assert.equal(abc, undefined);
 			},
 
 			'deferred feature test should not populate cache until evaluated'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
No longer throw when performing has() checks on unregistered features by default. Throwing by default is quite annoying, especially as we now leverage a lot of `has()` checks as part of the build tool where they are mostly progressive, so when using without the build tool (ie in a codesandbox) we'd have to write different code.

An additional strict param to enable the old functionality has been added.
