### PR TITLE
Fix links to the i18n ref guide from elsewhere in framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are eight sub-packages that form the framework for building a Dojo applica
 
 * [`dojo/core`](src/core/README.md) - The foundational code of the Dojo platform
 * [`dojo/has`](src/has/README.md) - A feature detection library
-* [`dojo/i18n`](docs/i18n/index.md) - A set of internationalization tooling
+* [`dojo/i18n`](docs/en/i18n/index.md) - A set of internationalization tooling
 * [`dojo/routing`](src/routing/README.md) - A routing service to build web applications with
 * [`dojo/shim`](src/shim/README.md) - Modules that provide fills of ES6+ functionality
 * [`dojo/stores`](src/stores/README.md) - A lightweight state container

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -2,4 +2,4 @@
 
 An internationalization package that provides locale-specific message loading, and support for locale-specific message, date, and number formatting.
 
-Please refer to the [I18n reference guide](../../docs/i18n/index.md) for details on how to use this module.
+Please refer to the [I18n reference guide](../../docs/en/i18n/index.md) for details on how to use this module.

--- a/src/widget-core/README.md
+++ b/src/widget-core/README.md
@@ -591,7 +591,7 @@ render() {
 
 ### Internationalization
 
-Please refer to the [I18n reference guide](../../docs/i18n/index.md) for details on how to to internationalize Dojo widgets and applications.
+Please refer to the [I18n reference guide](../../docs/en/i18n/index.md) for details on how to to internationalize Dojo widgets and applications.
 
 ## Key Principles
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:** Fix links to the localized i18n ref guide from elsewhere in framework.
