### PR TITLE
Enhancement: Do not mutate VNodes or WNodes

### DIFF
--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -1,6 +1,6 @@
 import Map from '../shim/Map';
 import WeakMap from '../shim/WeakMap';
-import { v, VNODE, isVNode, isWNode } from './d';
+import { v, isVNode, isWNode } from './d';
 import { auto } from './diff';
 import {
 	AfterRender,
@@ -51,16 +51,6 @@ export const widgetInstanceMap = new WeakMap<
 	WidgetData
 >();
 const boundAuto = auto.bind(null);
-
-function toTextVNode(data: any): VNode {
-	return {
-		tag: '',
-		properties: {},
-		children: undefined,
-		text: `${data}`,
-		type: VNODE
-	};
-}
 
 function isLazyDefine(item: any): item is LazyDefine {
 	return Boolean(item && item.label);
@@ -299,20 +289,20 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		}
 	}
 
-	private _filterAndConvert(nodes: DNode[]): (WNode | VNode)[];
-	private _filterAndConvert(nodes: DNode): WNode | VNode;
-	private _filterAndConvert(nodes: DNode | DNode[]): (WNode | VNode) | (WNode | VNode)[];
-	private _filterAndConvert(nodes: DNode | DNode[]): (WNode | VNode) | (WNode | VNode)[] {
+	private _filterAndConvert(nodes: DNode[]): (WNode | VNode | string)[];
+	private _filterAndConvert(nodes: DNode): WNode | VNode | string;
+	private _filterAndConvert(nodes: DNode | DNode[]): (WNode | VNode | string) | (WNode | VNode | string)[];
+	private _filterAndConvert(nodes: DNode | DNode[]): (WNode | VNode | string) | (WNode | VNode | string)[] {
 		const isArray = Array.isArray(nodes);
 		const filteredNodes = Array.isArray(nodes) ? nodes : [nodes];
-		const convertedNodes: (WNode | VNode)[] = [];
+		const convertedNodes: (WNode | VNode | string)[] = [];
 		for (let i = 0; i < filteredNodes.length; i++) {
 			const node = filteredNodes[i];
 			if (!node || node === true) {
 				continue;
 			}
 			if (typeof node === 'string') {
-				convertedNodes.push(toTextVNode(node));
+				convertedNodes.push(node);
 				continue;
 			}
 			if (isVNode(node) && node.deferredPropertiesCallback) {
@@ -348,7 +338,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		return isArray ? convertedNodes : convertedNodes[0];
 	}
 
-	public __render__(): (WNode | VNode) | (WNode | VNode)[] {
+	public __render__(): (WNode | VNode | string) | (WNode | VNode | string)[] {
 		const instanceData = widgetInstanceMap.get(this);
 		if (instanceData) {
 			instanceData.dirty = false;

--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -340,9 +340,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 				node.widgetConstructor =
 					this.registry.get<WidgetBase>(node.widgetConstructor) || node.widgetConstructor;
 			}
-			if (!node.bind) {
-				node.bind = this;
-			}
 			convertedNodes.push(node);
 			if (node.children && node.children.length) {
 				node.children = this._filterAndConvert(node.children);

--- a/src/widget-core/d.ts
+++ b/src/widget-core/d.ts
@@ -212,7 +212,6 @@ export function v(
 	return {
 		tag,
 		deferredPropertiesCallback,
-		originalProperties: {},
 		children,
 		properties,
 		type: VNODE

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -468,7 +468,7 @@ export interface WidgetBaseInterface<P = WidgetProperties, C extends DNode = DNo
 	/**
 	 * Main internal function for dealing with widget rendering
 	 */
-	__render__(): (WNode | VNode) | (WNode | VNode)[];
+	__render__(): (WNode | VNode | string) | (WNode | VNode | string)[];
 }
 
 /**

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -468,7 +468,7 @@ export interface WidgetBaseInterface<P = WidgetProperties, C extends DNode = DNo
 	/**
 	 * Main internal function for dealing with widget rendering
 	 */
-	__render__(): (WNode | VNode | string) | (WNode | VNode | string)[];
+	__render__(): RenderResult;
 }
 
 /**

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -303,11 +303,6 @@ export interface VNode {
 	properties: VNodeProperties;
 
 	/**
-	 * VNode properties
-	 */
-	originalProperties?: VNodeProperties;
-
-	/**
 	 * VNode attributes
 	 */
 	attributes?: { [index: string]: string | undefined };

--- a/src/widget-core/interfaces.d.ts
+++ b/src/widget-core/interfaces.d.ts
@@ -138,10 +138,6 @@ export interface VNodeProperties {
 	 */
 	updateAnimation?: (element: Element, properties?: VNodeProperties, previousProperties?: VNodeProperties) => void;
 	/**
-	 * Bind should not be defined.
-	 */
-	readonly bind?: void;
-	/**
 	 * Used to uniquely identify a DOM node among siblings.
 	 * A key is required when there are more children with the same selector and these children are added or removed dynamically.
 	 * NOTE: this does not have to be a string or number, a [[Component]] Object for instance is also possible.
@@ -345,11 +341,6 @@ export interface VNode {
 	 * Indicates the type of diff for the VNode
 	 */
 	diffType?: DiffType;
-
-	/**
-	 * instance the created the vnode
-	 */
-	bind?: WidgetBaseInterface;
 }
 
 export interface DomVNode extends VNode {
@@ -407,11 +398,6 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 	 * The type of node
 	 */
 	type: string;
-
-	/**
-	 * The instance that created the node
-	 */
-	bind?: WidgetBaseInterface & { registry: RegistryHandler };
 }
 
 /**
@@ -472,7 +458,7 @@ export interface WidgetBaseInterface<P = WidgetProperties, C extends DNode = DNo
 	 *
 	 * @param properties The new widget properties
 	 */
-	__setProperties__(properties: P & { [index: string]: any }, bind?: WidgetBaseInterface): void;
+	__setProperties__(properties: P & { [index: string]: any }): void;
 
 	/**
 	 * Sets the widget's children

--- a/src/widget-core/registerCustomElement.ts
+++ b/src/widget-core/registerCustomElement.ts
@@ -1,4 +1,4 @@
-import { WidgetBase, noBind } from './WidgetBase';
+import { WidgetBase } from './WidgetBase';
 import { renderer } from './vdom';
 import { from } from '../shim/array';
 import { w, dom } from './d';
@@ -211,9 +211,6 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 		}
 
 		private _setProperty(propertyName: string, value: any) {
-			if (typeof value === 'function') {
-				value[noBind] = true;
-			}
 			this._properties[propertyName] = value;
 			this._render();
 		}

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -12,7 +12,7 @@ import {
 	DomVNode
 } from './interfaces';
 import transitionStrategy from './animations/cssTransitions';
-import { isVNode, isWNode, WNODE, v, isDomVNode, w } from './d';
+import { isVNode, isWNode, WNODE, v, isDomVNode, w, VNODE } from './d';
 import { Registry, isWidgetBaseConstructor } from './Registry';
 import { WidgetBase, widgetInstanceMap } from './WidgetBase';
 
@@ -171,6 +171,16 @@ function isVNodeWrapper(child?: DNodeWrapper | null): child is VNodeWrapper {
 
 function isAttachApplication(value: any): value is AttachApplication | DetachApplication {
 	return !!value.type;
+}
+
+function toTextVNode(data: any): VNode {
+	return {
+		tag: '',
+		properties: {},
+		children: undefined,
+		text: `${data}`,
+		type: VNODE
+	};
 }
 
 function updateAttributes(
@@ -463,7 +473,10 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 			(hasCurrentParentChildren && rendered.length > 1);
 		let previousItem: DNodeWrapper | undefined;
 		for (let i = 0; i < rendered.length; i++) {
-			const renderedItem = rendered[i];
+			let renderedItem = rendered[i];
+			if (typeof renderedItem === 'string') {
+				renderedItem = toTextVNode(renderedItem);
+			}
 			const wrapper = {
 				node: renderedItem,
 				depth: depth + 1,

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -1055,7 +1055,7 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 			}
 		};
 		instanceData.rendering = true;
-		instance.__setProperties__(next.node.properties, next.node.bind);
+		instance.__setProperties__(next.node.properties);
 		instance.__setChildren__(next.node.children);
 		next.instance = instance;
 		let rendered = instance.__render__();
@@ -1087,7 +1087,7 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 		next.domNode = domNode;
 		next.hasAnimations = hasAnimations;
 		instanceData.rendering = true;
-		instance!.__setProperties__(next.node.properties, next.node.bind);
+		instance!.__setProperties__(next.node.properties);
 		instance!.__setChildren__(next.node.children);
 		_instanceToWrapperMap.set(next.instance!, next);
 		if (instanceData.dirty) {

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -985,6 +985,7 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 				item.current.instance = undefined;
 			}
 		}
+		_nodeToInstanceMap = new WeakMap();
 	}
 
 	function _runCallbacks() {

--- a/tests/routing/unit/Outlet.ts
+++ b/tests/routing/unit/Outlet.ts
@@ -120,17 +120,8 @@ describe('Outlet', () => {
 
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo');
-		const h = harness(() =>
-			w(TestOutlet, {
-				id: 'foo',
-				renderer(details: any) {
-					if (details.type === 'index') {
-						return w(Widget, {});
-					}
-				}
-			})
-		);
-		const widget = (h.getRender(0) as any).bind;
+
+		const widget = new TestOutlet();
 		widget.onAttach();
 		invalidateCount = 0;
 		router.setPath('/other');

--- a/tests/stores/unit/StoreProvider.ts
+++ b/tests/stores/unit/StoreProvider.ts
@@ -265,7 +265,6 @@ describe('StoreProvider', () => {
 			}
 		});
 		const result = container.__render__() as VNode;
-		assert.strictEqual(result.bind, container);
 		assert.deepEqual(result.properties, {});
 		assert.isUndefined(result.children);
 		assert.strictEqual(result.tag, 'div');

--- a/tests/widget-core/unit/Container.ts
+++ b/tests/widget-core/unit/Container.ts
@@ -52,7 +52,7 @@ registerSuite('mixins/Container', {
 			const TestWidgetContainer = Container(TestWidget, 'test-state-1', { getProperties });
 			const widget = new TestWidgetContainer();
 			widget.registry.base = registry;
-			widget.__setProperties__({ foo: 'bar' }, widget);
+			widget.__setProperties__({ foo: 'bar' });
 			widget.__setChildren__([]);
 			widget.__render__();
 		},
@@ -71,7 +71,7 @@ registerSuite('mixins/Container', {
 			const TestWidgetContainer = Container(TestWidget, 'test-state-1', { getProperties });
 			const widget = new TestWidgetContainer();
 			widget.registry.base = registry;
-			widget.__setProperties__({ foo: 'bar' }, widget);
+			widget.__setProperties__({ foo: 'bar' });
 			widget.__setChildren__([child]);
 			widget.__render__();
 		},

--- a/tests/widget-core/unit/WidgetBase.ts
+++ b/tests/widget-core/unit/WidgetBase.ts
@@ -100,7 +100,7 @@ describe('WidgetBase', () => {
 			const renderResult = widget.__render__() as VNode;
 			assert.strictEqual(renderResult.tag, 'my-app');
 			assert.lengthOf(renderResult.children!, 1);
-			assert.strictEqual((renderResult.children![0] as any).text, 'child');
+			assert.strictEqual(renderResult.children![0], 'child');
 		});
 
 		it('Deferred properties are run during __render__', () => {
@@ -115,7 +115,7 @@ describe('WidgetBase', () => {
 			assert.isFunction(renderResult.deferredPropertiesCallback);
 			assert.deepEqual(renderResult.properties, { foo: 'bar' });
 			assert.lengthOf(renderResult.children!, 1);
-			assert.strictEqual((renderResult.children![0] as any).text, 'child');
+			assert.strictEqual(renderResult.children![0], 'child');
 		});
 
 		it('Decorated properties are stored separately to resolved deferred properties', () => {
@@ -139,7 +139,7 @@ describe('WidgetBase', () => {
 			assert.deepEqual(renderResult.properties, { foo: 'bar', bar: 'foo' });
 			assert.deepEqual(renderResult.originalProperties, { bar: 'foo' });
 			assert.lengthOf(renderResult.children!, 1);
-			assert.strictEqual((renderResult.children![0] as any).text, 'child');
+			assert.strictEqual(renderResult.children![0], 'child');
 		});
 
 		it('Empty nodes are filtered from children', () => {
@@ -152,7 +152,7 @@ describe('WidgetBase', () => {
 			const renderResult = widget.__render__() as VNode;
 			assert.strictEqual(renderResult.tag, 'my-app');
 			assert.lengthOf(renderResult.children!, 1);
-			assert.strictEqual((renderResult.children![0] as any).text, 'child');
+			assert.strictEqual(renderResult.children![0], 'child');
 		});
 
 		it('Resolves registry items', () => {

--- a/tests/widget-core/unit/WidgetBase.ts
+++ b/tests/widget-core/unit/WidgetBase.ts
@@ -184,7 +184,6 @@ describe('WidgetBase', () => {
 			}
 			const widget = new MyWidget();
 			const initialNode = widget.__render__() as WNode;
-			assert.strictEqual(initialNode.bind, widget);
 			assert.deepEqual(initialNode.children, []);
 			assert.deepEqual(initialNode.properties, {});
 			assert.strictEqual(initialNode.type, WNODE);
@@ -192,7 +191,6 @@ describe('WidgetBase', () => {
 			resolver({ default: WidgetBase, __esModule: true });
 			return promise.then(() => {
 				const resolvedNode = widget.__render__() as WNode;
-				assert.strictEqual(resolvedNode.bind, widget);
 				assert.deepEqual(resolvedNode.children, []);
 				assert.deepEqual(resolvedNode.properties, {});
 				assert.strictEqual(resolvedNode.type, WNODE);
@@ -213,7 +211,6 @@ describe('WidgetBase', () => {
 			}
 			const widget = new MyWidget();
 			const initialNode = widget.__render__() as WNode;
-			assert.strictEqual(initialNode.bind, widget);
 			assert.deepEqual(initialNode.children, []);
 			assert.deepEqual(initialNode.properties, {});
 			assert.strictEqual(initialNode.type, WNODE);
@@ -221,7 +218,6 @@ describe('WidgetBase', () => {
 			resolver(WidgetBase);
 			return promise.then(() => {
 				const resolvedNode = widget.__render__() as WNode;
-				assert.strictEqual(resolvedNode.bind, widget);
 				assert.deepEqual(resolvedNode.children, []);
 				assert.deepEqual(resolvedNode.properties, {});
 				assert.strictEqual(resolvedNode.type, WNODE);
@@ -242,7 +238,6 @@ describe('WidgetBase', () => {
 			}
 			const widget = new MyWidget();
 			const initialNode = widget.__render__() as WNode;
-			assert.strictEqual(initialNode.bind, widget);
 			assert.deepEqual(initialNode.children, []);
 			assert.deepEqual(initialNode.properties, {});
 			assert.strictEqual(initialNode.type, WNODE);
@@ -250,7 +245,6 @@ describe('WidgetBase', () => {
 			resolver(WidgetBase);
 			return promise.then(() => {
 				const resolvedNode = widget.__render__() as WNode;
-				assert.strictEqual(resolvedNode.bind, widget);
 				assert.deepEqual(resolvedNode.children, []);
 				assert.deepEqual(resolvedNode.properties, {});
 				assert.strictEqual(resolvedNode.type, WNODE);
@@ -271,7 +265,6 @@ describe('WidgetBase', () => {
 			}
 			const widget = new MyWidget();
 			const initialNode = widget.__render__() as WNode;
-			assert.strictEqual(initialNode.bind, widget);
 			assert.deepEqual(initialNode.children, []);
 			assert.deepEqual(initialNode.properties, {});
 			assert.strictEqual(initialNode.type, WNODE);
@@ -279,7 +272,6 @@ describe('WidgetBase', () => {
 			resolver({ default: WidgetBase, __esModule: true });
 			return promise.then(() => {
 				const resolvedNode = widget.__render__() as WNode;
-				assert.strictEqual(resolvedNode.bind, widget);
 				assert.deepEqual(resolvedNode.children, []);
 				assert.deepEqual(resolvedNode.properties, {});
 				assert.strictEqual(resolvedNode.type, WNODE);

--- a/tests/widget-core/unit/WidgetBase.ts
+++ b/tests/widget-core/unit/WidgetBase.ts
@@ -2,7 +2,7 @@ const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { spy, stub, SinonStub } from 'sinon';
 
-import { WidgetBase, noBind, widgetInstanceMap } from '../../../src/widget-core/WidgetBase';
+import { WidgetBase, widgetInstanceMap } from '../../../src/widget-core/WidgetBase';
 import { v, w, WNODE } from '../../../src/widget-core/d';
 import { WIDGET_BASE_TYPE } from '../../../src/widget-core/Registry';
 import { Constructor, VNode, WidgetMetaConstructor, WNode, MetaBase } from '../../../src/widget-core/interfaces';
@@ -359,39 +359,6 @@ describe('WidgetBase', () => {
 			assert.isTrue(invalidateSpy.calledThrice);
 			assert.deepEqual(widget.changedPropertyKeys, ['foobar']);
 			assert.isUndefined(widget.properties.foobar);
-		});
-
-		it('Automatically binds functions properties', () => {
-			class TestWidget extends BaseTestWidget {
-				public called = false;
-			}
-
-			function baz(this: TestWidget) {
-				this.called = true;
-			}
-
-			const widget = new TestWidget();
-
-			widget.__setProperties__({ baz }, widget);
-			widget.properties.baz && widget.properties.baz();
-			assert.isTrue(widget.called);
-		});
-
-		it('does not bind function properties that carry the dojo no bind symbol', () => {
-			class TestWidget extends BaseTestWidget {
-				public called = false;
-			}
-
-			function baz(this: any) {
-				this.called = true;
-			}
-
-			(baz as any)[noBind] = true;
-
-			const widget = new TestWidget();
-			widget.__setProperties__({ baz }, widget);
-			widget.properties.baz && widget.properties.baz();
-			assert.isFalse(widget.called);
 		});
 
 		it('Does not bind Widget constructor properties', () => {

--- a/tests/widget-core/unit/decorators/beforeRender.ts
+++ b/tests/widget-core/unit/decorators/beforeRender.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import { stub, SinonStub } from 'sinon';
 
 import { v } from './../../../../src/widget-core/d';
-import { DNode, Render, VNode } from './../../../../src/widget-core/interfaces';
+import { DNode, Render } from './../../../../src/widget-core/interfaces';
 import { beforeRender } from './../../../../src/widget-core/decorators/beforeRender';
 import { WidgetBase } from './../../../../src/widget-core/WidgetBase';
 
@@ -105,7 +105,7 @@ registerSuite('decorators/beforeRender', {
 
 			const widget = new TestWidget();
 			const renderResult = widget.__render__();
-			assert.strictEqual((renderResult as VNode).text, 'first render');
+			assert.strictEqual(renderResult, 'first render');
 			assert.isTrue(consoleStub.calledOnce);
 			assert.isTrue(
 				consoleStub.calledWith('Render function not returned from beforeRender, using previous render')

--- a/tests/widget-core/unit/decorators/inject.ts
+++ b/tests/widget-core/unit/decorators/inject.ts
@@ -29,7 +29,7 @@ registerSuite('decorators/inject', {
 			class TestWidget extends WidgetBase<any> {}
 			const widget = new TestWidget();
 			widget.registry.base = registry;
-			widget.__setProperties__({}, widget);
+			widget.__setProperties__({});
 
 			assert.strictEqual(widget.properties.foo, 'bar');
 		},
@@ -46,7 +46,7 @@ registerSuite('decorators/inject', {
 			class TestWidget extends WidgetBase<any> {}
 			const widget = new TestWidget();
 			widget.registry.base = registry;
-			widget.__setProperties__({}, widget);
+			widget.__setProperties__({});
 			assert.strictEqual(widget.properties.foo, 'bar');
 			assert.strictEqual(widget.properties.bar, 'foo');
 		},
@@ -67,7 +67,7 @@ registerSuite('decorators/inject', {
 			}
 			const widget = new TestWidget();
 			widget.registry.base = registry;
-			widget.__setProperties__({}, widget);
+			widget.__setProperties__({});
 			assert.strictEqual(widget.properties.foo, 'bar');
 			assert.strictEqual(widget.properties.bar, 'foo');
 		},

--- a/tests/widget-core/unit/decorators/watch.ts
+++ b/tests/widget-core/unit/decorators/watch.ts
@@ -2,7 +2,6 @@ const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import WidgetBase from '../../../../src/widget-core/WidgetBase';
 import { watch } from '../../../../src/widget-core/decorators/watch';
-import { VNode } from '../../../../src/widget-core/interfaces';
 
 describe('Watch', () => {
 	it('should invalidate on set', () => {
@@ -21,8 +20,8 @@ describe('Watch', () => {
 		}
 
 		const widget = new A();
-		const result = widget.__render__() as VNode;
-		assert.strictEqual(result.text, 'other');
+		const result = widget.__render__();
+		assert.strictEqual(result, 'other');
 		assert.strictEqual(invalidateCount, 1);
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changes to ensure that `VNode`s and `WNode`s created by users are not mutated by the rendering engine:

 * Generate map of nodes to the widget instance that initially rendered to use for resolving registry items and adding DOM nodes to the widget NodeHandler for metas
 * Remove `bind` from `VNode` and `WNode` and automatically bind Widget functions to the widget instance (excluding `constructor` and `render`)
 * Resolve registry items in `vdom`, storing the resolved registry items on the `WNodeWrapper`
 * Create text `VNode` and filter `undefined`, `null`, `false` and `true` items in `vdom`
 * Remove `originalProperties` from `VNode` and `WNode`, process deferred properties in `vdom` storing the deferred properties results on the `VNodeWrapper`.

Resolves #289 
