### PR TITLE
Adjustments to AbortController Polyfill

### DIFF
--- a/src/shim/AbortController.ts
+++ b/src/shim/AbortController.ts
@@ -4,7 +4,7 @@ import { findIndex } from './array';
 
 export interface AbortSignal extends EventTarget {
 	aborted: boolean;
-	onabort: undefined | ((ev: Event) => any);
+	onabort: null | ((this: AbortSignal, ev: Event) => any);
 }
 
 export interface AbortSignalConstructor {
@@ -18,7 +18,7 @@ export let ShimAbortSignal: AbortSignalConstructor = global.AbortSignal;
 if (!has('abort-signal')) {
 	global.AbortSignal = ShimAbortSignal = class implements AbortSignal {
 		private _aborted = false;
-		onabort: undefined | ((ev: Event) => any);
+		onabort: null | ((this: AbortSignal, ev: Event) => any) = null;
 
 		listeners: { [type: string]: ((event: Event) => void)[] } = {};
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

In app code you currently have to do this:

```
import AbortController, { AbortController as IAbortController } from '@dojo/framework/shim/AbortController';

// Later on...

let validateController: IAbortController;

// Later

let validateController = new AbortController();

```

I think this is because currently the `shim` doesn't export as the interface as we do with `ResizeObserver` and `IntersectionObserver`. 

Also the types are currently incorrect for `AbortSignal`s `onabort` method, they should be like so:

https://github.com/Microsoft/TypeScript/blob/master/src/lib/webworker.generated.d.ts#L499

This PR attempts to address these two things.

Happy to admit I'm not totally sure if this is the right solution so would be happy to hear input