### PR TITLE
Ensure that nodes are inserted in the correct position when nested within widgets

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -1084,7 +1084,9 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 		}
 		const instanceData = widgetInstanceMap.get(instance)!;
 		next.instance = instance;
-		next.domNode = domNode;
+		if (domNode && domNode.parentNode) {
+			next.domNode = domNode;
+		}
 		next.hasAnimations = hasAnimations;
 		instanceData.rendering = true;
 		instance!.__setProperties__(next.node.properties, next.node.bind);

--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -1121,6 +1121,19 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 		};
 	}
 
+	function setDomNodeOnParentWrapper(next: VNodeWrapper) {
+		let parentWNodeWrapper = findParentWNodeWrapper(next);
+		while (parentWNodeWrapper && !parentWNodeWrapper.domNode) {
+			parentWNodeWrapper.domNode = next.domNode;
+			const nextParent = _parentWrapperMap.get(parentWNodeWrapper);
+			if (nextParent && isWNodeWrapper(nextParent)) {
+				parentWNodeWrapper = nextParent;
+				continue;
+			}
+			parentWNodeWrapper = undefined;
+		}
+	}
+
 	function _createDom({ next }: CreateDomInstruction): ProcessResult {
 		let mergeNodes: Node[] = [];
 		const parentDomNode = findParentDomNode(next)!;
@@ -1158,10 +1171,7 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 				next.childrenWrappers = renderedToWrapper(next.node.children, next, null);
 			}
 		}
-		const parentWNodeWrapper = findParentWNodeWrapper(next);
-		if (parentWNodeWrapper && !parentWNodeWrapper.domNode) {
-			parentWNodeWrapper.domNode = next.domNode;
-		}
+		setDomNodeOnParentWrapper(next);
 		const dom: ApplicationInstruction = {
 			next: next!,
 			parentDomNode: parentDomNode,

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -971,17 +971,16 @@ jsdomDescribe('vdom', () => {
 				}
 
 				protected render() {
-					const thing = ['a', 'b'];
 					return v('div', [
 						v('div', [
 							w(Renderer, {
 								renderer: () => {
-									return !this._filter && w(Test, {}, [thing[0]]);
+									return !this._filter && w(Test, {}, ['a']);
 								}
 							}),
 							w(Renderer, {
 								renderer: () => {
-									return w(Test, {}, [thing[1]]);
+									return w(Test, {}, ['b']);
 								}
 							})
 						])


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

In scenarios where there are multiple nested widgets, the child `domNode` is not applied to the top level widget. This means that when there are two siblings that have nested widgets looking up the `domNode` for the insert before position does not work.

Additionally, when copying over the associated `domNode` to the new WNodeWrapper, check that it is still attached to the DOM when updating a widget, if the previous `domNode` is not attached to the DOM then do not copy over and let the attachment process execute to add the new `domNode`.

Resolves #296
