### PR TITLE
Pause initial render for lazy loaded widgets while performing a merge

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -1150,10 +1150,13 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 			node: { widgetConstructor }
 		} = next;
 		let { registry } = _mountOptions;
-		resolveRegistryItem(next);
-		const Constructor = next.registryItem || widgetConstructor;
+		let Constructor = next.registryItem || widgetConstructor;
 		if (!isWidgetBaseConstructor(Constructor)) {
-			return false;
+			resolveRegistryItem(next);
+			if (!next.registryItem) {
+				return false;
+			}
+			Constructor = next.registryItem;
 		}
 		const instance = new Constructor() as WidgetBase;
 		if (registry) {

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -461,6 +461,54 @@ jsdomDescribe('vdom', () => {
 			});
 		});
 
+		it('Should pause rendering while merging to allow lazily loaded widgets to be loaded', () => {
+			const iframe = document.createElement('iframe');
+			document.body.appendChild(iframe);
+			iframe.contentDocument.write(`<div><span>54321</span><span>12345</span></div>`);
+			iframe.contentDocument.close();
+
+			const root = iframe.contentDocument.body.firstChild as HTMLElement;
+			const lazySpan = root.childNodes[0] as HTMLSpanElement;
+			const span = root.childNodes[1] as HTMLSpanElement;
+
+			const registry = new Registry();
+			class Foo extends WidgetBase {
+				render() {
+					return v('span', ['54321']);
+				}
+			}
+
+			let resolver: any;
+			const promise = new Promise<any>((resolve) => {
+				resolver = resolve;
+			});
+
+			class App extends WidgetBase {
+				render() {
+					return v('div', [
+						w(
+							{
+								label: 'foo',
+								registryItem: () => {
+									return promise;
+								}
+							},
+							{}
+						),
+						v('span', ['12345'])
+					]);
+				}
+			}
+
+			const r = renderer(() => w(App, {}));
+			r.mount({ registry, domNode: iframe.contentDocument.body, sync: true });
+			resolver(Foo);
+			return promise.then(() => {
+				assert.strictEqual(root.childNodes[1], span);
+				assert.strictEqual(root.childNodes[0], lazySpan);
+			});
+		});
+
 		it('registry items', () => {
 			let resolver = () => {};
 			const registry = new Registry();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changes to support the ability for an application to pause hydrating the application when performing a merge against an existing DOM structure if the renderer hits a lazily loaded widget(s). 

This means that the VDOM will not "throw away" the existing DOM nodes while the lazy widget is loaded, instead will wait for the lazy widget to be loaded before continuing the merge operation.

Resolves #309 
