### PR TITLE
Assertion Template Enhancements

### DIFF
--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -154,13 +154,13 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		const node = guard(findOne(render, selector));
 		return node.children || [];
 	};
-	assertionTemplateResult.replace = (selector: string, node: DNode) => {
+	assertionTemplateResult.replace = (selector: string, newNode: DNode) => {
 		return assertionTemplate(() => {
 			const render = renderFunc();
 			const node = guard(findOne(render, selector));
 			const parent = (node as any).parent;
 			const children = [...parent.children];
-			children.splice(children.indexOf(node), 1, node);
+			children.splice(children.indexOf(node), 1, newNode);
 			parent.children = children;
 			return render;
 		});

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -160,8 +160,8 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			const node = guard(findOne(render, selector));
 			const parent = (node as any).parent;
 			const children = [...parent.children];
-			children.splice(children.indexOf(node), 1);
-			parent.children = [node, ...children];
+			children.splice(children.indexOf(node), 1, node);
+			parent.children = children;
 			return render;
 		});
 	};

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -20,6 +20,7 @@ export interface AssertionTemplateResult {
 	getProperty(selector: string, property: string): any;
 	getProperties(selector: string): any;
 	replace(selector: string, node: DNode): AssertionTemplateResult;
+	remove(selector: string): AssertionTemplateResult;
 }
 
 const findOne = (nodes: DNode | DNode[], selector: string): DNode | undefined => {
@@ -161,6 +162,17 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			const children = [...parent.children];
 			children.splice(children.indexOf(node), 1);
 			parent.children = [node, ...children];
+			return render;
+		});
+	};
+	assertionTemplateResult.remove = (selector: string) => {
+		return assertionTemplate(() => {
+			const render = renderFunc();
+			const node = guard(findOne(render, selector));
+			const parent = (node as any).parent;
+			const children = [...parent.children];
+			children.splice(children.indexOf(node), 1);
+			parent.children = [...children];
 			return render;
 		});
 	};

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -48,7 +48,7 @@ const guard = (node: DNode): NodeWithProperties => {
 	return node;
 };
 
-export class Mimic extends WidgetBase {}
+export class Ignore extends WidgetBase {}
 
 export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 	const assertionTemplateResult: any = () => {

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -1,6 +1,9 @@
 import select from './support/selector';
 import { isWNode, isVNode, decorate } from '../widget-core/d';
 import { VNode, WNode, DNode } from '../widget-core/interfaces';
+import WidgetBase from '../widget-core/WidgetBase';
+
+export type PropertiesComparatorFunction = (expectedProperties: any, actualProperties: any) => any;
 
 export interface AssertionTemplateResult {
 	(): DNode | DNode[];
@@ -12,8 +15,10 @@ export interface AssertionTemplateResult {
 	insertSiblings(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 	setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 	setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
+	setProperties(selector: string, value: any | PropertiesComparatorFunction): AssertionTemplateResult;
 	getChildren(selector: string): DNode[];
 	getProperty(selector: string, property: string): any;
+	getProperties(selector: string): any;
 }
 
 const findOne = (nodes: DNode | DNode[], selector: string): DNode | undefined => {
@@ -41,6 +46,8 @@ const guard = (node: DNode): NodeWithProperties => {
 	return node;
 };
 
+export class Mimic extends WidgetBase {}
+
 export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 	const assertionTemplateResult: any = () => {
 		const render = renderFunc();
@@ -57,6 +64,14 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			const render = renderFunc();
 			const node = guard(findOne(render, selector));
 			node.properties[property] = value;
+			return render;
+		});
+	};
+	assertionTemplateResult.setProperties = (selector: string, value: any | PropertiesComparatorFunction) => {
+		return assertionTemplate(() => {
+			const render = renderFunc();
+			const node = guard(findOne(render, selector));
+			node.properties = value;
 			return render;
 		});
 	};
@@ -126,6 +141,11 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		const render = renderFunc();
 		const node = guard(findOne(render, selector));
 		return node.properties[property];
+	};
+	assertionTemplateResult.getProperties = (selector: string, property: string) => {
+		const render = renderFunc();
+		const node = guard(findOne(render, selector));
+		return node.properties;
 	};
 	assertionTemplateResult.getChildren = (selector: string) => {
 		const render = renderFunc();

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -99,16 +99,6 @@ function formatNode(node: WNode | VNode, tabs: any): string {
 	return `v("${node.tag}", ${properties}`;
 }
 
-const assertionWidgets = [
-	{
-		type: Ignore,
-		value(actual: DNode, expected: DNode) {
-			const node = actual ? actual : expected;
-			return [actual, node];
-		}
-	}
-];
-
 function isNode(node: any): node is VNode | WNode {
 	return isVNode(node) || isWNode(node);
 }
@@ -123,21 +113,14 @@ function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[],
 		let actualNode = actual[i];
 		let expectedNode = expected[i];
 
-		if (isWNode(expectedNode)) {
-			[actualNode, expectedNode] = assertionWidgets.reduce(
-				(result, assertionWidget) => {
-					if ((expectedNode as any).widgetConstructor === assertionWidget.type) {
-						return assertionWidget.value(result[0], result[1]);
-					}
-					return [result[0], result[1]];
-				},
-				[actualNode, expectedNode]
-			);
+		if (expectedNode && (expectedNode as any).widgetConstructor === Ignore) {
+			expectedNode = actualNode || expectedNode;
 		}
+
 		if (isNode(expectedNode)) {
 			if (typeof expectedNode.properties === 'function') {
 				const actualProperties = isNode(actualNode) ? actualNode.properties : {};
-				expectedNode.properties = expectedNode.properties(actualProperties);
+				expectedNode.properties = (expectedNode as any).properties(actualProperties);
 			}
 		}
 		const childrenA = isNode(actualNode) ? actualNode.children : [];

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -5,6 +5,7 @@ import WeakMap from '../../shim/WeakMap';
 import Set from '../../shim/Set';
 import Map from '../../shim/Map';
 import { from as arrayFrom } from '../../shim/array';
+import { Mimic } from '../assertionTemplate';
 
 let widgetClassCounter = 0;
 const widgetMap = new WeakMap<Constructor<DefaultWidgetBaseInterface>, number>();
@@ -98,9 +99,55 @@ function formatNode(node: WNode | VNode, tabs: any): string {
 	return `v("${node.tag}", ${properties}`;
 }
 
+const assertionWidgets = [
+	{
+		type: Mimic,
+		value(actual: DNode, expected: DNode) {
+			return [actual, actual];
+		}
+	}
+];
+
+function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[], DNode[]] {
+	actual = Array.isArray(actual) ? actual : [actual];
+	expected = Array.isArray(expected) ? expected : [expected];
+	let actualDecoratedNodes = [];
+	let expectedDecoratedNodes = [];
+	for (let i = 0; i < expected.length; i++) {
+		let actualNode = actual[i];
+		let expectedNode = expected[i];
+
+		if (isWNode(expectedNode)) {
+			[actualNode, expectedNode] = assertionWidgets.reduce(
+				(result, assertionWidget) => {
+					if ((expectedNode as any).widgetConstructor === assertionWidget.type) {
+						return assertionWidget.value(result[0], result[1]);
+					}
+					return [result[0], result[1]];
+				},
+				[actualNode, expectedNode]
+			);
+		}
+		if ((isWNode(actualNode) || isVNode(actualNode)) && (isWNode(expectedNode) || isVNode(expectedNode))) {
+			if (typeof expectedNode.properties === 'function') {
+				expectedNode.properties = expectedNode.properties(expectedNode.properties, actualNode.properties);
+			}
+			if (actualNode.children && expectedNode.children) {
+				const [actualChildren, expectedChildren] = decorate(actualNode.children, expectedNode.children);
+				actualNode.children = actualChildren;
+				expectedNode.children = expectedChildren;
+			}
+		}
+		actualDecoratedNodes.push(actualNode);
+		expectedDecoratedNodes.push(expectedNode);
+	}
+	return [actualDecoratedNodes, expectedDecoratedNodes];
+}
+
 export function assertRender(actual: DNode | DNode[], expected: DNode | DNode[], message?: string): void {
-	const parsedActual = formatDNodes(actual);
-	const parsedExpected = formatDNodes(expected);
+	const [decoratedActual, decoratedExpected] = decorate(actual, expected);
+	const parsedActual = formatDNodes(Array.isArray(actual) ? decoratedActual : decoratedActual[0]);
+	const parsedExpected = formatDNodes(Array.isArray(expected) ? decoratedExpected : decoratedExpected[0]);
 	const diffResult = diff.diffLines(parsedActual, parsedExpected);
 	let diffFound = false;
 	const parsedDiff = diffResult.reduce((result: string, part, index) => {

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -103,7 +103,8 @@ const assertionWidgets = [
 	{
 		type: Mimic,
 		value(actual: DNode, expected: DNode) {
-			return [actual, actual];
+			const node = actual ? actual : expected;
+			return [actual, node];
 		}
 	}
 ];

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -137,7 +137,7 @@ function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[],
 		if (isNode(expectedNode)) {
 			if (typeof expectedNode.properties === 'function') {
 				const actualProperties = isNode(actualNode) ? actualNode.properties : {};
-				expectedNode.properties = expectedNode.properties(expectedNode.properties, actualProperties);
+				expectedNode.properties = expectedNode.properties(actualProperties);
 			}
 		}
 		const childrenA = isNode(actualNode) ? actualNode.children : [];

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -109,7 +109,7 @@ const assertionWidgets = [
 	}
 ];
 
-function isWNodeOrVNode(node: any): node is VNode | WNode {
+function isNode(node: any): node is VNode | WNode {
 	return isVNode(node) || isWNode(node);
 }
 
@@ -134,20 +134,20 @@ function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[],
 				[actualNode, expectedNode]
 			);
 		}
-		if (isWNodeOrVNode(expectedNode)) {
+		if (isNode(expectedNode)) {
 			if (typeof expectedNode.properties === 'function') {
-				const actualProperties = isWNodeOrVNode(actualNode) ? actualNode.properties : {};
+				const actualProperties = isNode(actualNode) ? actualNode.properties : {};
 				expectedNode.properties = expectedNode.properties(expectedNode.properties, actualProperties);
 			}
 		}
-		const childrenA = isWNodeOrVNode(actualNode) ? actualNode.children : [];
-		const childrenB = isWNodeOrVNode(expectedNode) ? expectedNode.children : [];
+		const childrenA = isNode(actualNode) ? actualNode.children : [];
+		const childrenB = isNode(expectedNode) ? expectedNode.children : [];
 
 		const [actualChildren, expectedChildren] = decorate(childrenA, childrenB);
-		if (isWNodeOrVNode(actualNode)) {
+		if (isNode(actualNode)) {
 			actualNode.children = actualChildren;
 		}
-		if (isWNodeOrVNode(expectedNode)) {
+		if (isNode(expectedNode)) {
 			expectedNode.children = expectedChildren;
 		}
 		actualDecoratedNodes.push(actualNode);

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -5,7 +5,7 @@ import WeakMap from '../../shim/WeakMap';
 import Set from '../../shim/Set';
 import Map from '../../shim/Map';
 import { from as arrayFrom } from '../../shim/array';
-import { Mimic } from '../assertionTemplate';
+import { Ignore } from '../assertionTemplate';
 
 let widgetClassCounter = 0;
 const widgetMap = new WeakMap<Constructor<DefaultWidgetBaseInterface>, number>();
@@ -101,7 +101,7 @@ function formatNode(node: WNode | VNode, tabs: any): string {
 
 const assertionWidgets = [
 	{
-		type: Mimic,
+		type: Ignore,
 		value(actual: DNode, expected: DNode) {
 			const node = actual ? actual : expected;
 			return [actual, node];

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -174,7 +174,7 @@ describe('assertionTemplate', () => {
 		h.expect(propertyAssertion);
 	});
 
-	it('can use mimic', () => {
+	it('can use ignore', () => {
 		const h = harness(() => w(ListWidget, {}));
 		const childListAssertion = baseListAssertion.replaceChildren('ul', [
 			v('li', ['item: 0']),

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -5,7 +5,7 @@ import { harness } from '../../../src/testing/harness';
 import { WidgetBase } from '../../../src/widget-core/WidgetBase';
 import { v, w } from '../../../src/widget-core/d';
 import { tsx } from '../../../src/widget-core/tsx';
-import assertionTemplate, { Mimic } from '../../../src/testing/assertionTemplate';
+import assertionTemplate, { Ignore } from '../../../src/testing/assertionTemplate';
 
 class MyWidget extends WidgetBase<{
 	toggleProperty?: boolean;
@@ -178,7 +178,7 @@ describe('assertionTemplate', () => {
 		const h = harness(() => w(ListWidget, {}));
 		const childListAssertion = baseListAssertion.replaceChildren('ul', [
 			v('li', ['item: 0']),
-			...new Array(28).fill(w(Mimic, {})),
+			...[...new Array(28)].map(() => w(Ignore, {})),
 			v('li', ['item: 29'])
 		]);
 		h.expect(childListAssertion);

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -39,7 +39,9 @@ class MyWidget extends WidgetBase<{
 const baseAssertion = assertionTemplate(() =>
 	v('div', { '~key': 'root', classes: ['root'] }, [
 		v('h2', { '~key': 'header' }, ['hello']),
-		v('ul', [v('li', { '~key': 'li-one', foo: 'a' }, ['one']), v('li', ['two']), v('li', ['three'])])
+		undefined,
+		v('ul', [v('li', { '~key': 'li-one', foo: 'a' }, ['one']), v('li', ['two']), v('li', ['three'])]),
+		undefined
 	])
 );
 
@@ -103,10 +105,16 @@ describe('assertionTemplate', () => {
 
 	it('can set properties and use the actual properties', () => {
 		const h = harness(() => w(MyWidget, { toggleProperty: true }));
-		const propertyAssertion = baseAssertion.setProperties('~li-one', (expectedProps: any, actualProps: any) => {
+		const propertyAssertion = baseAssertion.setProperties('~li-one', (actualProps: any) => {
 			return actualProps;
 		});
 		h.expect(propertyAssertion);
+	});
+
+	it('can replace a node', () => {
+		const h = harness(() => w(MyWidget, {}));
+		const childAssertion = baseAssertion.replace('~header', v('h2', { '~key': 'header' }, ['hello']));
+		h.expect(childAssertion);
 	});
 
 	it('can set a child', () => {
@@ -117,7 +125,7 @@ describe('assertionTemplate', () => {
 
 	it('can set a child with replace', () => {
 		const h = harness(() => w(MyWidget, { replaceChild: true }));
-		const childAssertion = baseAssertion.replace('~header', ['replace']);
+		const childAssertion = baseAssertion.replaceChildren('~header', ['replace']);
 		h.expect(childAssertion);
 	});
 
@@ -153,7 +161,7 @@ describe('assertionTemplate', () => {
 
 	it('can use mimic', () => {
 		const h = harness(() => w(ListWidget, {}));
-		const childListAssertion = baseListAssertion.replace('ul', [
+		const childListAssertion = baseListAssertion.replaceChildren('ul', [
 			v('li', ['item: 0']),
 			...new Array(29).fill(w(Mimic, {}))
 		]);

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -5,7 +5,7 @@ import { harness } from '../../../src/testing/harness';
 import { WidgetBase } from '../../../src/widget-core/WidgetBase';
 import { v, w } from '../../../src/widget-core/d';
 import { tsx } from '../../../src/widget-core/tsx';
-import assertionTemplate from '../../../src/testing/assertionTemplate';
+import assertionTemplate, { Mimic } from '../../../src/testing/assertionTemplate';
 
 class MyWidget extends WidgetBase<{
 	toggleProperty?: boolean;
@@ -62,6 +62,11 @@ describe('assertionTemplate', () => {
 		assert.deepEqual(classes, ['root']);
 	});
 
+	it('can get properties', () => {
+		const properties = baseAssertion.getProperties('~root');
+		assert.deepEqual(properties, { '~key': 'root', classes: ['root'] });
+	});
+
 	it('can get a child', () => {
 		const children = baseAssertion.getChildren('~header');
 		assert.equal(children[0], 'hello');
@@ -75,6 +80,20 @@ describe('assertionTemplate', () => {
 	it('can set a property', () => {
 		const h = harness(() => w(MyWidget, { toggleProperty: true }));
 		const propertyAssertion = baseAssertion.setProperty('~li-one', 'foo', 'b');
+		h.expect(propertyAssertion);
+	});
+
+	it('can set properties', () => {
+		const h = harness(() => w(MyWidget, { toggleProperty: true }));
+		const propertyAssertion = baseAssertion.setProperties('~li-one', { foo: 'b' });
+		h.expect(propertyAssertion);
+	});
+
+	it('can set properties and use the actual properties', () => {
+		const h = harness(() => w(MyWidget, { toggleProperty: true }));
+		const propertyAssertion = baseAssertion.setProperties('~li-one', (expectedProps: any, actualProps: any) => {
+			return actualProps;
+		});
 		h.expect(propertyAssertion);
 	});
 
@@ -118,6 +137,12 @@ describe('assertionTemplate', () => {
 		const h = harness(() => <MyWidget toggleProperty={true} />);
 		const propertyAssertion = tsxAssertion.setProperty('~li-one', 'foo', 'b');
 		h.expect(propertyAssertion);
+	});
+
+	it('can use mimic', () => {
+		const h = harness(() => w(MyWidget, {}));
+		const childAssertion = baseAssertion.replace('~header', [w(Mimic, {})]);
+		h.expect(childAssertion);
 	});
 
 	it('should be immutable', () => {

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -12,11 +12,20 @@ class MyWidget extends WidgetBase<{
 	prependChild?: boolean;
 	appendChild?: boolean;
 	replaceChild?: boolean;
+	removeHeader?: boolean;
 	before?: boolean;
 	after?: boolean;
 }> {
 	render() {
-		const { toggleProperty, prependChild, appendChild, replaceChild, before, after } = this.properties;
+		const {
+			toggleProperty,
+			prependChild,
+			appendChild,
+			replaceChild,
+			removeHeader,
+			before,
+			after
+		} = this.properties;
 		let children = ['hello'];
 		if (prependChild) {
 			children = ['prepend', ...children];
@@ -28,7 +37,7 @@ class MyWidget extends WidgetBase<{
 			children = ['replace'];
 		}
 		return v('div', { classes: ['root'] }, [
-			v('h2', children),
+			removeHeader ? undefined : v('h2', children),
 			before ? v('span', ['before']) : undefined,
 			v('ul', [v('li', { foo: toggleProperty ? 'b' : 'a' }, ['one']), v('li', ['two']), v('li', ['three'])]),
 			after ? v('span', ['after']) : undefined
@@ -114,6 +123,12 @@ describe('assertionTemplate', () => {
 	it('can replace a node', () => {
 		const h = harness(() => w(MyWidget, {}));
 		const childAssertion = baseAssertion.replace('~header', v('h2', { '~key': 'header' }, ['hello']));
+		h.expect(childAssertion);
+	});
+
+	it('can remove a node', () => {
+		const h = harness(() => w(MyWidget, { removeHeader: true }));
+		const childAssertion = baseAssertion.remove('~header');
 		h.expect(childAssertion);
 	});
 

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -43,6 +43,18 @@ const baseAssertion = assertionTemplate(() =>
 	])
 );
 
+class ListWidget extends WidgetBase {
+	render() {
+		let children = [];
+		for (let i = 0; i < 30; i++) {
+			children.push(v('li', [`item: ${i}`]));
+		}
+		return v('div', { classes: ['root'] }, [v('ul', children)]);
+	}
+}
+
+const baseListAssertion = assertionTemplate(() => v('div', { classes: ['root'] }, [v('ul', [])]));
+
 const tsxAssertion = assertionTemplate(() => (
 	<div classes={['root']}>
 		<h2>hello</h2>
@@ -140,9 +152,12 @@ describe('assertionTemplate', () => {
 	});
 
 	it('can use mimic', () => {
-		const h = harness(() => w(MyWidget, {}));
-		const childAssertion = baseAssertion.replace('~header', [w(Mimic, {})]);
-		h.expect(childAssertion);
+		const h = harness(() => w(ListWidget, {}));
+		const childListAssertion = baseListAssertion.replace('ul', [
+			v('li', ['item: 0']),
+			...new Array(29).fill(w(Mimic, {}))
+		]);
+		h.expect(childListAssertion);
 	});
 
 	it('should be immutable', () => {

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -163,7 +163,8 @@ describe('assertionTemplate', () => {
 		const h = harness(() => w(ListWidget, {}));
 		const childListAssertion = baseListAssertion.replaceChildren('ul', [
 			v('li', ['item: 0']),
-			...new Array(29).fill(w(Mimic, {}))
+			...new Array(28).fill(w(Mimic, {})),
+			v('li', ['item: 29'])
 		]);
 		h.expect(childListAssertion);
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
TODO: Fill this out explaining enhancements.

API's changed:
```
replace -> replaceChildren
```
(this https://github.com/dojo/framework/pull/247#discussion_r256571684 came back to haunt me)

API's added:
```
replace
remove
setProperties
getProperties
```

New Assertion Template primitive:
```
Ignore
```
