### PR TITLE
V5 - Ensure that the latest wrapper is used when processing detached nodes

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -1210,17 +1210,18 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 				let wrappers = current.childrenWrappers || [];
 				let wrapper: DNodeWrapper | undefined;
 				while ((wrapper = wrappers.pop())) {
-					if (wrapper.childrenWrappers) {
-						wrappers.push(...wrapper.childrenWrappers);
-						wrapper.childrenWrappers = undefined;
-					}
 					if (isWNodeWrapper(wrapper)) {
+						wrapper = wrapper.instance ? _instanceToWrapperMap.get(wrapper.instance) || wrapper : wrapper;
 						if (wrapper.instance) {
 							_instanceToWrapperMap.delete(wrapper.instance);
 							const instanceData = widgetInstanceMap.get(wrapper.instance);
 							instanceData && instanceData.onDetach();
 						}
 						wrapper.instance = undefined;
+					}
+					if (wrapper.childrenWrappers) {
+						wrappers.push(...wrapper.childrenWrappers);
+						wrapper.childrenWrappers = undefined;
 					}
 					_wrapperSiblingMap.delete(wrapper);
 					_parentWrapperMap.delete(wrapper);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

V5 back port of #310 
