### PR TITLE
Throwing an error on missing selector in test harness trigger

### DIFF
--- a/src/testing/harness.ts
+++ b/src/testing/harness.ts
@@ -133,16 +133,19 @@ export function harness(
 		trigger(selector: string, functionSelector: string | FunctionalSelector, ...args: any[]): any {
 			_tryRender();
 			const [firstItem] = select(selector, _getRender());
-			if (firstItem) {
-				let triggerFunction: Function | undefined;
-				if (typeof functionSelector === 'string') {
-					triggerFunction = (firstItem.properties as any)[functionSelector];
-				} else {
-					triggerFunction = functionSelector(firstItem);
-				}
-				if (triggerFunction) {
-					return triggerFunction.apply(widget, args);
-				}
+
+			if (!firstItem) {
+				throw new Error(`Cannot find node with selector ${selector}`);
+			}
+
+			let triggerFunction: Function | undefined;
+			if (typeof functionSelector === 'string') {
+				triggerFunction = (firstItem.properties as any)[functionSelector];
+			} else {
+				triggerFunction = functionSelector(firstItem);
+			}
+			if (triggerFunction) {
+				return triggerFunction.apply(widget, args);
 			}
 		},
 		getRender(index?: number): DNode | DNode[] {

--- a/tests/testing/unit/harness.ts
+++ b/tests/testing/unit/harness.ts
@@ -271,18 +271,7 @@ describe('harness', () => {
 					w<ChildWidget>('registry-item', { key: 'registry', id: 'random-id' })
 				])
 			);
-			h.trigger('*[key="other"]', 'onclick');
-			h.expect(() =>
-				v('div', { classes: ['root', 'other'], onclick: () => {} }, [
-					v(
-						'span',
-						{ key: 'span', classes: 'span', style: 'width: 100px', id: 'random-id', onclick: () => {} },
-						['hello 0']
-					),
-					w(ChildWidget, { key: 'widget', id: 'random-id', func: noop }),
-					w<ChildWidget>('registry-item', { key: 'registry', id: 'random-id' })
-				])
-			);
+			assert.throws(() => h.trigger('*[key="other"]', 'onclick'));
 		});
 
 		it('trigger by pseudo selector', () => {
@@ -520,14 +509,9 @@ describe('harness', () => {
 
 		it('trigger with non matching selector', () => {
 			const h = harness(() => w(ArrayWidget, {}));
-			h.trigger('*[key="other"]', 'onclick');
-			h.expect(() => [
-				v('span', { key: 'span', classes: 'span', style: 'width: 100px', id: 'random-id', onclick: () => {} }, [
-					'hello 0'
-				]),
-				w(ChildWidget, { key: 'widget', id: 'random-id' }),
-				w<ChildWidget>('registry-item', { key: 'registry', id: 'random-id' })
-			]);
+			assert.throws(() => {
+				h.trigger('*[key="other"]', 'onclick');
+			});
 		});
 
 		it('custom compare for VNode', () => {

--- a/tests/testing/unit/harnessWithTsx.tsx
+++ b/tests/testing/unit/harnessWithTsx.tsx
@@ -1,4 +1,5 @@
 const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
 
 import { harness } from '../../../src/testing/harness';
 import { WidgetBase } from '../../../src/widget-core/WidgetBase';
@@ -181,16 +182,8 @@ describe('harness with tsx', () => {
 
 	it('trigger with non matching selector', () => {
 		const h = harness(() => <MyWidget />);
-		h.trigger('*[key="other"]', 'onclick');
-		h.expect(() => (
-			<div classes={['root', 'other']} onclick={noop}>
-				<span key="span" classes="span" style="widget: 100px" id="random-id" onclick={noop}>
-					hello 0
-				</span>
-				<ChildWidget key="widget" id="random-id" />
-				<RegistryWidget key="registry" id="random-id" />
-			</div>
-		));
+
+		assert.throws(() => h.trigger('*[key="other"]', 'onclick'));
 	});
 
 	it('custom compare for VNode', () => {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Instead of silently failing, throwing an error when a `h.trigger` encounters a selector that doesn't return any nodes.

Resolves #318 
