### PR TITLE
Fix typings for commands created by a command factory

### DIFF
--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -795,6 +795,20 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 			const processExecutor = process(store);
 			return processExecutor({});
 		});
+
+		it('should be able to compose commands created by a command factory', () => {
+			const createCommand = createCommandFactory<any>();
+			const composedCommand = createCommand(({ path }) => {
+				return [add(path('foo'), 'bar')];
+			});
+			const command = createCommand((options) => {
+				return [...composedCommand(options)];
+			});
+			const process = createProcess('test', [command]);
+			const executor = process(store);
+			executor({});
+			assert.strictEqual(store.get(store.path('foo')), 'bar');
+		});
 	});
 };
 

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -180,20 +180,8 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 			const createCommand = createCommandFactory<StateType>();
 
 			createProcess('test', [
-				createCommand(({ path }) => [
-					{
-						op: OperationType.ADD,
-						path: new Pointer(path('foo').path),
-						value: 3
-					}
-				]),
-				createCommand(({ path }) => [
-					{
-						op: OperationType.ADD,
-						path: new Pointer(path('a', 'b').path),
-						value: 'foo'
-					}
-				])
+				createCommand(({ path }) => [add(path('foo'), 3)]),
+				createCommand(({ path }) => [add(path('a', 'b'), 'foo')])
 			])(store)({});
 
 			assert.equal(store.get(store.path('a', 'b')), 'foo');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Re-jig the command factory typings to correct infer the type of the command created, either returning `promise<void>`, `promise<PatchOperation[]>`, `void` or `PatchOperation[]` not an union of them all.

Resolves #335 
