### PR TITLE
Stores reference

### DIFF
--- a/docs/en/stores/basic-usage.md
+++ b/docs/en/stores/basic-usage.md
@@ -1,0 +1,87 @@
+# Basic Usage
+
+-   Overview of Dojo stores
+    _ https://github.com/dojo/framework/blob/master/src/stores/README.md#overview
+    _ https://github.com/dojo/framework/blob/master/src/stores/README.md#how-does-this-differ-from-redux
+    _ global store
+    _ type safe \* uni-directional data flow
+
+## The Store
+
+-   Overview
+    _ one global store per application
+    _ in general store data should be serializable \* special cases need special care
+
+### Setting up a store
+
+-   Creating and registering a store
+
+## Updating stores
+
+-   Overview
+
+### Operations
+
+-   https://github.com/dojo/framework/blob/master/src/stores/README.md#operations
+-   JSON patch
+    _ add
+    _ remove
+    _ replace
+    _ test
+
+### Commands
+
+-   https://github.com/dojo/framework/blob/master/src/stores/README.md#commands
+-   Overview
+    _ functions with access to the store
+    _ return patch operation(s) \* may be async
+-   CommandRequest (Command API)
+    _ at
+    _ path
+    _ get
+    _ payload \* state object
+-   creating commands
+    _ command factory
+    _ examples
+
+### Processes
+
+-   overview \* https://github.com/dojo/framework/blob/master/src/stores/README.md#processes
+-   Combine commands into a single process
+-   execute commands against a store
+-   attach a middleware
+    _ before commands
+    _ useful for gating
+    _ after commands
+    _ useful for error handling
+
+### Initial State
+
+Example for setting up an application's initial state
+https://github.com/dojo/framework/blob/master/src/stores/README.md#initial-state
+
+## Widgets and Stores
+
+### Container
+
+-   Overview
+    _ wraps a Widget
+    _ has access to a store
+    _ provides dependencies
+    _ interfaces matches the widget
+-   When should I use
+    _ Containers are useful when a 1:1 mapping is desired
+    _ Useful for connecting processes + store data
+
+### StoreProvider
+
+-   Overview
+    _ has access to a store
+    _ has its own renderer
+    _ is usually encapsulated in a widget
+    _ therefore can have a different interface
+-   When should I use
+    _ StoreProviders are more flexible than Containers
+    _ Useful for encapsulating widgets
+    _ Can do the same thing as Containers
+    _ Can change the interface of a wrapped widget

--- a/docs/en/stores/basic-usage.md
+++ b/docs/en/stores/basic-usage.md
@@ -48,11 +48,11 @@ The above is a simple example for illustrative purposes. Examples in this refere
 
 ## Updating stores
 
-To work with Dojo Stores there are three core but simple concepts - Operations, Commands, and Processes.
+To work with Dojo Stores there are three core concepts.
 
 -   **Operations** are instructions to manipulate the state held by the store
 -   **Commands** are simple functions that perform business logic and return operations
--   **Processes** execute a group of commands and usually represent application behavior
+-   **Processes** execute a group of commands and represent application behavior
 
 ### Operations
 
@@ -60,11 +60,11 @@ Stores cannot be modified directly. Instead four operations are available for mo
 
 #### `path` and `at`
 
-The path is a `string` that describes the location where an operation is applied. The `path` and `at` functions are part of the `Store` and are accessible inside of a `Command`.
+The path is a `string` that describes the location where an operation is applied. The `path` and `at` functions are part of the `Store` and are accessible inside of a `Command` (which we will talk about later).
 
-Here are a couple examples to show how `path` and `at` describe a location in the store. The `State` provided is there to illustrate the location of a value and describe how the location functions are used to reference that location. Typically `path` and `at` are used in conjunction with operations inside of Commands, which we will show later.
+Here are a couple examples to show how `path` and `at` describe a location in the store. The `State` is the same as defined above in `interface.d.ts`. It is used by the `Store` to understand the shape of the state data.
 
-> `path` transverses an object hierarchy
+> `path` of the current user name
 
 ```ts
 const store = new Store<State>();
@@ -172,7 +172,7 @@ These operations set the current user unless a current user already exists.
 
 ### Commands
 
-Commands are simply functions that are called while executing a process and return an array of operations that modify the store. Each command is passed a `CommandRequest` which provides `path` and `at` functions to generate `Path`s in a type-safe way, a `get` function for access to the store's state, a `payload` object for the argument that the process executor was called with.
+Commands are simply functions that are called while executing a process. They return an array of operations that modify the store. Each command is passed a `CommandRequest` which provides `path` and `at` functions to generate `Path`s in a type-safe way, a `get` function for access to the store's state, a `payload` object for the argument that the process executor was called with.
 
 #### The command factory
 
@@ -193,7 +193,7 @@ const myCommand = createCommand(({ at, get, path, payload, state }) => {
 
 `createCommand` will ensure that the wrapped command has the correct typing and the passed `CommandRequest` functions will be typed to the `State` interface provided to `createCommandFactory`. While it is possible to manually type commands this guide will use `createCommand` in its examples.
 
-#### `get'
+#### `get`
 
 The `get` function returns a value from the store at a specified path or `undefined` if a value does not exist at that location.
 
@@ -362,7 +362,7 @@ login(store)({
 
 #### Initial State
 
-Initial application state can be defined on store creating by executing a process.
+Initial application state can be defined on a store creating by executing a process.
 
 > main.ts
 

--- a/docs/en/stores/basic-usage.md
+++ b/docs/en/stores/basic-usage.md
@@ -1,64 +1,407 @@
 # Basic Usage
 
--   Overview of Dojo stores
-    _ https://github.com/dojo/framework/blob/master/src/stores/README.md#overview
-    _ https://github.com/dojo/framework/blob/master/src/stores/README.md#how-does-this-differ-from-redux
-    _ global store
-    _ type safe \* uni-directional data flow
+Dojo is a reactive architecture concerned with constantly modifying and rendering the current state of an application. In simple systems this can happen at a local level and widgets can maintain their own state. However, as a system becomes more complex the need to better compartmentalize and encapsulate data and create a clean separation of concerns quickly grows.
+
+Stores provide a clean interface for storing, modifying, and retrieving data from a global object using a unidirectional data flow. Common patterns such as asynchronous retrieval, middleware, and undo patterns are built in. This allows widgets to remain focused on their primary roles of providing a visual representation of themselves and listening for user interactions.
 
 ## The Store
 
--   Overview
-    _ one global store per application
-    _ in general store data should be serializable \* special cases need special care
+The store hold the global, atomic state for the entire application. It is created when the application is created and defined in the `Registry` with an injector.
 
-### Setting up a store
+> main.ts
 
--   Creating and registering a store
+```ts
+import Registry from '@dojo/framework/widget-core/Registry';
+import Store from '@dojo/framework/stores/Store';
+import { State } from './interfaces';
+
+const registry = new Registry();
+const store = new Store<State>();
+registry.defineInjector('state', (invalidator) => {
+	store.on('invalidate', () => invalidator());
+	return () => store;
+});
+```
+
+`State` defines the shape of the global store using an interface. In general state should be serializable. This improves performance and makes it easier for Dojo to determine when changes to the data occur.
+
+> interfaces.d.ts
+
+```ts
+interface User {
+	id: string;
+	name: string;
+}
+
+export interface State {
+	auth: {
+		token: string;
+	};
+	users: {
+		current: User;
+		list: User[];
+	};
+}
+```
+
+The above is a simple example for illustrative purposes. Examples in this reference guide will refer back to this interface to reduce repetition.
 
 ## Updating stores
 
--   Overview
+To work with Dojo Stores there are three core but simple concepts - Operations, Commands, and Processes.
+
+-   **Operations** are instructions to manipulate the state held by the store
+-   **Commands** are simple functions that perform business logic and return operations
+-   **Processes** execute a group of commands and usually represent application behavior
 
 ### Operations
 
--   https://github.com/dojo/framework/blob/master/src/stores/README.md#operations
--   JSON patch
-    _ add
-    _ remove
-    _ replace
-    _ test
+Stores cannot be modified directly. Instead four operations are available for modifying state: `add`, `remove`, `replace`, and `test`. These operations are represented by simple objects based on the [JSON patch](http://jsonpatch.com/) format, but in practice helper functions will always be used.
+
+#### `path` and `at`
+
+The path is a `string` that describes the location where an operation is applied. The `path` and `at` functions are part of the `Store` and are accessible inside of a `Command`.
+
+Here are a couple examples to show how `path` and `at` describe a location in the store. The `State` provided is there to illustrate the location of a value and describe how the location functions are used to reference that location. Typically `path` and `at` are used in conjunction with operations inside of Commands, which we will show later.
+
+> `path` transverses an object hierarchy
+
+```ts
+const store = new Store<State>();
+const { path } = store;
+
+path('users', 'current', 'name');
+```
+
+This path refers to the `string` value located at `/users/current/name`. `path` is used to transverse the hierarchy in a type-safe way. It ensures only the property names defined in the `State` interface are used.
+
+> `at` is an offset
+
+```ts
+const store = new Store<State>();
+const { at, path } = store;
+
+at(path('users', 'list'), 1);
+```
+
+This path refers to the `User` located at `/users/list` at offset `1`.
+
+#### `add` operation
+
+Adds a value to an object or inserts it into an array.
+
+> `add` example
+
+```ts
+import { add } from '@dojo/framework/stores/state/operations';
+
+const store = new Store<State>();
+const { apply, at, path } = store;
+const user = { id: '0', name: 'Paul' };
+
+apply([add(at(path('users', 'list'), 0), user)]);
+```
+
+This will add `user` to the beginning of the user list.
+
+#### `remove` operation
+
+Removes a value from an object or an array
+
+> `remove` example
+
+```ts
+import { add, remove } from '@dojo/framework/stores/state/operations';
+
+const store = new Store<State>();
+const { apply, at, path } = store;
+const user = { id: '0', name: 'Paul' };
+
+apply([
+	add(path('users'), {
+		current: user,
+		list: [user]
+	}),
+	remove(at(path('users', 'list'), 0))
+]);
+```
+
+This example will add an initial state for `users` and remove the first `user` in the list.
+
+#### `replace` operation
+
+Replaces a value. Equivalent to a `remove` followed by an `add`.
+
+> `replace` example
+
+```ts
+import { add, replace } from '@dojo/framework/stores/state/operations';
+
+const store = new Store<State>();
+const { apply, at, path } = store;
+const users = [{ id: '0', name: 'Paul' }, { id: '1', name: 'Michael' }];
+const newUser = { id: '2', name: 'Shannon' };
+
+apply([
+	add(path('users'), {
+		current: user[0],
+		list: users
+	}),
+	replace(at(path('users', 'list'), 1), newUser)
+]);
+```
+
+This example will replace the second user in the `list` with `newUser`.
+
+#### `test` operation
+
+Tests that the specified value is set in the store. If the test fails then the entire set of operations should not apply.
+
+```ts
+import Store from '@dojo/framework/stores/Store';
+import { add } from '@dojo/framework/stores/state/operations';
+
+const store = new Store<State>();
+const { path, apply } = store;
+const user = { id: '0', name: 'Paul' };
+
+apply([test(path('users', 'current'), undefined), add(path('users', 'current'), user)]);
+```
+
+These operations set the current user unless a current user already exists.
 
 ### Commands
 
--   https://github.com/dojo/framework/blob/master/src/stores/README.md#commands
--   Overview
-    _ functions with access to the store
-    _ return patch operation(s) \* may be async
--   CommandRequest (Command API)
-    _ at
-    _ path
-    _ get
-    _ payload \* state object
--   creating commands
-    _ command factory
-    _ examples
+Commands are simply functions that are called while executing a process and return an array of operations that modify the store. Each command is passed a `CommandRequest` which provides `path` and `at` functions to generate `Path`s in a type-safe way, a `get` function for access to the store's state, a `payload` object for the argument that the process executor was called with.
+
+#### The command factory
+
+Stores have a simple wrapper function that acts as a type-safe factory for creating new commands.
+
+> Creating a store factory
+
+```ts
+import { createCommandFactory } from '@dojo/framework/stores/process';
+import { State } from './interfaces';
+
+const createCommand = createCommandFactory<State>();
+
+const myCommand = createCommand(({ at, get, path, payload, state }) => {
+	return [];
+});
+```
+
+`createCommand` will ensure that the wrapped command has the correct typing and the passed `CommandRequest` functions will be typed to the `State` interface provided to `createCommandFactory`. While it is possible to manually type commands this guide will use `createCommand` in its examples.
+
+#### `get'
+
+The `get` function returns a value from the store at a specified path or `undefined` if a value does not exist at that location.
+
+> Using `get`
+
+```ts
+import { createCommandFactory } from '@dojo/framework/stores/process';
+import { State } from './interfaces';
+import { remove, replace } from '@dojo/framework/stores/state/operations';
+
+const createCommand = createCommandFactory<State>();
+
+const updateCurrentUser = createCommand(async ({ at, get, path }) => {
+	const token = get(path('auth', 'token'));
+
+	if (!token) {
+		return [remove(path('users', 'current'))];
+	} else {
+		const user = await fetchCurrentUser(token);
+		return [replace(path('users', 'current'), user)];
+	}
+});
+```
+
+This example checks for the presence of an authentication token and works to update the current user information.
+
+#### `payload`
+
+The `payload` is an object literal passed into a command when it is called from a process. The `payload`'s type may be defined when constructing the command.
+
+> Defining a `payload`
+
+```ts
+import { createCommandFactory } from '@dojo/framework/stores/process';
+import { State } from './interfaces';
+import { remove, replace } from '@dojo/framework/stores/state/operations';
+
+const createCommand = createCommandFactory<State>();
+
+const addUser = createCommand<User>(({ at, path, payload }) => {
+	return [add(at(path('users', 'list'), 0), payload)];
+});
+```
+
+This example adds a user provided in the `payload` to the beginning of `/users/list`.
+
+#### `state`
+
+In modern browsers a `state` object is passed as part of the `CommandRequest`. Any modification to this object is translated to the appropriate patch operations and applied against the store.
+
+```ts
+import { createCommandFactory } from '@dojo/framework/stores/process';
+import { State } from './interfaces';
+import { remove, replace } from '@dojo/framework/stores/state/operations';
+
+const createCommand = createCommandFactory<State>();
+
+const addUser = createCommand<User>(({ payload, state }) => {
+	const currentUsers = state.users.list || [];
+	state.users.list = [...currentUsers, payload];
+});
+```
+
+Note that attempting to access state is not supported in IE and will immediately throw an error.
+
+#### Asynchronous commands
+
+Commands can be synchronous or asynchronous. Asynchronous commands should return a `Promise` to indicate when they are finished. Operations are collected and applied atomically after each command completes successfully.
 
 ### Processes
 
--   overview \* https://github.com/dojo/framework/blob/master/src/stores/README.md#processes
--   Combine commands into a single process
--   execute commands against a store
--   attach a middleware
-    _ before commands
-    _ useful for gating
-    _ after commands
-    _ useful for error handling
+A `Process` is a construct used to sequentially execute commands against a `store` in order to makes changes to the application state. Processes are created using the `createProcess` factory function that accepts a list of commands and optionally a list of middleware.
 
-### Initial State
+#### Creating a Process
 
-Example for setting up an application's initial state
-https://github.com/dojo/framework/blob/master/src/stores/README.md#initial-state
+First, create a couple commands responsible for obtaining a user token and use that token to load a `User`. Then create a process that uses those commands.
+
+> Create a process
+
+```ts
+import { createCommandFactory, createProcess } from "@dojo/framework/stores/process";
+import { State } from './interfaces';
+import { add, replace } from "@dojo/framework/stores/state/operations";
+
+const createCommand = createCommandFactory<State>();
+
+const fetchUser = createCommand(async ({ at, get, payload: { username, password } }) => {
+	const token = await fetchToken(username, password);
+
+	return [
+		add(path('auth', 'token'), token);
+	];
+}
+
+const loadUserData = createCommand(async ({ path }) => {
+	const token = get(path('auth', 'token'));
+	const user = await fetchCurrentUser(token);
+	return [
+		replace(path('users', 'current'), user)
+	];
+});
+
+export const login = createProcess('login', [ fetchUser, loadUserData ]);
+```
+
+#### Middleware
+
+Middleware wraps a process in `before` and `after` callbacks that surround a process. A common use of middleware is for the handling of errors and reinstating consistent state.
+
+Lets add some middleware that runs after the commands and resets the state if an error occurs.
+
+> commands/login.ts example
+
+```ts
+import { createCommandFactory } from "@dojo/framework/stores/process";
+import { State } from './interfaces';
+import { add, replace } from "@dojo/framework/stores/state/operations";
+
+const createCommand = createCommandFactory<State>();
+
+const fetchUser = createCommand(async ({ at, get, payload: { username, password } }) => {
+	const token = await fetchToken(username, password);
+
+	return [
+		add(path('auth', 'token'), token);
+	];
+}
+
+const loadUserData = createCommand(async ({ path }) => {
+	const token = get(path('auth', 'token'));
+	const user = await fetchCurrentUser(token);
+	return [
+		replace(path('users', 'current'), user)
+	];
+});
+
+const resetUserOnError = () => {
+	return {
+		after: (error, result) => {
+			if (error) {
+				result.store.apply([
+					remove(path('auth', 'token')),
+					remove(path('users', 'current'))
+				])
+			}
+		}
+	};
+};
+
+const login = createProcess('login', [ fetchUser, loadUserData ], [ resetUserOnError ]);
+```
+
+#### Excuting a Process
+
+A process simply defines an execution flow for a set of data. To execute a process it needs access to the store to create an executor. Then the executor can be provided a payload to act upon.
+
+```ts
+import { login } from 'commands/login';
+import { store } from 'main.ts';
+
+login(store)({
+	username: 'Paul',
+	password: 'password'
+});
+```
+
+#### Initial State
+
+Initial application state can be defined on store creating by executing a process.
+
+> main.ts
+
+```ts
+const store = new Store<State>();
+const { path } = store;
+
+const createCommand = createCommandFactory<State>();
+
+const initialStateCommand = createCommand(({ path }) => {
+	return [add(path('auth'), { token: undefined }), add(path('users'), { list: [] })];
+});
+
+const initialStateProcess = createProcess('initial', [initialStateCommand]);
+
+initialStateProcess(store)({});
+```
+
+#### `payload` type
+
+The process executor's `payload` is inferred from the `payload` type of the commands. If the payloads differ then it is necessary to explictly define the `payload` type.
+
+> Explicitly defining `payload` type
+
+```ts
+const createCommand = createCommandFactory<State>();
+
+const commandOne = createCommand<{ one: string }>(({ payload }) => {
+	return [];
+});
+
+const commandTwo = createCommand<{ two: string }>(({ payload }) => {
+	return [];
+});
+
+const process = createProcess<State, { one: string; two: string }>('example', [commandOne, commandTwo]);
+
+process(store)({ one: 'one', two: 'two' });
+```
 
 ## Widgets and Stores
 

--- a/docs/en/stores/basic-usage.md
+++ b/docs/en/stores/basic-usage.md
@@ -360,27 +360,6 @@ login(store)({
 });
 ```
 
-#### Initial State
-
-Initial application state can be defined on a store creating by executing a process.
-
-> main.ts
-
-```ts
-const store = new Store<State>();
-const { path } = store;
-
-const createCommand = createCommandFactory<State>();
-
-const initialStateCommand = createCommand(({ path }) => {
-	return [add(path('auth'), { token: undefined }), add(path('users'), { list: [] })];
-});
-
-const initialStateProcess = createProcess('initial', [initialStateCommand]);
-
-initialStateProcess(store)({});
-```
-
 #### `payload` type
 
 The process executor's `payload` is inferred from the `payload` type of the commands. If the payloads differ then it is necessary to explictly define the `payload` type.

--- a/docs/en/stores/introduction.md
+++ b/docs/en/stores/introduction.md
@@ -1,8 +1,8 @@
 # Introduction
 
-One line introduction to the capability being described in this reference guide.
+Dojo stores is a predictable, consistent state container with built-in support for common patterns.
 
-One or two more (brief) paragraphs describing what users can accomplish with the capability.
+This package provides a centralized store designed to be the single source of truth for an application. It operates using uni-directional data flow. This means all application data follows the same lifecycle, ensuring the application logic is predictable and easy to understand.
 
 | Feature                   | Description                                                          |
 | ------------------------- | -------------------------------------------------------------------- |
@@ -11,6 +11,11 @@ One or two more (brief) paragraphs describing what users can accomplish with the
 | type safe                 | access and modification of state is protected by interfaces          |
 | asynchronous support      | async commands supported out-of-the-box                              |
 | middleware                | before and after operations, error handling, and data transformation |
+| widget integration        | tools and patterns for integrating with Dojo widgets                 |
+
+<!-- TODO more features? Clean up descriptions above.
+Dojo stores have the benefit of using JSON Patch to ensure the underlying data is appropiately updated (as opposed to reducers that rely on the user to properly clone. So how do I say that?
 
 -   immutable data patterns
 -   no access to underlying data means no mistakes
+-->

--- a/docs/en/stores/introduction.md
+++ b/docs/en/stores/introduction.md
@@ -1,0 +1,16 @@
+# Introduction
+
+One line introduction to the capability being described in this reference guide.
+
+One or two more (brief) paragraphs describing what users can accomplish with the capability.
+
+| Feature                   | Description                                                          |
+| ------------------------- | -------------------------------------------------------------------- |
+| global data store         | Application state is stored globally in a single source of truth     |
+| uni-directional data flow |                                                                      |
+| type safe                 | access and modification of state is protected by interfaces          |
+| asynchronous support      | async commands supported out-of-the-box                              |
+| middleware                | before and after operations, error handling, and data transformation |
+
+-   immutable data patterns
+-   no access to underlying data means no mistakes

--- a/docs/en/stores/introduction.md
+++ b/docs/en/stores/introduction.md
@@ -6,16 +6,10 @@ This package provides a centralized store designed to be the single source of tr
 
 | Feature                   | Description                                                          |
 | ------------------------- | -------------------------------------------------------------------- |
-| global data store         | Application state is stored globally in a single source of truth     |
-| uni-directional data flow |                                                                      |
+| global data store         | application state is stored globally in a single source of truth     |
+| uni-directional data flow | predictable and global application state management                  |
 | type safe                 | access and modification of state is protected by interfaces          |
 | asynchronous support      | async commands supported out-of-the-box                              |
 | middleware                | before and after operations, error handling, and data transformation |
 | widget integration        | tools and patterns for integrating with Dojo widgets                 |
-
-<!-- TODO more features? Clean up descriptions above.
-Dojo stores have the benefit of using JSON Patch to ensure the underlying data is appropiately updated (as opposed to reducers that rely on the user to properly clone. So how do I say that?
-
--   immutable data patterns
--   no access to underlying data means no mistakes
--->
+| operations                | encapsulated, well-defined state modifications                       |

--- a/docs/en/stores/supplemental.md
+++ b/docs/en/stores/supplemental.md
@@ -6,6 +6,82 @@
 
 ## Process Middleware
 
+# JSON Patch and Store operations
+
+In the basic usage guide we show how Dojo Stores use operations in detail to make changes to the underlying state of an application and state that these operations are based on [JSON patch](). However, Stores deviates from the JSON Patch specification, [RFC 6902](https://tools.ietf.org/html/rfc6902), in a number of ways.
+
+First and foremost Dojo Stores was designed with simplicity in mind. For instance, operations will automatically create the underlying structure necessary to support an `add` or `replace` operation.
+
+> Deep `add` in an uninitialized store
+
+```ts
+import Store from '@dojo/framework/stores/Store';
+import { add } from '@dojo/framework/stores/state/operations';
+
+const store = new Store<State>();
+const { at, path, apply } = store;
+const user = { id: '0', name: 'Paul' };
+
+apply([add(at(path('users', 'list'), 10), user)]);
+```
+
+> Result
+
+```json
+{
+	"users": {
+		"list": [
+			{
+				"id": "0",
+				"name": "Paul"
+			}
+		]
+	}
+}
+```
+
+Even though state has not been initialized, Dojo is able to create the underlying hierarchy based on the provided path. This operation is safe because of the type safety that TypeScript and Dojo Stores provide. This allows for users to work naturally with the `State` interface used by the store instead of needing to be concerned with the data explicitly held by the store.
+
+When an explicit state is required that information can asserted by using a `test` operation or by getting the underlying data and validating it programmatically.
+
+This example will throw a test exception since `/users/list` has not been initialized.
+
+> Using `test` to ensure initialization
+
+```ts
+import Store from "@dojo/framework/stores/Store";
+import { test } from "@dojo/framework/stores/state/operations";
+
+const store = new Store<State>();
+const { at, path, apply } = store;
+
+apply([
+	test(at(path('users', 'list', 'length), 0))
+]);
+```
+
+This example ensures that `user` is always added to the end of the list as the last element.
+
+> Programmatic introspection
+
+```ts
+import Store from '@dojo/framework/stores/Store';
+import { add, test } from '@dojo/framework/stores/state/operations';
+
+const store = new Store<State>();
+const { get, at, path, apply } = store;
+const user = { id: '0', name: 'Paul' };
+const pos = get(path('users', 'list', 'length')) || 0;
+apply([
+	add(at(path('users', 'list'), pos), user),
+	test(at(path('users', 'list'), pos), user),
+	test(path('users', 'list', 'length'), pos + 1)
+]);
+```
+
+Access to state root is not permitted and will throw an error, for example, get(path('/')). This applies to Operations also, it is not possible to create an operation that will update the state root. Best practices with @dojo/framework/stores mean touching the smallest part of the store as is necessary.
+
+<!-- TODO
 StoreProvider
 
     Using the StoreProvider
@@ -35,3 +111,4 @@ _ local state
 _ stored while the widget is connected
 _ global state
 _ stored for the lifetime of the application \* easy to reinstate and alter
+-->

--- a/docs/en/stores/supplemental.md
+++ b/docs/en/stores/supplemental.md
@@ -1,0 +1,37 @@
+# StoreProvider
+
+# Working with Commands
+
+## Asynchronous Commands
+
+## Process Middleware
+
+StoreProvider
+
+    Using the StoreProvider
+    StoreProvider API
+    Registering paths for invalidation etc
+
+Working with Commands
+
+    Type safe commands with the command factory
+    The Command Request API
+
+Asynchronous and Concurrent Commands
+Process Middleware
+Immutable patterns when updating state
+Optimistic Update Pattern
+Handling errors and rollback
+Composing Commands
+Working with Arrays
+Transforming Process Payloads
+Normalizing State
+Custom State Management Implementation (i.e. immutable)
+Working with external / remote data sources
+Dojo provided middleware (i.e. local storage, history etc)
+Undo support
+Architectural considerations
+_ local state
+_ stored while the widget is connected
+_ global state
+_ stored for the lifetime of the application \* easy to reinstate and alter


### PR DESCRIPTION
This is a draft of the stores reference guide.

* Introduction is mostly complete. Some cleanup on the features will likely need to happen when I'm done writing and have full view of everything.
* Basic usage is done. It contains everything a person needs to use state from store to widget written in a manner that progresses from operations thru `StoreProvider`.
* Supplemental is done

Resolves #324 

We added a discussion about Dojo's implementation of JSON patch in the supplemental section after writing #339 and discussing the `state` feature with @maier49. Dojo differs quite significantly from JSON patch in that it tries to do the right thing regarding uninitialized state and avoid throwing errors.