### PR TITLE
Fix behavior for nested commands with state proxy

### DIFF
--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -574,7 +574,7 @@ const myProcess = createProcess('my-process', [commandOne, [concurrentCommandOne
 
 In this example, `commandOne` is executed, then both `concurrentCommandOne` and `concurrentCommandTwo` are executed concurrently. Once all of the concurrent commands are completed the results are applied in order before continuing with the process and executing `commandTwo`.
 
-**Note:** Concurrent commands are always assumed to be asynchronous and resolved using `Promise.all`.
+**Note:** Concurrent commands are all assumed to be asynchronous and resolved using `Promise.all` if any returns a `Promise`.
 
 ### Providing an alternative State implementation
 

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -208,33 +208,35 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 		});
 
 		it('handles nested async commands modifying the state proxy', async () => {
-			await createProcess('test', [
-				({ state }) => {
-					state.foo = 0;
-				},
-				[
-					(({ state }: any) => {
-						return new Promise((resolve) => {
-							setTimeout(() => {
-								assert.equal(state.foo, 0);
-								state.foo += 10;
-								resolve();
-							}, 100);
-						});
-					}) as any,
-					(({ state }: any) => {
-						return new Promise((resolve) => {
-							setTimeout(() => {
-								assert.equal(state.foo, 0);
-								state.foo = state.foo / 2;
-								resolve();
-							}, 10);
-						});
-					}) as any
-				]
-			])(store)({});
+			await assertProxyError(async () => {
+				await createProcess('test', [
+					({ state }) => {
+						state.foo = 0;
+					},
+					[
+						(({ state }: any) => {
+							return new Promise((resolve) => {
+								setTimeout(() => {
+									assert.equal(state.foo, 0);
+									state.foo += 10;
+									resolve();
+								}, 100);
+							});
+						}) as any,
+						(({ state }: any) => {
+							return new Promise((resolve) => {
+								setTimeout(() => {
+									assert.equal(state.foo, 0);
+									state.foo = state.foo / 2;
+									resolve();
+								}, 10);
+							});
+						}) as any
+					]
+				])(store)({});
 
-			assert.equal(store.get(store.path('foo')), 0);
+				assert.equal(store.get(store.path('foo')), 0);
+			});
 		});
 
 		it('Can set a proxied property to itself', async () => {


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This fixes the issue where nested commands are run out of order when using the `state` proxy, by scoping the proxy to each inner command.

Resolves #340
