### PR TITLE
Fix length return for immutable lists

### DIFF
--- a/src/stores/state/ImmutableState.ts
+++ b/src/stores/state/ImmutableState.ts
@@ -100,6 +100,14 @@ export class ImmutableState<T = any> implements MutableState<T> {
 		const pointer = new Pointer(hasMultipleSegments ? stringSegments : stringSegments[0] || '');
 		let value = this._state.getIn(pointer.segments);
 
+		if (pointer.segments.length > 1 && pointer.segments[pointer.segments.length - 1] === 'length') {
+			const parent = pointer.segments.slice(0, pointer.segments.length - 1);
+			const parentState = this._state.getIn(parent);
+			if (isList(parentState)) {
+				value = parentState.size;
+			}
+		}
+
 		if (isList(value) || isMap(value)) {
 			value = value.toJS();
 		}

--- a/tests/stores/unit/state/ImmutableState.ts
+++ b/tests/stores/unit/state/ImmutableState.ts
@@ -218,11 +218,11 @@ describe('state/ImmutableState', () => {
 		const state = new ImmutableState();
 		state.apply([{ op: OperationType.ADD, path: new Pointer('foo'), value: [] }]);
 
-		assert.equal(state.path('foo', 'length').value, 0);
+		assert.equal(state.get(state.path('foo', 'length')), 0);
 
 		state.apply([{ op: OperationType.ADD, path: new Pointer('foo/0'), value: 'foo' }]);
 
-		assert.equal(state.path('foo', 'length').value, 1);
+		assert.equal(state.get(state.path('foo', 'length')), 1);
 	});
 
 	it('unknown', () => {

--- a/tests/stores/unit/state/ImmutableState.ts
+++ b/tests/stores/unit/state/ImmutableState.ts
@@ -214,6 +214,17 @@ describe('state/ImmutableState', () => {
 		});
 	});
 
+	it('should report the length of an array', () => {
+		const state = new ImmutableState();
+		state.apply([{ op: OperationType.ADD, path: new Pointer('foo'), value: [] }]);
+
+		assert.equal(state.path('foo', 'length').value, 0);
+
+		state.apply([{ op: OperationType.ADD, path: new Pointer('foo/0'), value: 'foo' }]);
+
+		assert.equal(state.path('foo', 'length').value, 1);
+	});
+
 	it('unknown', () => {
 		assert.throws(
 			() => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds logic to convert Immutable List size to array length 
Resolves #343
