### PR TITLE
Make shims polyfills

### DIFF
--- a/src/shim/Map.ts
+++ b/src/shim/Map.ts
@@ -125,7 +125,7 @@ export interface MapConstructor {
 export let Map: MapConstructor = global.Map;
 
 if (!has('es6-map')) {
-	Map = class Map<K, V> {
+	Map = global.Map = class Map<K, V> {
 		protected readonly _keys: K[] = [];
 		protected readonly _values: V[] = [];
 

--- a/src/shim/README.md
+++ b/src/shim/README.md
@@ -2,7 +2,7 @@
 
 This package provides functional shims for ECMAScript, access to the Typescript helpers, and a quick way to include the polyfills needed to run Dojo in the browser.
 
-It is targeted at providing function shims for ECMAScript 6 and beyond targeted at ECMAScript 5. It is different than other solutions of shimming or polyfilling functionality, in that it does not provide the functionality via augmenting the built-in classes in the global namespace.
+It is targeted at providing polyfills for ECMAScript 6 and beyond targeted at ECMAScript 5. For backwards compatibility function shims are also provided in some cases.
 
 There are two exceptions to this. One is the `Promise` object, which needs to be globally available for async/await operations. The other exception is the `Symbol` functionality, in that the well-known symbols need to be located off of the global `Symbol` object in order to ensure that the correct symbol is referenced.
 

--- a/src/shim/Set.ts
+++ b/src/shim/Set.ts
@@ -103,7 +103,7 @@ export interface SetConstructor {
 export let Set: SetConstructor = global.Set;
 
 if (!has('es6-set')) {
-	Set = class Set<T> {
+	Set = global.Set = class Set<T> {
 		private readonly _setData: T[] = [];
 
 		static [Symbol.species] = Set;

--- a/src/shim/WeakMap.ts
+++ b/src/shim/WeakMap.ts
@@ -91,7 +91,7 @@ if (!has('es6-weakmap')) {
 		};
 	})();
 
-	WeakMap = class WeakMap<K, V> {
+	WeakMap = global.WeakMap = class WeakMap<K, V> {
 		private readonly _name: string;
 		private readonly _frozenEntries: Entry<K, V>[];
 

--- a/src/shim/array.ts
+++ b/src/shim/array.ts
@@ -25,11 +25,6 @@ export interface FindCallback<T> {
 	(element: T, index: number, array: ArrayLike<T>): boolean;
 }
 
-interface WritableArrayLike<T> {
-	readonly length: number;
-	[n: number]: T;
-}
-
 /* ES6 Array static methods */
 
 export interface From {
@@ -119,66 +114,59 @@ export let findIndex: <T>(target: ArrayLike<T>, callback: FindCallback<T>, thisA
  */
 export let includes: <T>(target: ArrayLike<T>, searchElement: T, fromIndex?: number) => boolean;
 
-if (has('es6-array') && has('es6-array-fill')) {
-	from = global.Array.from;
-	of = global.Array.of;
-	copyWithin = wrapNative(global.Array.prototype.copyWithin);
-	fill = wrapNative(global.Array.prototype.fill);
-	find = wrapNative(global.Array.prototype.find);
-	findIndex = wrapNative(global.Array.prototype.findIndex);
-} else {
-	// It is only older versions of Safari/iOS that have a bad fill implementation and so aren't in the wild
-	// To make things easier, if there is a bad fill implementation, the whole set of functions will be filled
+const Array: ArrayConstructor = global.Array;
 
-	/**
-	 * Ensures a non-negative, non-infinite, safe integer.
-	 *
-	 * @param length The number to validate
-	 * @return A proper length
-	 */
-	const toLength = function toLength(length: number): number {
-		if (isNaN(length)) {
-			return 0;
-		}
+// Util functions for filled implementations
+/**
+ * Ensures a non-negative, non-infinite, safe integer.
+ *
+ * @param length The number to validate
+ * @return A proper length
+ */
+const toLength = function toLength(length: number): number {
+	if (isNaN(length)) {
+		return 0;
+	}
 
-		length = Number(length);
-		if (isFinite(length)) {
-			length = Math.floor(length);
-		}
-		// Ensure a non-negative, real, safe integer
-		return Math.min(Math.max(length, 0), MAX_SAFE_INTEGER);
-	};
+	length = Number(length);
+	if (isFinite(length)) {
+		length = Math.floor(length);
+	}
+	// Ensure a non-negative, real, safe integer
+	return Math.min(Math.max(length, 0), MAX_SAFE_INTEGER);
+};
 
-	/**
-	 * From ES6 7.1.4 ToInteger()
-	 *
-	 * @param value A value to convert
-	 * @return An integer
-	 */
-	const toInteger = function toInteger(value: any): number {
-		value = Number(value);
-		if (isNaN(value)) {
-			return 0;
-		}
-		if (value === 0 || !isFinite(value)) {
-			return value;
-		}
+/**
+ * From ES6 7.1.4 ToInteger()
+ *
+ * @param value A value to convert
+ * @return An integer
+ */
+const toInteger = function toInteger(value: any): number {
+	value = Number(value);
+	if (isNaN(value)) {
+		return 0;
+	}
+	if (value === 0 || !isFinite(value)) {
+		return value;
+	}
 
-		return (value > 0 ? 1 : -1) * Math.floor(Math.abs(value));
-	};
+	return (value > 0 ? 1 : -1) * Math.floor(Math.abs(value));
+};
 
-	/**
-	 * Normalizes an offset against a given length, wrapping it if negative.
-	 *
-	 * @param value The original offset
-	 * @param length The total length to normalize against
-	 * @return If negative, provide a distance from the end (length); otherwise provide a distance from 0
-	 */
-	const normalizeOffset = function normalizeOffset(value: number, length: number): number {
-		return value < 0 ? Math.max(length + value, 0) : Math.min(value, length);
-	};
+/**
+ * Normalizes an offset against a given length, wrapping it if negative.
+ *
+ * @param value The original offset
+ * @param length The total length to normalize against
+ * @return If negative, provide a distance from the end (length); otherwise provide a distance from 0
+ */
+const normalizeOffset = function normalizeOffset(value: number, length: number): number {
+	return value < 0 ? Math.max(length + value, 0) : Math.min(value, length);
+};
 
-	from = function from(
+if (!has('es6-array')) {
+	Array.from = function from(
 		this: ArrayConstructor,
 		arrayLike: Iterable<any> | ArrayLike<any>,
 		mapFunction?: MapCallback<any, any>,
@@ -229,21 +217,16 @@ if (has('es6-array') && has('es6-array-fill')) {
 		return array;
 	};
 
-	of = function of<T>(...items: T[]): Array<T> {
+	Array.of = function of<T>(...items: T[]): Array<T> {
 		return Array.prototype.slice.call(items);
 	};
 
-	copyWithin = function copyWithin<T>(
-		target: ArrayLike<T>,
-		offset: number,
-		start: number,
-		end?: number
-	): ArrayLike<T> {
-		if (target == null) {
+	Array.prototype.copyWithin = function copyWithin(offset: number, start: number, end?: number) {
+		if (this == null) {
 			throw new TypeError('copyWithin: target must be an array-like object');
 		}
 
-		const length = toLength(target.length);
+		const length = toLength(this.length);
 		offset = normalizeOffset(toInteger(offset), length);
 		start = normalizeOffset(toInteger(start), length);
 		end = normalizeOffset(end === undefined ? length : toInteger(end), length);
@@ -257,10 +240,10 @@ if (has('es6-array') && has('es6-array-fill')) {
 		}
 
 		while (count > 0) {
-			if (start in target) {
-				(target as WritableArrayLike<T>)[offset] = target[start];
+			if (start in this) {
+				this[offset] = this[start];
 			} else {
-				delete (target as WritableArrayLike<T>)[offset];
+				delete this[offset];
 			}
 
 			offset += direction;
@@ -268,28 +251,18 @@ if (has('es6-array') && has('es6-array-fill')) {
 			count--;
 		}
 
-		return target;
+		return this;
 	};
 
-	fill = function fill<T>(target: ArrayLike<T>, value: any, start?: number, end?: number): ArrayLike<T> {
-		const length = toLength(target.length);
-		let i = normalizeOffset(toInteger(start), length);
-		end = normalizeOffset(end === undefined ? length : toInteger(end), length);
+	type Predicate = (this: void, value: any, index: number, obj: any[]) => boolean;
 
-		while (i < end) {
-			(target as WritableArrayLike<T>)[i++] = value;
-		}
-
-		return target;
+	Array.prototype.find = function find(callback: Predicate, thisArg?: {}) {
+		const index = this.findIndex(callback, thisArg);
+		return index !== -1 ? this[index] : undefined;
 	};
 
-	find = function find<T>(target: ArrayLike<T>, callback: FindCallback<T>, thisArg?: {}): T | undefined {
-		const index = findIndex<T>(target, callback, thisArg);
-		return index !== -1 ? target[index] : undefined;
-	};
-
-	findIndex = function findIndex<T>(target: ArrayLike<T>, callback: FindCallback<T>, thisArg?: {}): number {
-		const length = toLength(target.length);
+	Array.prototype.findIndex = function findIndex(callback: Predicate, thisArg?: {}): number {
+		const length = toLength(this.length);
 
 		if (!callback) {
 			throw new TypeError('find: second argument must be a function');
@@ -300,7 +273,7 @@ if (has('es6-array') && has('es6-array-fill')) {
 		}
 
 		for (let i = 0; i < length; i++) {
-			if (callback(target[i], i, target)) {
+			if (callback(this[i], i, this)) {
 				return i;
 			}
 		}
@@ -309,32 +282,26 @@ if (has('es6-array') && has('es6-array-fill')) {
 	};
 }
 
-if (has('es7-array')) {
-	includes = wrapNative(global.Array.prototype.includes);
-} else {
-	/**
-	 * Ensures a non-negative, non-infinite, safe integer.
-	 *
-	 * @param length The number to validate
-	 * @return A proper length
-	 */
-	const toLength = function toLength(length: number): number {
-		length = Number(length);
-		if (isNaN(length)) {
-			return 0;
-		}
-		if (isFinite(length)) {
-			length = Math.floor(length);
-		}
-		// Ensure a non-negative, real, safe integer
-		return Math.min(Math.max(length, 0), MAX_SAFE_INTEGER);
-	};
+if (!has('es-array-fill')) {
+	Array.prototype.fill = function fill(value: any, start?: number, end?: number) {
+		const length = toLength(this.length);
+		let i = normalizeOffset(toInteger(start), length);
+		end = normalizeOffset(end === undefined ? length : toInteger(end), length);
 
-	includes = function includes<T>(target: ArrayLike<T>, searchElement: T, fromIndex: number = 0): boolean {
-		let len = toLength(target.length);
+		while (i < end) {
+			this[i++] = value;
+		}
+
+		return this;
+	};
+}
+
+if (!has('es7-array')) {
+	Array.prototype.includes = function includes(searchElement, fromIndex = 0) {
+		let len = toLength(this.length);
 
 		for (let i = fromIndex; i < len; ++i) {
-			const currentElement = target[i];
+			const currentElement = this[i];
 			if (
 				searchElement === currentElement ||
 				(searchElement !== searchElement && currentElement !== currentElement)
@@ -346,3 +313,13 @@ if (has('es7-array')) {
 		return false;
 	};
 }
+
+from = global.Array.from;
+of = global.Array.of;
+copyWithin = wrapNative(global.Array.prototype.copyWithin);
+fill = wrapNative(global.Array.prototype.fill);
+find = wrapNative(global.Array.prototype.find);
+findIndex = wrapNative(global.Array.prototype.findIndex);
+includes = wrapNative(global.Array.prototype.includes);
+
+export default Array;

--- a/src/shim/array.ts
+++ b/src/shim/array.ts
@@ -1,4 +1,3 @@
-import global from './global';
 import { isArrayLike, isIterable, Iterable } from './iterator';
 import { MAX_SAFE_INTEGER } from './number';
 import has from '../core/has';
@@ -113,8 +112,6 @@ export let findIndex: <T>(target: ArrayLike<T>, callback: FindCallback<T>, thisA
  * @return `true` if the array includes the element, otherwise `false`
  */
 export let includes: <T>(target: ArrayLike<T>, searchElement: T, fromIndex?: number) => boolean;
-
-const Array: ArrayConstructor = global.Array;
 
 // Util functions for filled implementations
 /**
@@ -314,12 +311,12 @@ if (!has('es7-array')) {
 	};
 }
 
-from = global.Array.from;
-of = global.Array.of;
-copyWithin = wrapNative(global.Array.prototype.copyWithin);
-fill = wrapNative(global.Array.prototype.fill);
-find = wrapNative(global.Array.prototype.find);
-findIndex = wrapNative(global.Array.prototype.findIndex);
-includes = wrapNative(global.Array.prototype.includes);
+from = Array.from;
+of = Array.of;
+copyWithin = wrapNative(Array.prototype.copyWithin);
+fill = wrapNative(Array.prototype.fill);
+find = wrapNative(Array.prototype.find);
+findIndex = wrapNative(Array.prototype.findIndex);
+includes = wrapNative(Array.prototype.includes);
 
 export default Array;

--- a/src/shim/math.ts
+++ b/src/shim/math.ts
@@ -4,6 +4,111 @@ export const FRACTION_UNITS = Math.pow(2, 23);
 export const MAX_FLOAT32 = 3.4028234663852886e38;
 export const MIN_FLOAT32 = 1.401298464324817e-45;
 
+if (!has('es6-math')) {
+	Math.acosh = function acosh(n: number): number {
+		return Math.log(n + Math.sqrt(n * n - 1));
+	};
+
+	Math.asinh = function asinh(n: number): number {
+		if (n === -Infinity) {
+			return n;
+		} else {
+			return Math.log(n + Math.sqrt(n * n + 1));
+		}
+	};
+
+	Math.atanh = function atanh(n: number): number {
+		return Math.log((1 + n) / (1 - n)) / 2;
+	};
+
+	Math.cbrt = function cbrt(n: number): number {
+		const y = Math.pow(Math.abs(n), 1 / 3);
+		return n < 0 ? -y : y;
+	};
+
+	Math.clz32 = function clz32(n: number): number {
+		n = Number(n) >>> 0;
+		return n ? 32 - n.toString(2).length : 32;
+	};
+
+	Math.cosh = function cosh(n: number): number {
+		const m = Math.exp(n);
+		return (m + 1 / m) / 2;
+	};
+
+	Math.expm1 = function expm1(n: number): number {
+		return Math.exp(n) - 1;
+	};
+
+	Math.fround = function(n: number): number {
+		return new Float32Array([n])[0];
+	};
+
+	Math.hypot = function hypot(...args: number[]): number {
+		// See: http://mzl.la/1HDi6xP
+		let n = 0;
+
+		for (let arg of args) {
+			if (arg === Infinity || arg === -Infinity) {
+				return Infinity;
+			}
+			n += arg * arg;
+		}
+		return Math.sqrt(n);
+	};
+
+	Math.log2 = function log2(n: number): number {
+		return Math.log(n) / Math.LN2;
+	};
+
+	Math.log10 = function log10(n: number): number {
+		return Math.log(n) / Math.LN10;
+	};
+
+	Math.log1p = function log1p(n: number): number {
+		return Math.log(1 + n);
+	};
+
+	Math.sign = function sign(n: number): number {
+		n = Number(n);
+		if (n === 0 || n !== n) {
+			return n;
+		}
+		return n > 0 ? 1 : -1;
+	};
+
+	Math.sinh = function sinh(n: number): number {
+		const m = Math.exp(n);
+		return (m - 1 / m) / 2;
+	};
+
+	Math.tanh = function tanh(n: number): number {
+		if (n === Infinity) {
+			return 1;
+		} else if (n === -Infinity) {
+			return -1;
+		} else {
+			const y = Math.exp(2 * n);
+			return (y - 1) / (y + 1);
+		}
+	};
+
+	Math.trunc = function trunc(n: number): number {
+		return n < 0 ? Math.ceil(n) : Math.floor(n);
+	};
+}
+
+if (!has('es6-math-imul')) {
+	Math.imul = function imul(n: number, m: number): number {
+		// See: http://mzl.la/1K279FK
+		const ah = (n >>> 16) & 0xffff;
+		const al = n & 0xffff;
+		const bh = (m >>> 16) & 0xffff;
+		const bl = m & 0xffff;
+		return (al * bl + (((ah * bl + al * bh) << 16) >>> 0)) | 0;
+	};
+}
+
 /**
  * Returns the hyperbolic arccosine of a number.
  *
@@ -141,107 +246,4 @@ export let tanh: (n: number) => number = (Math as any).tanh;
  */
 export let trunc: (n: number) => number = (Math as any).trunc;
 
-if (!has('es6-math')) {
-	acosh = function acosh(n: number): number {
-		return Math.log(n + Math.sqrt(n * n - 1));
-	};
-
-	asinh = function asinh(n: number): number {
-		if (n === -Infinity) {
-			return n;
-		} else {
-			return Math.log(n + Math.sqrt(n * n + 1));
-		}
-	};
-
-	atanh = function atanh(n: number): number {
-		return Math.log((1 + n) / (1 - n)) / 2;
-	};
-
-	cbrt = function cbrt(n: number): number {
-		const y = Math.pow(Math.abs(n), 1 / 3);
-		return n < 0 ? -y : y;
-	};
-
-	clz32 = function clz32(n: number): number {
-		n = Number(n) >>> 0;
-		return n ? 32 - n.toString(2).length : 32;
-	};
-
-	cosh = function cosh(n: number): number {
-		const m = Math.exp(n);
-		return (m + 1 / m) / 2;
-	};
-
-	expm1 = function expm1(n: number): number {
-		return Math.exp(n) - 1;
-	};
-
-	fround = function(n: number): number {
-		return new Float32Array([n])[0];
-	};
-
-	hypot = function hypot(...args: number[]): number {
-		// See: http://mzl.la/1HDi6xP
-		let n = 0;
-
-		for (let arg of args) {
-			if (arg === Infinity || arg === -Infinity) {
-				return Infinity;
-			}
-			n += arg * arg;
-		}
-		return Math.sqrt(n);
-	};
-
-	log2 = function log2(n: number): number {
-		return Math.log(n) / Math.LN2;
-	};
-
-	log10 = function log10(n: number): number {
-		return Math.log(n) / Math.LN10;
-	};
-
-	log1p = function log1p(n: number): number {
-		return Math.log(1 + n);
-	};
-
-	sign = function sign(n: number): number {
-		n = Number(n);
-		if (n === 0 || n !== n) {
-			return n;
-		}
-		return n > 0 ? 1 : -1;
-	};
-
-	sinh = function sinh(n: number): number {
-		const m = Math.exp(n);
-		return (m - 1 / m) / 2;
-	};
-
-	tanh = function tanh(n: number): number {
-		if (n === Infinity) {
-			return 1;
-		} else if (n === -Infinity) {
-			return -1;
-		} else {
-			const y = Math.exp(2 * n);
-			return (y - 1) / (y + 1);
-		}
-	};
-
-	trunc = function trunc(n: number): number {
-		return n < 0 ? Math.ceil(n) : Math.floor(n);
-	};
-}
-
-if (!has('es6-math-imul')) {
-	imul = function imul(n: number, m: number): number {
-		// See: http://mzl.la/1K279FK
-		const ah = (n >>> 16) & 0xffff;
-		const al = n & 0xffff;
-		const bh = (m >>> 16) & 0xffff;
-		const bl = m & 0xffff;
-		return (al * bl + (((ah * bl + al * bh) << 16) >>> 0)) | 0;
-	};
-}
+export default Math;

--- a/src/shim/object.ts
+++ b/src/shim/object.ts
@@ -146,7 +146,7 @@ if (!has('es6-object')) {
 	};
 
 	Object.getOwnPropertySymbols = function getOwnPropertySymbols(o: any): symbol[] {
-		return Object.getOwnPropertyNames(o)
+		return getOwnPropertyNames(o)
 			.filter((key) => Boolean(key.match(/^@@.+/)))
 			.map((key) => Symbol.for(key.substring(2)));
 	};

--- a/src/shim/object.ts
+++ b/src/shim/object.ts
@@ -1,4 +1,3 @@
-import global from './global';
 import has from '../core/has';
 import { isSymbol } from './Symbol';
 
@@ -117,20 +116,18 @@ export let entries: ObjectEnteries;
 
 export let values: ObjectValues;
 
-const ObjectShim: ObjectConstructor = global.Object;
-
 if (!has('es6-object')) {
-	ObjectShim.keys = function symbolAwareKeys(o: object): string[] {
-		return ObjectShim.keys(o).filter((key) => !Boolean(key.match(/^@@.+/)));
+	Object.keys = function symbolAwareKeys(o: object): string[] {
+		return Object.keys(o).filter((key) => !Boolean(key.match(/^@@.+/)));
 	};
 
-	ObjectShim.assign = function assign(target: any, ...sources: any[]) {
+	Object.assign = function assign(target: any, ...sources: any[]) {
 		if (target == null) {
 			// TypeError if undefined or null
 			throw new TypeError('Cannot convert undefined or null to object');
 		}
 
-		const to = ObjectShim(target);
+		const to = Object(target);
 		sources.forEach((nextSource) => {
 			if (nextSource) {
 				// Skip over if undefined or null
@@ -143,28 +140,25 @@ if (!has('es6-object')) {
 		return to;
 	};
 
-	ObjectShim.getOwnPropertyDescriptor = function<T, K extends keyof T>(
-		o: T,
-		prop: K
-	): PropertyDescriptor | undefined {
+	Object.getOwnPropertyDescriptor = function<T, K extends keyof T>(o: T, prop: K): PropertyDescriptor | undefined {
 		if (isSymbol(prop)) {
-			return ObjectShim.getOwnPropertyDescriptor(o, prop);
+			return Object.getOwnPropertyDescriptor(o, prop);
 		} else {
-			return ObjectShim.getOwnPropertyDescriptor(o, prop);
+			return Object.getOwnPropertyDescriptor(o, prop);
 		}
 	};
 
-	ObjectShim.getOwnPropertyNames = function getOwnPropertyNames(o: any): string[] {
-		return ObjectShim.getOwnPropertyNames(o).filter((key) => !Boolean(key.match(/^@@.+/)));
+	Object.getOwnPropertyNames = function getOwnPropertyNames(o: any): string[] {
+		return Object.getOwnPropertyNames(o).filter((key) => !Boolean(key.match(/^@@.+/)));
 	};
 
-	ObjectShim.getOwnPropertySymbols = function getOwnPropertySymbols(o: any): symbol[] {
-		return ObjectShim.getOwnPropertyNames(o)
+	Object.getOwnPropertySymbols = function getOwnPropertySymbols(o: any): symbol[] {
+		return Object.getOwnPropertyNames(o)
 			.filter((key) => Boolean(key.match(/^@@.+/)))
 			.map((key) => Symbol.for(key.substring(2)));
 	};
 
-	ObjectShim.is = function is(value1: any, value2: any): boolean {
+	Object.is = function is(value1: any, value2: any): boolean {
 		if (value1 === value2) {
 			return value1 !== 0 || 1 / value1 === 1 / value2; // -0
 		}
@@ -173,35 +167,35 @@ if (!has('es6-object')) {
 }
 
 if (!has('es2017-object')) {
-	ObjectShim.getOwnPropertyDescriptors = function getOwnPropertyDescriptors<T>(
+	Object.getOwnPropertyDescriptors = function getOwnPropertyDescriptors<T>(
 		o: T
 	): { [P in keyof T]: TypedPropertyDescriptor<T[P]> } & { [x: string]: PropertyDescriptor } {
-		return ObjectShim.getOwnPropertyNames(o).reduce(
+		return Object.getOwnPropertyNames(o).reduce(
 			(previous, key) => {
-				previous[key] = ObjectShim.getOwnPropertyDescriptor(o, key)!;
+				previous[key] = Object.getOwnPropertyDescriptor(o, key)!;
 				return previous;
 			},
 			{} as { [P in keyof T]: TypedPropertyDescriptor<T[P]> } & { [x: string]: PropertyDescriptor }
 		);
 	};
 
-	ObjectShim.entries = function entries(o: any): [string, any][] {
+	Object.entries = function entries(o: any): [string, any][] {
 		return keys(o).map((key) => [key, o[key]] as [string, any]);
 	};
 
-	ObjectShim.values = function values(o: any): any[] {
+	Object.values = function values(o: any): any[] {
 		return keys(o).map((key) => o[key]);
 	};
 }
 
-assign = ObjectShim.assign;
-getOwnPropertyDescriptor = ObjectShim.getOwnPropertyDescriptor;
-getOwnPropertyNames = ObjectShim.getOwnPropertyNames;
-getOwnPropertySymbols = ObjectShim.getOwnPropertySymbols;
-is = ObjectShim.is;
-keys = ObjectShim.keys;
-getOwnPropertyDescriptors = ObjectShim.getOwnPropertyDescriptors;
-entries = ObjectShim.entries;
-values = ObjectShim.values;
+assign = Object.assign;
+getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+getOwnPropertyNames = Object.getOwnPropertyNames;
+getOwnPropertySymbols = Object.getOwnPropertySymbols;
+is = Object.is;
+keys = Object.keys;
+getOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
+entries = Object.entries;
+values = Object.values;
 
-export default ObjectShim;
+export default Object;

--- a/src/shim/object.ts
+++ b/src/shim/object.ts
@@ -1,5 +1,4 @@
 import has from '../core/has';
-import { isSymbol } from './Symbol';
 
 export interface ObjectAssign {
 	/**
@@ -117,8 +116,9 @@ export let entries: ObjectEnteries;
 export let values: ObjectValues;
 
 if (!has('es6-object')) {
+	const keys = Object.keys.bind(Object);
 	Object.keys = function symbolAwareKeys(o: object): string[] {
-		return Object.keys(o).filter((key) => !Boolean(key.match(/^@@.+/)));
+		return keys(o).filter((key) => !Boolean(key.match(/^@@.+/)));
 	};
 
 	Object.assign = function assign(target: any, ...sources: any[]) {
@@ -140,16 +140,9 @@ if (!has('es6-object')) {
 		return to;
 	};
 
-	Object.getOwnPropertyDescriptor = function<T, K extends keyof T>(o: T, prop: K): PropertyDescriptor | undefined {
-		if (isSymbol(prop)) {
-			return Object.getOwnPropertyDescriptor(o, prop);
-		} else {
-			return Object.getOwnPropertyDescriptor(o, prop);
-		}
-	};
-
-	Object.getOwnPropertyNames = function getOwnPropertyNames(o: any): string[] {
-		return Object.getOwnPropertyNames(o).filter((key) => !Boolean(key.match(/^@@.+/)));
+	const getOwnPropertyNames = Object.getOwnPropertyNames.bind(Object);
+	Object.getOwnPropertyNames = function symbolAwareGetOwnPropertyNames(o: any): string[] {
+		return getOwnPropertyNames(o).filter((key) => !Boolean(key.match(/^@@.+/)));
 	};
 
 	Object.getOwnPropertySymbols = function getOwnPropertySymbols(o: any): symbol[] {

--- a/src/shim/string.ts
+++ b/src/shim/string.ts
@@ -1,4 +1,3 @@
-import global from './global';
 import has from '../core/has';
 import { wrapNative } from './support/util';
 
@@ -140,8 +139,6 @@ export let padEnd: (target: string, maxLength: number, fillString?: string) => s
  *        The default value for this parameter is " " (U+0020).
  */
 export let padStart: (target: string, maxLength: number, fillString?: string) => string;
-
-const String: StringConstructor = global.String;
 
 if (!has('es6-string')) {
 	/**
@@ -375,8 +372,8 @@ if (!has('es2017-string')) {
 	};
 }
 
-fromCodePoint = global.String.fromCodePoint;
-raw = global.String.raw;
+fromCodePoint = String.fromCodePoint;
+raw = String.raw;
 
 codePointAt = wrapNative(String.prototype.codePointAt);
 endsWith = wrapNative(String.prototype.endsWith);

--- a/src/shim/string.ts
+++ b/src/shim/string.ts
@@ -69,7 +69,7 @@ export let raw: (template: TemplateStringsArray, ...substitutions: any[]) => str
  * If there is no element at that position, the result is undefined.
  * If a valid UTF-16 surrogate pair does not begin at pos, the result is the code unit at pos.
  */
-export let codePointAt: (target: string, pos?: number) => number | undefined;
+export let codePointAt: (target: string, pos: number) => number | undefined;
 
 /**
  * Returns true if the sequence of elements of searchString converted to a String is the
@@ -102,7 +102,7 @@ export let normalize: StringNormalize;
  * T is the empty String is returned.
  * @param count number of copies to append
  */
-export let repeat: (target: string, count?: number) => string;
+export let repeat: (target: string, count: number) => string;
 
 /**
  * Returns true if the sequence of elements of searchString converted to a String is the
@@ -378,13 +378,13 @@ if (!has('es2017-string')) {
 fromCodePoint = global.String.fromCodePoint;
 raw = global.String.raw;
 
-codePointAt = wrapNative(global.String.prototype.codePointAt);
-endsWith = wrapNative(global.String.prototype.endsWith);
-includes = wrapNative(global.String.prototype.includes);
-normalize = wrapNative(global.String.prototype.normalize);
-repeat = wrapNative(global.String.prototype.repeat);
-startsWith = wrapNative(global.String.prototype.startsWith);
-padEnd = wrapNative(global.String.prototype.padEnd);
-padStart = wrapNative(global.String.prototype.padStart);
+codePointAt = wrapNative(String.prototype.codePointAt);
+endsWith = wrapNative(String.prototype.endsWith);
+includes = wrapNative(String.prototype.includes);
+normalize = wrapNative(String.prototype.normalize);
+repeat = wrapNative(String.prototype.repeat);
+startsWith = wrapNative(String.prototype.startsWith);
+padEnd = wrapNative(String.prototype.padEnd);
+padStart = wrapNative(String.prototype.padStart);
 
 export default String;

--- a/tests/shim/unit/array.ts
+++ b/tests/shim/unit/array.ts
@@ -1,6 +1,6 @@
 import Array, * as array from '../../../src/shim/array';
 import global from '../../../src/shim/global';
-import has, { add as hasAdd } from '../../../src/has/has';
+import has, { add as hasAdd } from '../../../src/core/has';
 import { Iterable, ShimIterator } from '../../../src/shim/iterator';
 import '../../../src/shim/Symbol';
 

--- a/tests/shim/unit/math.ts
+++ b/tests/shim/unit/math.ts
@@ -1,4 +1,5 @@
-import * as math from '../../../src/shim/math';
+import Math, * as math from '../../../src/shim/math';
+import global from '../../../src/shim/global';
 
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
@@ -10,174 +11,204 @@ function assertIsNaN(...results: number[]) {
 }
 
 registerSuite('math', {
+	polyfill() {
+		assert.equal(Math, global.Math);
+	},
 	'.acosh()'() {
-		assertIsNaN(math.acosh(NaN), math.acosh(0), math.acosh(0.9999999), math.acosh(-0.001));
-		assert.strictEqual(math.acosh(Infinity), Infinity);
-		assert.strictEqual(math.acosh(1), 0);
-		assert.closeTo(math.acosh(2), 1.3169578969248166, 1e-13);
-		assert.closeTo(math.acosh(3), 1.762747174039086, 1e-13);
+		for (let acosh of [Math.acosh, math.acosh]) {
+			assertIsNaN(acosh(NaN), acosh(0), acosh(0.9999999), acosh(-0.001));
+			assert.strictEqual(acosh(Infinity), Infinity);
+			assert.strictEqual(acosh(1), 0);
+			assert.closeTo(acosh(2), 1.3169578969248166, 1e-13);
+			assert.closeTo(acosh(3), 1.762747174039086, 1e-13);
+		}
 	},
 
 	'.asinh()'() {
-		assertIsNaN(math.asinh(NaN));
-		assert.strictEqual(math.asinh(Infinity), Infinity);
-		assert.strictEqual(math.asinh(-Infinity), -Infinity);
-		assert.strictEqual(math.asinh(0), 0);
-		assert.closeTo(math.asinh(1), 0.8813735870195429, 1e-13);
-		assert.closeTo(math.acosh(2), 1.3169578969248166, 1e-13);
+		for (let asinh of [Math.asinh, math.asinh]) {
+			assertIsNaN(asinh(NaN));
+			assert.strictEqual(asinh(Infinity), Infinity);
+			assert.strictEqual(asinh(-Infinity), -Infinity);
+			assert.strictEqual(asinh(0), 0);
+			assert.closeTo(asinh(1), 0.8813735870195429, 1e-13);
+		}
 	},
 
 	'.atanh()'() {
-		assertIsNaN(
-			math.atanh(NaN),
-			math.atanh(-1.00000001),
-			math.atanh(1.00000001),
-			math.atanh(-1e300),
-			math.atanh(1e300)
-		);
-		assert.strictEqual(math.atanh(0), 0);
-		assert.strictEqual(math.atanh(1), Infinity);
-		assert.strictEqual(math.atanh(-1), -Infinity);
-		assert.closeTo(math.atanh(0.5), 0.5493061443340549, 1e-13);
+		for (let atanh of [Math.atanh, math.atanh]) {
+			assertIsNaN(atanh(NaN), atanh(-1.00000001), atanh(1.00000001), atanh(-1e300), atanh(1e300));
+			assert.strictEqual(atanh(0), 0);
+			assert.strictEqual(atanh(1), Infinity);
+			assert.strictEqual(atanh(-1), -Infinity);
+			assert.closeTo(atanh(0.5), 0.5493061443340549, 1e-13);
+		}
 	},
 
 	'.cbrt()'() {
-		assert.strictEqual(math.cbrt(0), 0);
-		assert.strictEqual(math.cbrt(1), 1);
-		assert.strictEqual(math.cbrt(8), 2);
-		assert.strictEqual(math.cbrt(-1), -1);
-		assert.strictEqual(math.cbrt(-8), -2);
-		assert.strictEqual(math.cbrt(Infinity), Infinity);
-		assert.strictEqual(math.cbrt(-Infinity), -Infinity);
+		for (let cbrt of [Math.cbrt, math.cbrt]) {
+			assert.strictEqual(cbrt(0), 0);
+			assert.strictEqual(cbrt(1), 1);
+			assert.strictEqual(cbrt(8), 2);
+			assert.strictEqual(cbrt(-1), -1);
+			assert.strictEqual(cbrt(-8), -2);
+			assert.strictEqual(cbrt(Infinity), Infinity);
+			assert.strictEqual(cbrt(-Infinity), -Infinity);
+		}
 	},
 
 	'.clz32()'() {
-		assert.strictEqual(math.clz32(1), 31);
-		assert.strictEqual(math.clz32(0.1), 32);
-		assert.strictEqual(math.clz32(-1), 0);
-		assert.strictEqual(math.clz32(1000), 22);
-		assert.strictEqual(math.clz32(2), 30);
+		for (let clz32 of [Math.clz32, math.clz32]) {
+			assert.strictEqual(clz32(1), 31);
+			assert.strictEqual(clz32(0.1), 32);
+			assert.strictEqual(clz32(-1), 0);
+			assert.strictEqual(clz32(1000), 22);
+			assert.strictEqual(clz32(2), 30);
+		}
 	},
 
 	'.cosh()'() {
-		assertIsNaN(math.cosh(NaN));
-		assert.strictEqual(math.cosh(0), 1);
-		assert.strictEqual(math.cosh(-Infinity), Infinity);
-		assert.strictEqual(math.cosh(Infinity), Infinity);
-		assert.closeTo(math.cosh(-1), 1.5430806348152435, 1e-13);
-		assert.closeTo(math.cosh(1), 1.5430806348152437, 1e-13);
+		for (let cosh of [Math.cosh, math.cosh]) {
+			assertIsNaN(cosh(NaN));
+			assert.strictEqual(cosh(0), 1);
+			assert.strictEqual(cosh(-Infinity), Infinity);
+			assert.strictEqual(cosh(Infinity), Infinity);
+			assert.closeTo(cosh(-1), 1.5430806348152435, 1e-13);
+			assert.closeTo(cosh(1), 1.5430806348152437, 1e-13);
+		}
 	},
 
 	'.expm1()'() {
-		assertIsNaN(math.expm1(NaN));
-		assert.strictEqual(math.expm1(0), 0);
-		assert.strictEqual(math.expm1(Infinity), Infinity);
-		assert.strictEqual(math.expm1(-Infinity), -1);
-		assert.closeTo(math.expm1(-1), -0.6321205588285577, 1e-13);
-		assert.closeTo(math.expm1(1), 1.718281828459045, 1e-13);
+		for (let expm1 of [Math.expm1, math.expm1]) {
+			assertIsNaN(expm1(NaN));
+			assert.strictEqual(expm1(0), 0);
+			assert.strictEqual(expm1(Infinity), Infinity);
+			assert.strictEqual(expm1(-Infinity), -1);
+			assert.closeTo(expm1(-1), -0.6321205588285577, 1e-13);
+			assert.closeTo(expm1(1), 1.718281828459045, 1e-13);
+		}
 	},
 
 	'.fround()'() {
-		assert.strictEqual(math.fround(0), 0);
-		assert.strictEqual(math.fround(Infinity), Infinity);
-		assert.strictEqual(math.fround(-Infinity), -Infinity);
-		assert.strictEqual(math.fround(1), 1);
-		assert.strictEqual(math.fround(-1), -1);
-		assert.closeTo(math.fround(1.337), 1.3370000123977661, 1e-13);
-		assert.closeTo(math.fround(-1.337), -1.3370000123977661, 1e-13);
+		for (let fround of [Math.fround, math.fround]) {
+			assert.strictEqual(fround(0), 0);
+			assert.strictEqual(fround(Infinity), Infinity);
+			assert.strictEqual(fround(-Infinity), -Infinity);
+			assert.strictEqual(fround(1), 1);
+			assert.strictEqual(fround(-1), -1);
+			assert.closeTo(fround(1.337), 1.3370000123977661, 1e-13);
+			assert.closeTo(fround(-1.337), -1.3370000123977661, 1e-13);
 
-		assert.strictEqual(math.fround(Number.MAX_VALUE), Infinity);
-		assert.strictEqual(math.fround(-Number.MAX_VALUE), -Infinity);
-		assert.strictEqual(math.fround(Number.MIN_VALUE), 0);
-		assert.strictEqual(math.fround(-Number.MIN_VALUE), 0);
+			assert.strictEqual(fround(Number.MAX_VALUE), Infinity);
+			assert.strictEqual(fround(-Number.MAX_VALUE), -Infinity);
+			assert.strictEqual(fround(Number.MIN_VALUE), 0);
+			assert.strictEqual(fround(-Number.MIN_VALUE), 0);
 
-		const MAX_FLOAT32 = 3.4028234663852886e38;
-		const MIN_FLOAT32 = 1.401298464324817e-45;
-		assert.strictEqual(math.fround(MAX_FLOAT32), MAX_FLOAT32);
-		assert.strictEqual(math.fround(-MAX_FLOAT32), -MAX_FLOAT32);
-		assert.strictEqual(math.fround(MIN_FLOAT32), MIN_FLOAT32);
-		assert.strictEqual(math.fround(-MIN_FLOAT32), -MIN_FLOAT32);
+			const MAX_FLOAT32 = 3.4028234663852886e38;
+			const MIN_FLOAT32 = 1.401298464324817e-45;
+			assert.strictEqual(fround(MAX_FLOAT32), MAX_FLOAT32);
+			assert.strictEqual(fround(-MAX_FLOAT32), -MAX_FLOAT32);
+			assert.strictEqual(fround(MIN_FLOAT32), MIN_FLOAT32);
+			assert.strictEqual(fround(-MIN_FLOAT32), -MIN_FLOAT32);
+		}
 	},
 
 	'.hypot()'() {
-		assertIsNaN(math.hypot(NaN), math.hypot(1, NaN));
-		assert.strictEqual(math.hypot(), 0);
-		assert.strictEqual(math.hypot(0), 0);
-		assert.strictEqual(math.hypot(0, 0), 0);
-		assert.strictEqual(math.hypot(Infinity), Infinity);
-		assert.strictEqual(math.hypot(Infinity, NaN), Infinity);
-		assert.strictEqual(math.hypot(1, 2, 2), 3);
-		assert.closeTo(math.hypot(2, 4), 4.47213595499958, 1e-13);
-		assert.closeTo(math.hypot(2, 4, 6), 7.483314773547883, 1e-13);
+		for (let hypot of [Math.hypot, math.hypot]) {
+			assertIsNaN(hypot(NaN), hypot(1, NaN));
+			assert.strictEqual(hypot(), 0);
+			assert.strictEqual(hypot(0), 0);
+			assert.strictEqual(hypot(0, 0), 0);
+			assert.strictEqual(hypot(Infinity), Infinity);
+			assert.strictEqual(hypot(Infinity, NaN), Infinity);
+			assert.strictEqual(hypot(1, 2, 2), 3);
+			assert.closeTo(hypot(2, 4), 4.47213595499958, 1e-13);
+			assert.closeTo(hypot(2, 4, 6), 7.483314773547883, 1e-13);
+		}
 	},
 
 	'.imul()'() {
-		assert.strictEqual(math.imul(2, 4), 8);
-		assert.strictEqual(math.imul(-1, 8), -8);
-		assert.strictEqual(math.imul(-2, -2), 4);
-		assert.strictEqual(math.imul(0xffffffff, 5), -5);
-		assert.strictEqual(math.imul(0xfffffffe, 5), -10);
+		for (let imul of [Math.imul, math.imul]) {
+			assert.strictEqual(imul(2, 4), 8);
+			assert.strictEqual(imul(-1, 8), -8);
+			assert.strictEqual(imul(-2, -2), 4);
+			assert.strictEqual(imul(0xffffffff, 5), -5);
+			assert.strictEqual(imul(0xfffffffe, 5), -10);
+		}
 	},
 
 	'.log2()'() {
-		assertIsNaN(math.log2(NaN));
-		assert.strictEqual(math.log2(0), -Infinity);
-		assert.strictEqual(math.log2(Infinity), Infinity);
-		assert.strictEqual(math.log2(1), 0);
-		assert.strictEqual(math.log2(2), 1);
-		assert.closeTo(math.log2(3), 1.584962500721156, 1e-13);
+		for (let log2 of [Math.log2, math.log2]) {
+			assertIsNaN(log2(NaN));
+			assert.strictEqual(log2(0), -Infinity);
+			assert.strictEqual(log2(Infinity), Infinity);
+			assert.strictEqual(log2(1), 0);
+			assert.strictEqual(log2(2), 1);
+			assert.closeTo(log2(3), 1.584962500721156, 1e-13);
+		}
 	},
 
 	'.log10()'() {
-		assertIsNaN(math.log10(NaN));
-		assert.strictEqual(math.log10(0), -Infinity);
-		assert.strictEqual(math.log10(Infinity), Infinity);
-		assert.strictEqual(math.log10(1), 0);
-		assert.closeTo(math.log10(2), 0.3010299956639812, 1e-13);
+		for (let log10 of [Math.log10, math.log10]) {
+			assertIsNaN(log10(NaN));
+			assert.strictEqual(log10(0), -Infinity);
+			assert.strictEqual(log10(Infinity), Infinity);
+			assert.strictEqual(log10(1), 0);
+			assert.closeTo(log10(2), 0.3010299956639812, 1e-13);
+		}
 	},
 
 	'.log1p()'() {
-		assertIsNaN(math.log1p(NaN));
-		assert.strictEqual(math.log1p(Infinity), Infinity);
-		assert.strictEqual(math.log1p(-1), -Infinity);
-		assert.strictEqual(math.log1p(0), 0);
-		assert.closeTo(math.log1p(1), 0.6931471805599453, 1e-13);
+		for (let log1p of [Math.log1p, math.log1p]) {
+			assertIsNaN(log1p(NaN));
+			assert.strictEqual(log1p(Infinity), Infinity);
+			assert.strictEqual(log1p(-1), -Infinity);
+			assert.strictEqual(log1p(0), 0);
+			assert.closeTo(log1p(1), 0.6931471805599453, 1e-13);
+		}
 	},
 
 	'.sign()'() {
-		assertIsNaN(math.sign(NaN));
-		assert.strictEqual(math.sign(0), 0);
-		assert.strictEqual(math.sign(1), 1);
-		assert.strictEqual(math.sign(Infinity), 1);
-		assert.strictEqual(math.sign(-1), -1);
-		assert.strictEqual(math.sign(-Infinity), -1);
+		for (let sign of [Math.sign, math.sign]) {
+			assertIsNaN(sign(NaN));
+			assert.strictEqual(sign(0), 0);
+			assert.strictEqual(sign(1), 1);
+			assert.strictEqual(sign(Infinity), 1);
+			assert.strictEqual(sign(-1), -1);
+			assert.strictEqual(sign(-Infinity), -1);
+		}
 	},
 
 	'.sinh()'() {
-		assertIsNaN(math.sinh(NaN));
-		assert.strictEqual(math.sinh(0), 0);
-		assert.strictEqual(math.sinh(Infinity), Infinity);
-		assert.strictEqual(math.sinh(-Infinity), -Infinity);
-		assert.closeTo(math.sinh(1), 1.1752011936438014, 1e-13);
-		assert.closeTo(math.sinh(2), 3.6268604078470186, 1e-13);
+		for (let sinh of [Math.sinh, math.sinh]) {
+			assertIsNaN(sinh(NaN));
+			assert.strictEqual(sinh(0), 0);
+			assert.strictEqual(sinh(Infinity), Infinity);
+			assert.strictEqual(sinh(-Infinity), -Infinity);
+			assert.closeTo(sinh(1), 1.1752011936438014, 1e-13);
+			assert.closeTo(sinh(2), 3.6268604078470186, 1e-13);
+		}
 	},
 
 	'.tanh()'() {
-		assertIsNaN(math.tanh(NaN));
-		assert.strictEqual(math.tanh(0), 0);
-		assert.strictEqual(math.tanh(Infinity), 1);
-		assert.strictEqual(math.tanh(-Infinity), -1);
-		assert.strictEqual(math.tanh(90), 1);
-		assert.closeTo(math.tanh(1), 0.761594155955765, 1e-13);
+		for (let tanh of [Math.tanh, math.tanh]) {
+			assertIsNaN(tanh(NaN));
+			assert.strictEqual(tanh(0), 0);
+			assert.strictEqual(tanh(Infinity), 1);
+			assert.strictEqual(tanh(-Infinity), -1);
+			assert.strictEqual(tanh(90), 1);
+			assert.closeTo(tanh(1), 0.761594155955765, 1e-13);
+		}
 	},
 
 	'.trunc()'() {
-		assert.strictEqual(math.trunc(Infinity), Infinity);
-		assert.strictEqual(math.trunc(-Infinity), -Infinity);
-		assert.strictEqual(math.trunc(1.1), 1);
-		assert.strictEqual(math.trunc(1.9), 1);
-		assert.strictEqual(math.trunc(-1.1), -1);
-		assert.strictEqual(math.trunc(-1.9), -1);
-		assert.strictEqual(math.trunc(1), 1);
+		for (let trunc of [Math.trunc, math.trunc]) {
+			assert.strictEqual(trunc(Infinity), Infinity);
+			assert.strictEqual(trunc(-Infinity), -Infinity);
+			assert.strictEqual(trunc(1.1), 1);
+			assert.strictEqual(trunc(1.9), 1);
+			assert.strictEqual(trunc(-1.1), -1);
+			assert.strictEqual(trunc(-1.9), -1);
+			assert.strictEqual(trunc(1), 1);
+		}
 	}
 });

--- a/tests/shim/unit/object.ts
+++ b/tests/shim/unit/object.ts
@@ -1,304 +1,368 @@
-import * as object from '../../../src/shim/object';
-import { assign } from '../../../src/shim/object';
+import Object, * as object from '../../../src/shim/object';
+import global from '../../../src/shim/global';
 import '../../../src/shim/Symbol';
 
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 registerSuite('object', {
+	polyfill() {
+		assert.equal(Object, global.Object);
+	},
 	'.assign()': {
 		'.assign()'() {
-			const source: {
-				a: number;
-				b: {
-					enumerable: boolean;
-					configurable: boolean;
-					writable: boolean;
-					value: number;
-				};
-			} = Object.create(
-				{ a: 1 },
-				{
-					b: {
-						enumerable: false,
-						configurable: true,
-						writable: true,
-						value: 2
-					}
-				}
-			);
-			(<any>source).c = 3;
-			(<any>source).nested = { a: 5 };
-
-			const object: {
-				c: number;
-				nested: {
+			for (let assign of [Object.assign, object.assign]) {
+				const source: {
 					a: number;
-				};
-			} = Object.create(null);
-			const assignedObject = assign(object, source);
+					b: {
+						enumerable: boolean;
+						configurable: boolean;
+						writable: boolean;
+						value: number;
+					};
+				} = Object.create(
+					{ a: 1 },
+					{
+						b: {
+							enumerable: false,
+							configurable: true,
+							writable: true,
+							value: 2
+						}
+					}
+				);
+				(<any>source).c = 3;
+				(<any>source).nested = { a: 5 };
 
-			assert.strictEqual(object, assignedObject, 'assign should return the modified target object');
-			assert.isUndefined(assignedObject.a, 'assign should not copy inherited properties');
-			assert.isUndefined(assignedObject.b, 'assign should not copy non-enumerable properties');
-			assert.strictEqual(assignedObject.c, 3);
-			assert.strictEqual(assignedObject.nested, (<any>source).nested, 'assign should perform a shallow copy');
-			assert.strictEqual(assignedObject.nested.a, 5);
+				const object: {
+					c: number;
+					nested: {
+						a: number;
+					};
+				} = Object.create(null);
+				const assignedObject = assign(object, source);
+
+				assert.strictEqual(object, assignedObject, 'assign should return the modified target object');
+				assert.isUndefined(assignedObject.a, 'assign should not copy inherited properties');
+				assert.isUndefined(assignedObject.b, 'assign should not copy non-enumerable properties');
+				assert.strictEqual(assignedObject.c, 3);
+				assert.strictEqual(assignedObject.nested, (<any>source).nested, 'assign should perform a shallow copy');
+				assert.strictEqual(assignedObject.nested.a, 5);
+			}
 		},
 
 		'.assign() with multiple sources'() {
-			let source1 = {
-				property3: 'value3',
-				property4: 'value4'
-			};
+			for (let assign of [Object.assign, object.assign]) {
+				let source1 = {
+					property3: 'value3',
+					property4: 'value4'
+				};
 
-			let source3 = {
-				property7: 'value7',
-				property8: 'value8'
-			};
+				let source3 = {
+					property7: 'value7',
+					property8: 'value8'
+				};
 
-			const object = {
-				property1: 'value1',
-				property2: 'value2'
-			};
+				const object = {
+					property1: 'value1',
+					property2: 'value2'
+				};
 
-			assign(object, source1, null, source3);
+				assign(object, source1, null, source3);
 
-			assert.deepEqual(object, {
-				property1: 'value1',
-				property2: 'value2',
-				property3: 'value3',
-				property4: 'value4',
-				property7: 'value7',
-				property8: 'value8'
-			} as any);
+				assert.deepEqual(object, {
+					property1: 'value1',
+					property2: 'value2',
+					property3: 'value3',
+					property4: 'value4',
+					property7: 'value7',
+					property8: 'value8'
+				} as any);
+			}
 		},
 
 		'.assign() with inferred type from multiple sources'() {
-			let source1: { a: number; b: number } | { c: number; d: number } = {
-				a: 1,
-				b: 2,
-				c: 3,
-				d: 4
-			};
+			for (let assign of [Object.assign, object.assign]) {
+				let source1: { a: number; b: number } | { c: number; d: number } = {
+					a: 1,
+					b: 2,
+					c: 3,
+					d: 4
+				};
 
-			let source2 = {
-				a: 3,
-				b: 2
-			};
+				let source2 = {
+					a: 3,
+					b: 2
+				};
 
-			let source3 = {
-				c: 3,
-				d: 4
-			};
+				let source3 = {
+					c: 3,
+					d: 4
+				};
 
-			const object = {};
+				const object = {};
 
-			const assignedObject = assign(object, source1, source2, source3);
+				const assignedObject = assign(object, source1, source2, source3);
 
-			assert(assignedObject);
+				assert(assignedObject);
 
-			// Verify that the inferred type is what we expect
-			const alsoAssigned: {} & ({ a: number; b: number } | { c: number; d: number }) = assign(
-				object,
-				source1,
-				source2,
-				source3
-			);
+				// Verify that the inferred type is what we expect
+				const alsoAssigned: {} & ({ a: number; b: number } | { c: number; d: number }) = assign(
+					object,
+					source1,
+					source2,
+					source3
+				);
 
-			assert(alsoAssigned);
+				assert(alsoAssigned);
+			}
 		},
 
 		'.assign() with different types of sources'() {
-			const baseObject = {
-				foo: 'foo'
-			};
+			for (let assign of [Object.assign, object.assign]) {
+				const baseObject = {
+					foo: 'foo'
+				};
 
-			const assignedObject = assign({}, baseObject, { bar: 'bar' });
-			assert.strictEqual(assignedObject.bar, 'bar');
-			assert.strictEqual(assignedObject.foo, 'foo');
+				const assignedObject = assign({}, baseObject, { bar: 'bar' });
+				assert.strictEqual(assignedObject.bar, 'bar');
+				assert.strictEqual(assignedObject.foo, 'foo');
+			}
 		},
 		'.assign() with a source whose type is a subset of another'() {
-			const foobar = {
-				foo: 'foo',
-				bar: 'bar'
-			};
-			const bar = {
-				bar: 'baz'
-			};
-			const assignedObject = assign({}, foobar, bar);
-			assert.strictEqual(assignedObject.foo, 'foo');
-			assert.strictEqual(assignedObject.bar, 'baz');
+			for (let assign of [Object.assign, object.assign]) {
+				const foobar = {
+					foo: 'foo',
+					bar: 'bar'
+				};
+				const bar = {
+					bar: 'baz'
+				};
+				const assignedObject = assign({}, foobar, bar);
+				assert.strictEqual(assignedObject.foo, 'foo');
+				assert.strictEqual(assignedObject.bar, 'baz');
+			}
 		}
 	},
 
 	'.is()': {
 		'two identical strings'() {
-			assert.isTrue(object.is('foo', 'foo'));
+			for (let is of [Object.is, object.is]) {
+				assert.isTrue(is('foo', 'foo'));
+			}
 		},
 
 		'two different strings'() {
-			assert.isFalse(object.is('foo', 'bar'));
+			for (let is of [Object.is, object.is]) {
+				assert.isFalse(is('foo', 'bar'));
+			}
 		},
 
 		'two NaNs'() {
-			assert.isTrue(object.is(NaN, NaN));
+			for (let is of [Object.is, object.is]) {
+				assert.isTrue(is(NaN, NaN));
+			}
 		},
 
 		'the same object'() {
-			let obj = {};
-			assert.isTrue(object.is(obj, obj));
+			for (let is of [Object.is, object.is]) {
+				let obj = {};
+				assert.isTrue(is(obj, obj));
+			}
 		},
 
 		'two nulls'() {
-			assert.isTrue(object.is(null, null));
+			for (let is of [Object.is, object.is]) {
+				assert.isTrue(is(null, null));
+			}
 		},
 
 		'two undefineds'() {
-			assert.isTrue(object.is(undefined, undefined));
+			for (let is of [Object.is, object.is]) {
+				assert.isTrue(is(undefined, undefined));
+			}
 		},
 
 		'null and undefined'() {
-			assert.isFalse(object.is(null, undefined));
+			for (let is of [Object.is, object.is]) {
+				assert.isFalse(is(null, undefined));
+			}
 		},
 
 		'two arrays'() {
-			assert.isFalse(object.is([], []));
+			for (let is of [Object.is, object.is]) {
+				assert.isFalse(is([], []));
+			}
 		},
 
 		'zero and negative zero'() {
-			assert.isFalse(object.is(0, -0));
+			for (let is of [Object.is, object.is]) {
+				assert.isFalse(is(0, -0));
+			}
 		},
 
 		'two positive zeros'() {
-			assert.isTrue(object.is(0, 0));
+			for (let is of [Object.is, object.is]) {
+				assert.isTrue(is(0, 0));
+			}
 		},
 
 		'two negative zeros'() {
-			assert.isTrue(object.is(-0, -0));
+			for (let is of [Object.is, object.is]) {
+				assert.isTrue(is(-0, -0));
+			}
 		},
 
 		'two of the same boolean'() {
-			assert.isTrue(object.is(true, true));
+			for (let is of [Object.is, object.is]) {
+				assert.isTrue(is(true, true));
+			}
 		},
 
 		'two different booleans'() {
-			assert.isFalse(object.is(true, false));
+			for (let is of [Object.is, object.is]) {
+				assert.isFalse(is(true, false));
+			}
 		},
 
 		'two different Date objects with the same value'() {
-			let date = new Date();
-			assert.isFalse(object.is(date, new Date(Number(date))));
+			for (let is of [Object.is, object.is]) {
+				let date = new Date();
+				assert.isFalse(is(date, new Date(Number(date))));
+			}
 		}
 	},
 
 	'.getOwnPropertySymbols()': {
 		'well-known'() {
-			const o = {
-				[Symbol.iterator]() {
-					return 'foo';
-				},
-				bar() {
-					return 'foo';
-				}
-			};
-			const [sym, ...other] = object.getOwnPropertySymbols(o);
-			assert.strictEqual(sym, Symbol.iterator);
-			assert.strictEqual(other.length, 0);
+			for (let getOwnPropertySymbols of [Object.getOwnPropertySymbols, object.getOwnPropertySymbols]) {
+				const o = {
+					[Symbol.iterator]() {
+						return 'foo';
+					},
+					bar() {
+						return 'foo';
+					}
+				};
+				const [sym, ...other] = getOwnPropertySymbols(o);
+				assert.strictEqual(sym, Symbol.iterator);
+				assert.strictEqual(other.length, 0);
+			}
 		},
 		'Symbol.for'() {
-			const foo = Symbol.for('foo');
-			const o = {
-				[foo]: 'bar',
-				bar: 1
-			};
-			const [sym, ...other] = object.getOwnPropertySymbols(o);
-			assert.strictEqual(sym, foo);
-			assert.strictEqual(other.length, 0);
+			for (let getOwnPropertySymbols of [Object.getOwnPropertySymbols, object.getOwnPropertySymbols]) {
+				const foo = Symbol.for('foo');
+				const o = {
+					[foo]: 'bar',
+					bar: 1
+				};
+				const [sym, ...other] = getOwnPropertySymbols(o);
+				assert.strictEqual(sym, foo);
+				assert.strictEqual(other.length, 0);
+			}
 		}
 	},
 
 	'.getOwnPropertyNames()'() {
-		const sym = Symbol('foo');
-		const o = {
-			[Symbol.iterator]() {
-				return 'foo';
-			},
-			[sym]: 'bar',
-			bar: 1
-		};
-		assert.deepEqual(object.getOwnPropertyNames(o), ['bar']);
+		for (let getOwnPropertyNames of [Object.getOwnPropertyNames, object.getOwnPropertyNames]) {
+			const sym = Symbol('foo');
+			const o = {
+				[Symbol.iterator]() {
+					return 'foo';
+				},
+				[sym]: 'bar',
+				bar: 1
+			};
+			assert.deepEqual(getOwnPropertyNames(o), ['bar']);
+		}
 	},
 
 	'.getOwnPropertyDescriptors()'() {
-		const visibleSymbol = Symbol.for('foo');
-		const hiddenSymbol = Symbol.for('hidden');
-
-		const obj = {
-			prop1: 'value1',
-			get prop2() {
-				return 'value2';
+		for (let { getOwnPropertyDescriptors, getOwnPropertySymbols } of [
+			{
+				getOwnPropertyDescriptors: Object.getOwnPropertyDescriptors,
+				getOwnPropertySymbols: Object.getOwnPropertySymbols
 			},
-			set prop3(_: string) {},
-			[visibleSymbol]: 'foo'
-		};
+			{
+				getOwnPropertyDescriptors: object.getOwnPropertyDescriptors,
+				getOwnPropertySymbols: object.getOwnPropertySymbols
+			}
+		]) {
+			const visibleSymbol = Symbol.for('foo');
+			const hiddenSymbol = Symbol.for('hidden');
 
-		Object.defineProperty(obj, 'hidden', {
-			value: 'hidden',
-			enumerable: false
-		});
+			const obj = {
+				prop1: 'value1',
+				get prop2() {
+					return 'value2';
+				},
+				set prop3(_: string) {},
+				[visibleSymbol]: 'foo'
+			};
 
-		(<any>Object).defineProperty(obj, hiddenSymbol, {
-			value: 'test',
-			enumerable: false
-		});
+			Object.defineProperty(obj, 'hidden', {
+				value: 'hidden',
+				enumerable: false
+			});
 
-		let keys = object.getOwnPropertyDescriptors(obj);
+			(<any>Object).defineProperty(obj, hiddenSymbol, {
+				value: 'test',
+				enumerable: false
+			});
 
-		assert.sameMembers(Object.keys(keys), ['prop1', 'prop2', 'prop3', 'hidden']);
+			let keys = getOwnPropertyDescriptors(obj);
 
-		assert.sameMembers(object.getOwnPropertySymbols(obj), [visibleSymbol, hiddenSymbol]);
+			assert.sameMembers(Object.keys(keys), ['prop1', 'prop2', 'prop3', 'hidden']);
+
+			assert.sameMembers(getOwnPropertySymbols(obj), [visibleSymbol, hiddenSymbol]);
+		}
 	},
 
 	'.keys()'() {
-		const sym = Symbol('foo');
-		const o = {
-			[Symbol.iterator]() {
-				return 'foo';
-			},
-			[sym]: 'bar',
-			bar: 1
-		};
+		for (let keys of [Object.keys, object.keys]) {
+			const sym = Symbol('foo');
+			const o = {
+				[Symbol.iterator]() {
+					return 'foo';
+				},
+				[sym]: 'bar',
+				bar: 1
+			};
 
-		Object.defineProperty(o, 'baz', {
-			value: 'qat',
-			enumerable: false
-		});
+			Object.defineProperty(o, 'baz', {
+				value: 'qat',
+				enumerable: false
+			});
 
-		assert.strictEqual((<any>o).baz, 'qat');
-		assert.strictEqual((<any>o)[sym], 'bar');
-		assert.deepEqual(object.keys(o), ['bar']);
+			assert.strictEqual((<any>o).baz, 'qat');
+			assert.strictEqual((<any>o)[sym], 'bar');
+			assert.deepEqual(keys(o), ['bar']);
+		}
 	},
 
 	'.values()'() {
-		const sym = Symbol('foo');
-		const o = {
-			key1: 'value1',
-			key2: 2,
-			[sym]: 5
-		};
+		for (let values of [Object.values, object.values]) {
+			const sym = Symbol('foo');
+			const o = {
+				key1: 'value1',
+				key2: 2,
+				[sym]: 5
+			};
 
-		assert.sameMembers(object.values(o), ['value1', 2]);
+			assert.sameMembers(values(o), ['value1', 2]);
+		}
 	},
 
 	'.entries()'() {
-		const sym = Symbol('foo');
-		const o = {
-			key1: 'value1',
-			key2: 2,
-			[sym]: 5
-		};
+		for (let entries of [Object.entries, object.entries]) {
+			const sym = Symbol('foo');
+			const o = {
+				key1: 'value1',
+				key2: 2,
+				[sym]: 5
+			};
 
-		assert.sameDeepMembers(object.entries(o), [['key1', 'value1'], ['key2', 2]]);
+			assert.sameDeepMembers(entries(o), [['key1', 'value1'], ['key2', 2]]);
+		}
 	}
 });

--- a/tests/shim/unit/string.ts
+++ b/tests/shim/unit/string.ts
@@ -1,9 +1,81 @@
-import * as stringUtil from '../../../src/shim/string';
+import global from '../../../src/shim/global';
+import String, * as stringUtil from '../../../src/shim/string';
 
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
+function testCodePointAt(text: string, codePoint?: number, expected?: number) {
+	assert.strictEqual(stringUtil.codePointAt(text, codePoint), expected);
+
+	if (typeof codePoint !== 'undefined') {
+		assert.strictEqual(text.codePointAt(codePoint), expected);
+	}
+}
+
+function getPositionAndExpected(
+	position: number | boolean | undefined,
+	expected?: boolean
+): { positionArg: number | undefined; expectedValue: boolean } {
+	let positionArg: number | undefined = position as any;
+	let expectedValue = expected;
+	if (arguments.length === 1) {
+		expectedValue = position as any;
+		positionArg = undefined;
+	}
+
+	return { positionArg, expectedValue: Boolean(expectedValue) };
+}
+
+function testEndsWith(text: string, endsWith: string, position: number | boolean | undefined, expected?: boolean) {
+	const { expectedValue, positionArg } = getPositionAndExpected(position, expected);
+	assert.strictEqual(stringUtil.endsWith(text, endsWith, positionArg), expectedValue);
+
+	assert.strictEqual(text.endsWith(endsWith, positionArg), expectedValue);
+}
+
+function testFromCodePoint(codePoints: number[], expected: string) {
+	assert.equal(stringUtil.fromCodePoint(...codePoints), expected);
+	assert.equal(String.fromCodePoint(...codePoints), expected);
+}
+
+function testInclude(text: string, includes: string, position: number | boolean | undefined, expected?: boolean) {
+	const { positionArg, expectedValue } = getPositionAndExpected(position, expected);
+	assert.strictEqual(stringUtil.includes(text, includes, positionArg), expectedValue);
+
+	assert.strictEqual(text.includes(includes, positionArg), expectedValue);
+}
+
+function testStartsWith(text: string, startsWith: string, position: number | boolean | undefined, expected?: boolean) {
+	const { positionArg, expectedValue } = getPositionAndExpected(position, expected);
+	assert.strictEqual(stringUtil.startsWith(text, startsWith, positionArg), expectedValue);
+
+	assert.strictEqual(text.startsWith(startsWith, positionArg), expectedValue);
+}
+
+function testPadEnd(text: string, maxLength: number, fillString?: string, expected?: string) {
+	if (expected === undefined) {
+		expected = fillString;
+		fillString = undefined;
+	}
+
+	assert.strictEqual(stringUtil.padEnd(text, maxLength, fillString), expected);
+	assert.strictEqual(text.padEnd(maxLength, fillString), expected);
+}
+
+function testPadStart(text: string, maxLength: number, fillString?: string, expected?: string) {
+	if (expected === undefined) {
+		expected = fillString;
+		fillString = undefined;
+	}
+
+	assert.strictEqual(stringUtil.padStart(text, maxLength, fillString), expected);
+	assert.strictEqual(text.padStart(maxLength, fillString), expected);
+}
+
 registerSuite('shim - string functions', {
+	polyfill() {
+		assert.equal(String, global.String);
+	},
 	'.codePointAt()': {
 		'throws on undefined or null string'() {
 			assert.throws(function() {
@@ -18,33 +90,33 @@ registerSuite('shim - string functions', {
 			const text = 'abc\uD834\uDF06def';
 
 			// Cases expected to return the first code point (i.e. position 0)
-			assert.strictEqual(stringUtil.codePointAt(text), 0x61);
-			assert.strictEqual(stringUtil.codePointAt(text, 0), 0x61);
-			assert.strictEqual(stringUtil.codePointAt(text, NaN), 0x61);
-			assert.strictEqual(stringUtil.codePointAt(text, <any>null), 0x61);
-			assert.strictEqual(stringUtil.codePointAt(text, <any>undefined), 0x61);
+			testCodePointAt(text, undefined, 0x61);
+			testCodePointAt(text, 0, 0x61);
+			testCodePointAt(text, NaN, 0x61);
+			testCodePointAt(text, <any>null, 0x61);
+			testCodePointAt(text, <any>undefined, 0x61);
 
 			// Cases expected to return undefined (i.e. position out of range)
-			assert.strictEqual(stringUtil.codePointAt(text, -Infinity), <any>undefined);
-			assert.strictEqual(stringUtil.codePointAt(text, Infinity), <any>undefined);
-			assert.strictEqual(stringUtil.codePointAt(text, -1), <any>undefined);
-			assert.strictEqual(stringUtil.codePointAt(text, 42), <any>undefined);
+			testCodePointAt(text, -Infinity, <any>undefined);
+			testCodePointAt(text, Infinity, <any>undefined);
+			testCodePointAt(text, -1, <any>undefined);
+			testCodePointAt(text, 42, <any>undefined);
 
 			// Test various code points in the string
-			assert.strictEqual(stringUtil.codePointAt(text, 3), 0x1d306);
-			assert.strictEqual(stringUtil.codePointAt(text, 4), 0xdf06);
-			assert.strictEqual(stringUtil.codePointAt(text, 5), 0x64);
+			testCodePointAt(text, 3, 0x1d306);
+			testCodePointAt(text, 4, 0xdf06);
+			testCodePointAt(text, 5, 0x64);
 		},
 
 		'string starting with an astral symbol'() {
 			const text = '\uD834\uDF06def';
-			assert.strictEqual(stringUtil.codePointAt(text, 0), 0x1d306);
-			assert.strictEqual(stringUtil.codePointAt(text, 1), 0xdf06);
+			testCodePointAt(text, 0, 0x1d306);
+			testCodePointAt(text, 1, 0xdf06);
 		},
 
 		'lone high/low surrogates'() {
-			assert.strictEqual(stringUtil.codePointAt('\uD834abc', 0), 0xd834);
-			assert.strictEqual(stringUtil.codePointAt('\uDF06abc', 0), 0xdf06);
+			testCodePointAt('\uD834abc', 0, 0xd834);
+			testCodePointAt('\uDF06abc', 0, 0xdf06);
 		}
 	},
 
@@ -59,75 +131,75 @@ registerSuite('shim - string functions', {
 		},
 
 		'null or undefined search value'() {
-			assert.isTrue(stringUtil.endsWith('undefined', <any>undefined));
-			assert.isFalse(stringUtil.endsWith('undefined', <any>null));
-			assert.isTrue(stringUtil.endsWith('null', <any>null));
-			assert.isFalse(stringUtil.endsWith('null', <any>undefined));
+			testEndsWith('undefined', <any>undefined, true);
+			testEndsWith('undefined', <any>null, false);
+			testEndsWith('null', <any>null, true);
+			testEndsWith('null', <any>undefined, false);
 		},
 
 		'position is Infinity, not included, or NaN'() {
-			assert.isTrue(stringUtil.endsWith('abc', '', Infinity));
-			assert.isFalse(stringUtil.endsWith('abc', '\0', Infinity));
-			assert.isTrue(stringUtil.endsWith('abc', 'c', Infinity));
-			assert.isFalse(stringUtil.endsWith('abc', 'b', Infinity));
-			assert.isTrue(stringUtil.endsWith('abc', 'bc', Infinity));
-			assert.isTrue(stringUtil.endsWith('abc', 'abc', Infinity));
-			assert.isFalse(stringUtil.endsWith('abc', 'abcd', Infinity));
+			testEndsWith('abc', '', Infinity, true);
+			testEndsWith('abc', '\0', Infinity, false);
+			testEndsWith('abc', 'c', Infinity, true);
+			testEndsWith('abc', 'b', Infinity, false);
+			testEndsWith('abc', 'bc', Infinity, true);
+			testEndsWith('abc', 'abc', Infinity, true);
+			testEndsWith('abc', 'abcd', Infinity, false);
 
-			assert.isTrue(stringUtil.endsWith('abc', '', undefined));
-			assert.isFalse(stringUtil.endsWith('abc', '\0', undefined));
-			assert.isTrue(stringUtil.endsWith('abc', 'c', undefined));
-			assert.isFalse(stringUtil.endsWith('abc', 'b', undefined));
-			assert.isTrue(stringUtil.endsWith('abc', 'bc', undefined));
-			assert.isTrue(stringUtil.endsWith('abc', 'abc', undefined));
-			assert.isFalse(stringUtil.endsWith('abc', 'abcd', undefined));
+			testEndsWith('abc', '', undefined, true);
+			testEndsWith('abc', '\0', undefined, false);
+			testEndsWith('abc', 'c', undefined, true);
+			testEndsWith('abc', 'b', undefined, false);
+			testEndsWith('abc', 'bc', undefined, true);
+			testEndsWith('abc', 'abc', undefined, true);
+			testEndsWith('abc', 'abcd', undefined, false);
 
-			assert.isTrue(stringUtil.endsWith('abc', '', null as any));
-			assert.isFalse(stringUtil.endsWith('abc', '\0', null as any));
-			assert.isFalse(stringUtil.endsWith('abc', 'c', null as any));
-			assert.isFalse(stringUtil.endsWith('abc', 'b', null as any));
-			assert.isFalse(stringUtil.endsWith('abc', 'bc', null as any));
-			assert.isFalse(stringUtil.endsWith('abc', 'abc', null as any));
-			assert.isFalse(stringUtil.endsWith('abc', 'abcd', null as any));
+			testEndsWith('abc', '', null as any, true);
+			testEndsWith('abc', '\0', null as any, false);
+			testEndsWith('abc', 'c', null as any, false);
+			testEndsWith('abc', 'b', null as any, false);
+			testEndsWith('abc', 'bc', null as any, false);
+			testEndsWith('abc', 'abc', null as any, false);
+			testEndsWith('abc', 'abcd', null as any, false);
 
-			assert.isTrue(stringUtil.endsWith('abc', '', NaN));
-			assert.isFalse(stringUtil.endsWith('abc', '\0', NaN));
-			assert.isFalse(stringUtil.endsWith('abc', 'c', NaN));
-			assert.isFalse(stringUtil.endsWith('abc', 'b', NaN));
-			assert.isFalse(stringUtil.endsWith('abc', 'bc', NaN));
-			assert.isFalse(stringUtil.endsWith('abc', 'abc', NaN));
-			assert.isFalse(stringUtil.endsWith('abc', 'abcd', NaN));
+			testEndsWith('abc', '', NaN, true);
+			testEndsWith('abc', '\0', NaN, false);
+			testEndsWith('abc', 'c', NaN, false);
+			testEndsWith('abc', 'b', NaN, false);
+			testEndsWith('abc', 'bc', NaN, false);
+			testEndsWith('abc', 'abc', NaN, false);
+			testEndsWith('abc', 'abcd', NaN, false);
 		},
 
 		'position is 0 or negative'() {
 			let counts = [0, -1];
 			for (let count of counts) {
-				assert.isTrue(stringUtil.endsWith('abc', '', count));
-				assert.isFalse(stringUtil.endsWith('abc', '\0', count));
-				assert.isFalse(stringUtil.endsWith('abc', 'a', count));
-				assert.isFalse(stringUtil.endsWith('abc', 'b', count));
-				assert.isFalse(stringUtil.endsWith('abc', 'ab', count));
-				assert.isFalse(stringUtil.endsWith('abc', 'abc', count));
-				assert.isFalse(stringUtil.endsWith('abc', 'abcd', count));
+				testEndsWith('abc', '', count, true);
+				testEndsWith('abc', '\0', count, false);
+				testEndsWith('abc', 'a', count, false);
+				testEndsWith('abc', 'b', count, false);
+				testEndsWith('abc', 'ab', count, false);
+				testEndsWith('abc', 'abc', count, false);
+				testEndsWith('abc', 'abcd', count, false);
 			}
 		},
 
 		'position is 1'() {
-			assert.isTrue(stringUtil.endsWith('abc', '', 1));
-			assert.isFalse(stringUtil.endsWith('abc', '\0', 1));
-			assert.isTrue(stringUtil.endsWith('abc', 'a', 1));
-			assert.isFalse(stringUtil.endsWith('abc', 'b', 1));
-			assert.isFalse(stringUtil.endsWith('abc', 'bc', 1));
-			assert.isFalse(stringUtil.endsWith('abc', 'abc', 1));
-			assert.isFalse(stringUtil.endsWith('abc', 'abcd', 1));
+			testEndsWith('abc', '', 1, true);
+			testEndsWith('abc', '\0', 1, false);
+			testEndsWith('abc', 'a', 1, true);
+			testEndsWith('abc', 'b', 1, false);
+			testEndsWith('abc', 'bc', 1, false);
+			testEndsWith('abc', 'abc', 1, false);
+			testEndsWith('abc', 'abcd', 1, false);
 		},
 
 		'unicode support'() {
-			assert.isTrue(stringUtil.endsWith('\xA2fa\xA3', 'fa\xA3'));
-			assert.isTrue(stringUtil.endsWith('\xA2fa', '\xA2', 1));
-			assert.isTrue(stringUtil.endsWith('\xA2fa\uDA04', '\xA2fa\uDA04'));
-			assert.isTrue(stringUtil.endsWith('\xA2fa\uDA04', 'fa', 3));
-			assert.isTrue(stringUtil.endsWith('\xA2fa\uDA04', '\uDA04'));
+			testEndsWith('\xA2fa\xA3', 'fa\xA3', true);
+			testEndsWith('\xA2fa', '\xA2', 1, true);
+			testEndsWith('\xA2fa\uDA04', '\xA2fa\uDA04', true);
+			testEndsWith('\xA2fa\uDA04', 'fa', 3, true);
+			testEndsWith('\xA2fa\uDA04', '\uDA04', true);
 		}
 	},
 
@@ -143,12 +215,12 @@ registerSuite('shim - string functions', {
 		},
 
 		'basic cases'() {
-			assert.strictEqual(stringUtil.fromCodePoint(<any>null), '\0');
-			assert.strictEqual(stringUtil.fromCodePoint(0), '\0');
-			assert.strictEqual(stringUtil.fromCodePoint(), '');
-			assert.strictEqual(stringUtil.fromCodePoint(0x1d306), '\uD834\uDF06');
-			assert.strictEqual(stringUtil.fromCodePoint(0x1d306, 0x61, 0x1d307), '\uD834\uDF06a\uD834\uDF07');
-			assert.strictEqual(stringUtil.fromCodePoint(0x61, 0x62, 0x1d307), 'ab\uD834\uDF07');
+			testFromCodePoint([<any>null], '\0');
+			testFromCodePoint([0], '\0');
+			testFromCodePoint([], '');
+			testFromCodePoint([0x1d306], '\uD834\uDF06');
+			testFromCodePoint([0x1d306, 0x61, 0x1d307], '\uD834\uDF06a\uD834\uDF07');
+			testFromCodePoint([0x61, 0x62, 0x1d307], 'ab\uD834\uDF07');
 		},
 
 		'test that valid cases do not throw'() {
@@ -164,6 +236,8 @@ registerSuite('shim - string functions', {
 			assert.doesNotThrow(function() {
 				stringUtil.fromCodePoint.apply(null, oneUnitArgs);
 				stringUtil.fromCodePoint.apply(null, twoUnitArgs);
+				String.fromCodePoint.apply(null, oneUnitArgs);
+				String.fromCodePoint.apply(null, twoUnitArgs);
 			});
 		}
 	},
@@ -179,51 +253,51 @@ registerSuite('shim - string functions', {
 		},
 
 		'null or undefined search value'() {
-			assert.isTrue(stringUtil.includes('undefined', <any>undefined));
-			assert.isFalse(stringUtil.includes('undefined', <any>null));
-			assert.isTrue(stringUtil.includes('null', <any>null));
-			assert.isFalse(stringUtil.includes('null', <any>undefined));
+			testInclude('undefined', <any>undefined, true);
+			testInclude('undefined', <any>null, false);
+			testInclude('null', <any>null, true);
+			testInclude('null', <any>undefined, false);
 		},
 
 		'position is 0 (whether explicitly, by default, or due to NaN or negative)'() {
 			let counts = [0, -1, NaN, <any>undefined, null];
 			for (let count of counts) {
-				assert.isTrue(stringUtil.includes('abc', '', count));
-				assert.isFalse(stringUtil.includes('abc', '\0', count));
-				assert.isTrue(stringUtil.includes('abc', 'a', count));
-				assert.isTrue(stringUtil.includes('abc', 'b', count));
-				assert.isTrue(stringUtil.includes('abc', 'ab', count));
-				assert.isTrue(stringUtil.includes('abc', 'abc', count));
-				assert.isFalse(stringUtil.includes('abc', 'abcd', count));
+				testInclude('abc', '', count, true);
+				testInclude('abc', '\0', count, false);
+				testInclude('abc', 'a', count, true);
+				testInclude('abc', 'b', count, true);
+				testInclude('abc', 'ab', count, true);
+				testInclude('abc', 'abc', count, true);
+				testInclude('abc', 'abcd', count, false);
 			}
 		},
 
 		'position is Infinity'() {
-			assert.isTrue(stringUtil.includes('abc', '', Infinity));
-			assert.isFalse(stringUtil.includes('abc', '\0', Infinity));
-			assert.isFalse(stringUtil.includes('abc', 'a', Infinity));
-			assert.isFalse(stringUtil.includes('abc', 'b', Infinity));
-			assert.isFalse(stringUtil.includes('abc', 'ab', Infinity));
-			assert.isFalse(stringUtil.includes('abc', 'abc', Infinity));
-			assert.isFalse(stringUtil.includes('abc', 'abcd', Infinity));
+			testInclude('abc', '', Infinity, true);
+			testInclude('abc', '\0', Infinity, false);
+			testInclude('abc', 'a', Infinity, false);
+			testInclude('abc', 'b', Infinity, false);
+			testInclude('abc', 'ab', Infinity, false);
+			testInclude('abc', 'abc', Infinity, false);
+			testInclude('abc', 'abcd', Infinity, false);
 		},
 
 		'position is 1'() {
-			assert.isTrue(stringUtil.includes('abc', '', 1));
-			assert.isFalse(stringUtil.includes('abc', '\0', 1));
-			assert.isFalse(stringUtil.includes('abc', 'a', 1));
-			assert.isTrue(stringUtil.includes('abc', 'b', 1));
-			assert.isTrue(stringUtil.includes('abc', 'bc', 1));
-			assert.isFalse(stringUtil.includes('abc', 'abc', 1));
-			assert.isFalse(stringUtil.includes('abc', 'abcd', 1));
+			testInclude('abc', '', 1, true);
+			testInclude('abc', '\0', 1, false);
+			testInclude('abc', 'a', 1, false);
+			testInclude('abc', 'b', 1, true);
+			testInclude('abc', 'bc', 1, true);
+			testInclude('abc', 'abc', 1, false);
+			testInclude('abc', 'abcd', 1, false);
 		},
 
 		'unicode support'() {
-			assert.isTrue(stringUtil.includes('\xA2fa', '\xA2'));
-			assert.isTrue(stringUtil.includes('\xA2fa', 'fa', 1));
-			assert.isTrue(stringUtil.includes('\xA2fa\uDA04', '\xA2fa\uDA04'));
-			assert.isTrue(stringUtil.includes('\xA2fa\uDA04', 'fa\uDA04', 1));
-			assert.isTrue(stringUtil.includes('\xA2fa\uDA04', '\uDA04', 3));
+			testInclude('\xA2fa', '\xA2', true);
+			testInclude('\xA2fa', 'fa', 1, true);
+			testInclude('\xA2fa\uDA04', '\xA2fa\uDA04', true);
+			testInclude('\xA2fa\uDA04', 'fa\uDA04', 1, true);
+			testInclude('\xA2fa\uDA04', '\uDA04', 3, true);
 		}
 	},
 
@@ -242,6 +316,12 @@ registerSuite('shim - string functions', {
 				'stringUtil.raw applied to template string should result in expected value'
 			);
 
+			assert.strictEqual(
+				String.raw`The answer is:\n${answer}`,
+				'The answer is:\\n42',
+				'stringUtil.raw applied to template string should result in expected value'
+			);
+
 			function getCallSite(callSite: TemplateStringsArray, ...substitutions: any[]): TemplateStringsArray {
 				const result = [...callSite];
 				(result as any).raw = callSite.raw;
@@ -255,9 +335,21 @@ registerSuite('shim - string functions', {
 				'stringUtil.raw applied with insufficient arguments should result in no substitution'
 			);
 
+			assert.strictEqual(
+				String.raw(callSite),
+				'The answer is:\\n',
+				'stringUtil.raw applied with insufficient arguments should result in no substitution'
+			);
+
 			(callSite as any).raw = ['The answer is:\\n'];
 			assert.strictEqual(
 				stringUtil.raw(callSite, 42),
+				'The answer is:\\n',
+				'stringUtil.raw applied with insufficient raw fragments should result in truncation before substitution'
+			);
+
+			assert.strictEqual(
+				String.raw(callSite, 42),
 				'The answer is:\\n',
 				'stringUtil.raw applied with insufficient raw fragments should result in truncation before substitution'
 			);
@@ -281,6 +373,10 @@ registerSuite('shim - string functions', {
 				assert.throws(function() {
 					stringUtil.repeat('abc', count);
 				}, RangeError);
+
+				assert.throws(function() {
+					'abc'.repeat(count);
+				}, RangeError);
 			}
 		},
 
@@ -289,6 +385,7 @@ registerSuite('shim - string functions', {
 			let counts = [<any>undefined, null, 0, NaN];
 			for (let count of counts) {
 				assert.strictEqual(stringUtil.repeat('abc', count), '');
+				assert.strictEqual('abc'.repeat(count), '');
 			}
 		},
 
@@ -297,6 +394,11 @@ registerSuite('shim - string functions', {
 			assert.strictEqual(stringUtil.repeat('abc', 2), 'abcabc');
 			assert.strictEqual(stringUtil.repeat('abc', 3), 'abcabcabc');
 			assert.strictEqual(stringUtil.repeat('abc', 4), 'abcabcabcabc');
+
+			assert.strictEqual('abc'.repeat(1), 'abc');
+			assert.strictEqual('abc'.repeat(2), 'abcabc');
+			assert.strictEqual('abc'.repeat(3), 'abcabcabc');
+			assert.strictEqual('abc'.repeat(4), 'abcabcabcabc');
 		}
 	},
 
@@ -311,51 +413,51 @@ registerSuite('shim - string functions', {
 		},
 
 		'null or undefined search value'() {
-			assert.isTrue(stringUtil.startsWith('undefined', <any>undefined));
-			assert.isFalse(stringUtil.startsWith('undefined', <any>null));
-			assert.isTrue(stringUtil.startsWith('null', <any>null));
-			assert.isFalse(stringUtil.startsWith('null', <any>undefined));
+			testStartsWith('undefined', <any>undefined, true);
+			testStartsWith('undefined', <any>null, false);
+			testStartsWith('null', <any>null, true);
+			testStartsWith('null', <any>undefined, false);
 		},
 
 		'position is 0 (whether explicitly, by default, or due to NaN or negative)'() {
 			let counts = [0, -1, NaN, <any>undefined, null];
 			for (let count of counts) {
-				assert.isTrue(stringUtil.startsWith('abc', '', count));
-				assert.isFalse(stringUtil.startsWith('abc', '\0', count));
-				assert.isTrue(stringUtil.startsWith('abc', 'a', count));
-				assert.isFalse(stringUtil.startsWith('abc', 'b', count));
-				assert.isTrue(stringUtil.startsWith('abc', 'ab', count));
-				assert.isTrue(stringUtil.startsWith('abc', 'abc', count));
-				assert.isFalse(stringUtil.startsWith('abc', 'abcd', count));
+				testStartsWith('abc', '', count, true);
+				testStartsWith('abc', '\0', count, false);
+				testStartsWith('abc', 'a', count, true);
+				testStartsWith('abc', 'b', count, false);
+				testStartsWith('abc', 'ab', count, true);
+				testStartsWith('abc', 'abc', count, true);
+				testStartsWith('abc', 'abcd', count, false);
 			}
 		},
 
 		'position is Infinity'() {
-			assert.isTrue(stringUtil.startsWith('abc', '', Infinity));
-			assert.isFalse(stringUtil.startsWith('abc', '\0', Infinity));
-			assert.isFalse(stringUtil.startsWith('abc', 'a', Infinity));
-			assert.isFalse(stringUtil.startsWith('abc', 'b', Infinity));
-			assert.isFalse(stringUtil.startsWith('abc', 'ab', Infinity));
-			assert.isFalse(stringUtil.startsWith('abc', 'abc', Infinity));
-			assert.isFalse(stringUtil.startsWith('abc', 'abcd', Infinity));
+			testStartsWith('abc', '', Infinity, true);
+			testStartsWith('abc', '\0', Infinity, false);
+			testStartsWith('abc', 'a', Infinity, false);
+			testStartsWith('abc', 'b', Infinity, false);
+			testStartsWith('abc', 'ab', Infinity, false);
+			testStartsWith('abc', 'abc', Infinity, false);
+			testStartsWith('abc', 'abcd', Infinity, false);
 		},
 
 		'position is 1'() {
-			assert.isTrue(stringUtil.startsWith('abc', '', 1));
-			assert.isFalse(stringUtil.startsWith('abc', '\0', 1));
-			assert.isFalse(stringUtil.startsWith('abc', 'a', 1));
-			assert.isTrue(stringUtil.startsWith('abc', 'b', 1));
-			assert.isTrue(stringUtil.startsWith('abc', 'bc', 1));
-			assert.isFalse(stringUtil.startsWith('abc', 'abc', 1));
-			assert.isFalse(stringUtil.startsWith('abc', 'abcd', 1));
+			testStartsWith('abc', '', 1, true);
+			testStartsWith('abc', '\0', 1, false);
+			testStartsWith('abc', 'a', 1, false);
+			testStartsWith('abc', 'b', 1, true);
+			testStartsWith('abc', 'bc', 1, true);
+			testStartsWith('abc', 'abc', 1, false);
+			testStartsWith('abc', 'abcd', 1, false);
 		},
 
 		'unicode support'() {
-			assert.isTrue(stringUtil.startsWith('\xA2fa', '\xA2'));
-			assert.isTrue(stringUtil.startsWith('\xA2fa', 'fa', 1));
-			assert.isTrue(stringUtil.startsWith('\xA2fa\uDA04', '\xA2fa\uDA04'));
-			assert.isTrue(stringUtil.startsWith('\xA2fa\uDA04', 'fa\uDA04', 1));
-			assert.isTrue(stringUtil.startsWith('\xA2fa\uDA04', '\uDA04', 3));
+			testStartsWith('\xA2fa', '\xA2', true);
+			testStartsWith('\xA2fa', 'fa', 1, true);
+			testStartsWith('\xA2fa\uDA04', '\xA2fa\uDA04', true);
+			testStartsWith('\xA2fa\uDA04', 'fa\uDA04', 1, true);
+			testStartsWith('\xA2fa\uDA04', '\uDA04', 3, true);
 		}
 	},
 
@@ -371,20 +473,24 @@ registerSuite('shim - string functions', {
 		},
 
 		'null/undefined/invalid length'() {
-			assert.equal(stringUtil.padEnd('test', <any>null), 'test');
-			assert.equal(stringUtil.padEnd('test', <any>undefined), 'test');
-			assert.equal(stringUtil.padEnd('test', -1), 'test');
+			testPadEnd('test', <any>null, 'test');
+			testPadEnd('test', <any>undefined, 'test');
+			testPadEnd('test', -1, 'test');
 
 			assert.throws(() => {
 				stringUtil.padEnd('', Infinity);
 			});
+
+			assert.throws(() => {
+				''.padEnd(Infinity);
+			});
 		},
 
 		'padEnd()'() {
-			assert.equal(stringUtil.padEnd('', 10), '          ');
-			assert.equal(stringUtil.padEnd('test', 5), 'test ');
-			assert.equal(stringUtil.padEnd('test', 10, 'test'), 'testtestte');
-			assert.equal(stringUtil.padEnd('test', 3, 'padding'), 'test');
+			testPadEnd('', 10, '          ');
+			testPadEnd('test', 5, 'test ');
+			testPadEnd('test', 10, 'test', 'testtestte');
+			testPadEnd('test', 3, 'padding', 'test');
 		}
 	},
 
@@ -400,20 +506,24 @@ registerSuite('shim - string functions', {
 		},
 
 		'null/undefined/invalid length'() {
-			assert.equal(stringUtil.padStart('test', <any>null), 'test');
-			assert.equal(stringUtil.padStart('test', <any>undefined), 'test');
-			assert.equal(stringUtil.padStart('test', -1), 'test');
+			testPadStart('test', <any>null, 'test');
+			testPadStart('test', <any>undefined, 'test');
+			testPadStart('test', -1, 'test');
 
 			assert.throws(() => {
 				stringUtil.padStart('', Infinity);
 			});
+
+			assert.throws(() => {
+				''.padStart(Infinity);
+			});
 		},
 
 		'padStart()'() {
-			assert.equal(stringUtil.padStart('', 10), '          ');
-			assert.equal(stringUtil.padStart('test', 5), ' test');
-			assert.equal(stringUtil.padStart('test', 10, 'test'), 'testtetest');
-			assert.equal(stringUtil.padStart('test', 3, 'padding'), 'test');
+			testPadStart('', 10, '          ');
+			testPadStart('test', 5, ' test');
+			testPadStart('test', 10, 'test', 'testtetest');
+			testPadStart('test', 3, 'padding', 'test');
 		}
 	}
 });

--- a/tests/shim/unit/string.ts
+++ b/tests/shim/unit/string.ts
@@ -5,7 +5,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 function testCodePointAt(text: string, codePoint?: number, expected?: number) {
-	assert.strictEqual(stringUtil.codePointAt(text, codePoint), expected);
+	assert.strictEqual(stringUtil.codePointAt(text, codePoint as any), expected);
 
 	if (typeof codePoint !== 'undefined') {
 		assert.strictEqual(text.codePointAt(codePoint), expected);
@@ -79,10 +79,10 @@ registerSuite('shim - string functions', {
 	'.codePointAt()': {
 		'throws on undefined or null string'() {
 			assert.throws(function() {
-				stringUtil.codePointAt(<any>undefined);
+				stringUtil.codePointAt(<any>undefined, <any>undefined);
 			}, TypeError);
 			assert.throws(function() {
-				stringUtil.codePointAt(<any>null);
+				stringUtil.codePointAt(<any>null, <any>undefined);
 			}, TypeError);
 		},
 
@@ -359,10 +359,10 @@ registerSuite('shim - string functions', {
 	'.repeat()': {
 		'throws on undefined or null string'() {
 			assert.throws(function() {
-				stringUtil.repeat(<any>undefined);
+				stringUtil.repeat(<any>undefined, <any>undefined);
 			}, TypeError);
 			assert.throws(function() {
-				stringUtil.repeat(<any>null);
+				stringUtil.repeat(<any>null, <any>null);
 			}, TypeError);
 		},
 
@@ -381,7 +381,7 @@ registerSuite('shim - string functions', {
 		},
 
 		'returns empty string when passed 0, NaN, or no count'() {
-			assert.strictEqual(stringUtil.repeat('abc'), '');
+			assert.strictEqual((stringUtil.repeat as any)('abc'), '');
 			let counts = [<any>undefined, null, 0, NaN];
 			for (let count of counts) {
 				assert.strictEqual(stringUtil.repeat('abc', count), '');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Conversion of shims that are used directly to polyfills, while maintaining backwards compatibility with current usage. Also makes sure that we are actually applying our more standard polyfills to the global object when appropriate, as some modules were not. This is one part of the work for #279.