### PR TITLE
Fixing a problem with auto-bind and multiple subclasses

### DIFF
--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -52,15 +52,38 @@ function isDomMeta(meta: any): meta is Base {
 	return Boolean(meta.afterRender);
 }
 
-const IGNORE_LIST: (string | symbol)[] = ['constructor', 'render'];
+const IGNORE_LIST: (string | symbol)[] = ['render', ...Object.getOwnPropertyNames(Object.getPrototypeOf({}))];
+
+const autoBindCache = new Map<any, string[]>();
 
 function autoBind(instance: any) {
-	let keys: string[] = Object.getOwnPropertyNames(instance.constructor.prototype);
+	let prototype = instance.constructor.prototype;
+
+	let keys: string[] = [];
+
+	if (autoBindCache.has(prototype)) {
+		keys = autoBindCache.get(prototype) as string[];
+	} else {
+		let p = prototype;
+		while (p) {
+			const ownKeys = Object.getOwnPropertyNames(p);
+
+			if (ownKeys.indexOf('_type') !== -1) {
+				break;
+			}
+
+			keys = [...keys, ...ownKeys];
+			p = Object.getPrototypeOf(p);
+		}
+
+		keys = keys.filter((k) => typeof instance[k] === 'function' && IGNORE_LIST.indexOf(k) === -1);
+
+		autoBindCache.set(prototype, keys);
+	}
+
 	for (let i = 0; i < keys.length; i++) {
 		const key = keys[i];
-		if (typeof instance[key] !== 'function' || IGNORE_LIST.indexOf(key) > -1) {
-			continue;
-		}
+
 		const boundFunc = instance[key].bind(instance);
 		Object.defineProperty(instance, key, {
 			configurable: true,

--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -64,16 +64,15 @@ function autoBind(instance: any) {
 	if (autoBindCache.has(prototype)) {
 		keys = autoBindCache.get(prototype) as string[];
 	} else {
-		let p = prototype;
-		while (p) {
-			const ownKeys = Object.getOwnPropertyNames(p);
+		while (prototype) {
+			const ownKeys = Object.getOwnPropertyNames(prototype);
 
 			if (ownKeys.indexOf('_type') !== -1) {
 				break;
 			}
 
 			keys = [...keys, ...ownKeys];
-			p = Object.getPrototypeOf(p);
+			prototype = Object.getPrototypeOf(prototype);
 		}
 
 		keys = keys.filter((k) => typeof instance[k] === 'function' && IGNORE_LIST.indexOf(k) === -1);

--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -67,11 +67,12 @@ function autoBind(instance: any) {
 		while (prototype) {
 			const ownKeys = Object.getOwnPropertyNames(prototype);
 
-			if (ownKeys.indexOf('_type') !== -1) {
+			keys = [...keys, ...ownKeys];
+
+			if (prototype.constructor._type !== undefined) {
 				break;
 			}
 
-			keys = [...keys, ...ownKeys];
 			prototype = Object.getPrototypeOf(prototype);
 		}
 

--- a/src/widget-core/WidgetBase.ts
+++ b/src/widget-core/WidgetBase.ts
@@ -67,11 +67,11 @@ function autoBind(instance: any) {
 		while (prototype) {
 			const ownKeys = Object.getOwnPropertyNames(prototype);
 
-			keys = [...keys, ...ownKeys];
-
-			if (prototype.constructor._type !== undefined) {
+			if (prototype.constructor.hasOwnProperty('_type')) {
 				break;
 			}
+
+			keys = [...keys, ...ownKeys];
 
 			prototype = Object.getPrototypeOf(prototype);
 		}

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -5665,4 +5665,32 @@ jsdomDescribe('vdom', () => {
 		setProperties({ rtl: false });
 		assert.strictEqual(root.dir, 'ltr');
 	});
+
+	it('widget methods are bound correctly', () => {
+		const stubby = stub();
+		class Bar extends WidgetBase<any> {
+			render() {
+				this.properties.func();
+				return 'blah';
+			}
+		}
+		class Foo extends WidgetBase {
+			private _stub = stubby;
+
+			protected test() {
+				this._stub();
+			}
+		}
+
+		class FooSubClass extends Foo {
+			render() {
+				return w(Bar, { func: this.test });
+			}
+		}
+
+		const r = renderer(() => w(FooSubClass, {}));
+		const root: any = document.createElement('div');
+		r.mount({ domNode: root });
+		assert.isTrue(stubby.calledOnce);
+	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

There is a problem with the new auto-bind code when there are multiple levels of inheritance. It currently only applies the binding logic to the first level of inheritance.

To fix this, we're walking the prototype chain up to `WidgetBase` and gathering all the properties from there. Since this is a bit of an expensive operation, we're also caching the result of the property gathering so it only needs to happen once per widget class.
