### PR TITLE
Do not use existing text node on merge when content is different

### DIFF
--- a/src/widget-core/vdom.ts
+++ b/src/widget-core/vdom.ts
@@ -168,6 +168,10 @@ const NAMESPACE_XLINK = NAMESPACE_W3 + '1999/xlink';
 let lazyWidgetId = 0;
 const lazyWidgetIdMap = new WeakMap<LazyWidget, string>();
 
+function isTextNode(item: any): item is Text {
+	return item.nodeType === 3;
+}
+
 function isLazyDefine(item: any): item is LazyDefine {
 	return Boolean(item && item.label);
 }
@@ -1277,12 +1281,18 @@ export function renderer(renderer: () => WNode | VNode): Renderer {
 					_insertBeforeMap.set(next, _allMergedNodes[0]);
 				}
 			}
-		} else {
-			if (_mountOptions.merge) {
+		} else if (_mountOptions.merge) {
+			next.merged = true;
+			if (isTextNode(next.domNode)) {
+				if (next.domNode.data !== next.node.text) {
+					_allMergedNodes = [next.domNode, ..._allMergedNodes];
+					next.domNode = global.document.createTextNode(next.node.text);
+					next.merged = false;
+				}
+			} else {
 				mergeNodes = arrayFrom(next.domNode.childNodes);
 				_allMergedNodes = [..._allMergedNodes, ...mergeNodes];
 			}
-			next.merged = true;
 		}
 		if (next.domNode) {
 			if (next.node.children) {

--- a/tests/widget-core/unit/vdom.ts
+++ b/tests/widget-core/unit/vdom.ts
@@ -4905,6 +4905,31 @@ jsdomDescribe('vdom', () => {
 			assert.isTrue(onclickListener.called, 'onclickListener should have been called');
 			document.body.removeChild(iframe);
 		});
+		it('should replace text node on merge when value is different', () => {
+			const iframe = document.createElement('iframe');
+			document.body.appendChild(iframe);
+			iframe.contentDocument!.write(`<div class="foo"><span>hello</span><span>world</span></div>`);
+			iframe.contentDocument!.close();
+			const div = iframe.contentDocument!.body.firstChild as HTMLElement;
+			const firstSpan = div.childNodes[0];
+			const firstText = firstSpan.childNodes[0] as Text;
+			const secondSpan = div.childNodes[1] as HTMLLabelElement;
+			const secondText = secondSpan.childNodes[0] as Text;
+			class App extends WidgetBase {
+				render() {
+					return v('div', [v('span', ['hello']), v('span', ['tests'])]);
+				}
+			}
+			const r = renderer(() => w(App, {}));
+			r.mount({ domNode: iframe.contentDocument!.body });
+			assert.strictEqual(div, iframe.contentDocument!.body.firstChild);
+			assert.strictEqual(firstSpan, iframe.contentDocument!.body.firstChild!.childNodes[0]);
+			assert.strictEqual(firstText, iframe.contentDocument!.body.firstChild!.childNodes[0].childNodes[0]);
+			assert.strictEqual(secondSpan, iframe.contentDocument!.body.firstChild!.childNodes[1]);
+			assert.notStrictEqual(secondText, iframe.contentDocument!.body.firstChild!.childNodes[1].childNodes[0]);
+			assert.strictEqual(div.outerHTML, '<div class="foo"><span>hello</span><span>tests</span></div>');
+			document.body.removeChild(iframe);
+		});
 	});
 
 	describe('sync mode', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Do not merge text nodes when the hydrated value is different to the existing text node's value.

Resolves #354 
