### PR TITLE
Move instance map to vdom

### DIFF
--- a/src/core/WidgetBase.ts
+++ b/src/core/WidgetBase.ts
@@ -20,28 +20,17 @@ import NodeHandler from './NodeHandler';
 import { WIDGET_BASE_TYPE } from './Registry';
 import { Handle } from '../core/Destroyable';
 import { Base } from './meta/Base';
+import { widgetInstanceMap } from './vdom';
 
 interface ReactionFunctionConfig {
 	propertyName: string;
 	reaction: DiffPropertyReaction;
 }
 
-export interface WidgetData {
-	onDetach: () => void;
-	onAttach: () => void;
-	dirty: boolean;
-	nodeHandler: NodeHandler;
-	invalidate?: Function;
-	rendering: boolean;
-	inputProperties: any;
-	registry: RegistryHandler;
-}
-
 export type BoundFunctionData = { boundFunc: (...args: any[]) => any; scope: any };
 
 const decoratorMap = new WeakMap<Function, Map<string, any[]>>();
 const builtDecoratorMap = new WeakMap<Function, Map<string, any[]>>();
-export const widgetInstanceMap = new WeakMap<WidgetBaseInterface, WidgetData>();
 const boundAuto = auto.bind(null);
 
 function isDomMeta(meta: any): meta is Base {

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -23,10 +23,10 @@ import {
 import transitionStrategy from './animations/cssTransitions';
 import { isVNode, isWNode, WNODE, v, isDomVNode, VNODE, isWNodeFactory } from './d';
 import { Registry, isWidget, isWidgetBaseConstructor, isWidgetFunction } from './Registry';
-import { widgetInstanceMap } from './WidgetBase';
 import { auto } from './diff';
 import RegistryHandler from './RegistryHandler';
 import { w } from './d';
+import { NodeHandler } from './NodeHandler';
 
 export interface BaseNodeWrapper {
 	owningId: string;
@@ -59,6 +59,17 @@ export interface WidgetMeta {
 	registryHandler: any;
 	properties: any;
 	children?: DNode[];
+}
+
+export interface WidgetData {
+	onDetach: () => void;
+	onAttach: () => void;
+	dirty: boolean;
+	nodeHandler: NodeHandler;
+	invalidate?: Function;
+	rendering: boolean;
+	inputProperties: any;
+	registry: RegistryHandler;
 }
 
 export interface VNodeWrapper extends BaseNodeWrapper {
@@ -443,6 +454,7 @@ function wrapNodes(renderer: () => RenderResult) {
 	return factory(callback);
 }
 
+export const widgetInstanceMap = new WeakMap<WidgetBaseInterface, WidgetData>();
 const widgetMetaMap = new Map<string, WidgetMeta>();
 let wrapperId = 0;
 let metaId = 0;

--- a/tests/core/unit/WidgetBase.ts
+++ b/tests/core/unit/WidgetBase.ts
@@ -2,7 +2,8 @@ const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { spy, stub, SinonStub } from 'sinon';
 
-import { WidgetBase, widgetInstanceMap } from '../../../src/core/WidgetBase';
+import { WidgetBase } from '../../../src/core/WidgetBase';
+import { widgetInstanceMap } from '../../../src/core/vdom';
 import { v } from '../../../src/core/d';
 import { WIDGET_BASE_TYPE } from '../../../src/core/Registry';
 import { VNode, WidgetMetaConstructor, MetaBase } from '../../../src/core/interfaces';

--- a/tests/core/unit/decorators/diffProperty.ts
+++ b/tests/core/unit/decorators/diffProperty.ts
@@ -4,7 +4,8 @@ const { assert } = intern.getPlugin('chai');
 import { PropertyChangeRecord } from './../../../../src/core/interfaces';
 import { always, ignore } from './../../../../src/core/diff';
 import { diffProperty } from './../../../../src/core/decorators/diffProperty';
-import { WidgetBase, widgetInstanceMap } from './../../../../src/core/WidgetBase';
+import { WidgetBase } from './../../../../src/core/WidgetBase';
+import { widgetInstanceMap } from './../../../../src/core/vdom';
 
 interface TestProperties {
 	id?: string;

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -6,10 +6,10 @@ import { add } from '../../../src/has/has';
 import { createResolvers } from './../support/util';
 import sendEvent from '../support/sendEvent';
 
-import { create, renderer, invalidator } from '../../../src/core/vdom';
+import { create, renderer, invalidator, widgetInstanceMap } from '../../../src/core/vdom';
 import { v, w, dom as d, VNODE } from '../../../src/core/d';
 import { VNode, DNode, DomVNode } from '../../../src/core/interfaces';
-import { WidgetBase, widgetInstanceMap } from '../../../src/core/WidgetBase';
+import { WidgetBase } from '../../../src/core/WidgetBase';
 import Registry from '../../../src/core/Registry';
 import { I18nMixin } from '../../../src/core/mixins/I18n';
 import registry from '../../../src/core/decorators/registry';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Moves the instance map to `vdom` from `WidgetBase` as `vdom` doesn't need to depend on `WidgetBase` at all anymore.