### PR TITLE
report not found selectors in assertion template methods

### DIFF
--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -119,6 +119,14 @@ describe('assertionTemplate', () => {
 		h.expect(propertyAssertion);
 	});
 
+	it('should throw an error when selector is not found', () => {
+		const h = harness(() => w(MyWidget, {}));
+		assert.throws(
+			() => h.expect(baseAssertion.setProperty('~cant-spell', 'foo', 'b')),
+			'Node not found for selector "~cant-spell"'
+		);
+	});
+
 	it('should be immutable', () => {
 		const fooAssertion = baseAssertion
 			.setChildren(':root', ['foo'])


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Reports the missing selector in failed assertion template methods. Useful when debugging tests because it provides an indication of what part of the developer's code isn't working.

Resolves #353
