### PR TITLE
Harness needs to support widgets with typed children

### DIFF
--- a/src/testing/harness.ts
+++ b/src/testing/harness.ts
@@ -1,6 +1,6 @@
 import assertRender from './support/assertRender';
 import { decorateNodes, select } from './support/selector';
-import { WNode, DNode, WidgetBaseTypes, Constructor, VNode } from '../core/interfaces';
+import { WNode, DNode, Constructor, VNode } from '../core/interfaces';
 import { WidgetBase } from '../core/WidgetBase';
 
 export interface CustomComparator {
@@ -43,10 +43,7 @@ export interface HarnessAPI {
 	getRender: GetRender;
 }
 
-export function harness(
-	renderFunc: () => WNode<WidgetBaseTypes>,
-	customComparator: CustomComparator[] = []
-): HarnessAPI {
+export function harness(renderFunc: () => WNode, customComparator: CustomComparator[] = []): HarnessAPI {
 	let invalidated = true;
 	let wNode = renderFunc();
 	let widget: WidgetBase;

--- a/tests/testing/unit/harness.ts
+++ b/tests/testing/unit/harness.ts
@@ -6,7 +6,7 @@ import { WidgetBase } from '../../../src/core/WidgetBase';
 import { v, w, isVNode } from '../../../src/core/vdom';
 import Set from '../../../src/shim/Set';
 import Map from '../../../src/shim/Map';
-import { VNode, WNode } from '../../../src/core/interfaces';
+import { VNode, WNode, WidgetProperties } from '../../../src/core/interfaces';
 
 const noop: any = () => {};
 
@@ -114,6 +114,12 @@ describe('harness', () => {
 		it('Should support deferred properties', () => {
 			const h = harness(() => w(MyDeferredWidget, {}));
 			h.expect(() => v('div', { classes: ['root', 'other'], styles: { marginTop: '100px' } }));
+		});
+
+		it('Should support widgets that have typed children', () => {
+			class WidgetWithTypedChildren extends WidgetBase<WidgetProperties, WNode<MyDeferredWidget>> {}
+			const h = harness(() => w(WidgetWithTypedChildren, {}, [w(MyDeferredWidget, {})]));
+			h.expect(() => v('div', [w(MyDeferredWidget, {})]));
 		});
 
 		it('expect partial for WNode constructor', () => {

--- a/tests/testing/unit/support/assertRender.ts
+++ b/tests/testing/unit/support/assertRender.ts
@@ -38,7 +38,7 @@ class WidgetWithMap extends WidgetBase {
 }
 
 function getExpectedError() {
-	const widgetName = (MockWidget as any).name || 'Widget-4';
+	const widgetName = (MockWidget as any).name || 'Widget-5';
 	return `
 v("div", {
 (A)	"classes": "class",


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The typings for the harness cause issues with widgets that have typed children.