### PR TITLE
Cache Middleware

### DIFF
--- a/src/core/middleware/cache.ts
+++ b/src/core/middleware/cache.ts
@@ -1,0 +1,24 @@
+import { create, destroy } from '../vdom';
+import Map from '../../shim/Map';
+
+const factory = create({ destroy });
+
+export const cache = factory(({ middleware: { destroy } }) => {
+	const cacheMap = new Map<string, any>();
+	destroy(() => {
+		cacheMap.clear();
+	});
+	return {
+		get<T = any>(key: any): T | null {
+			return cacheMap.get(key);
+		},
+		set<T = any>(key: any, value: T): void {
+			cacheMap.set(key, value);
+		},
+		clear(): void {
+			cacheMap.clear();
+		}
+	};
+});
+
+export default cache;

--- a/tests/core/unit/all.ts
+++ b/tests/core/unit/all.ts
@@ -17,3 +17,4 @@ import './NodeHandler';
 import './meta/all';
 import './vdom';
 import './registerCustomElement';
+import './middleware/all';

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -1,0 +1,1 @@
+import './cache';

--- a/tests/core/unit/middleware/cache.ts
+++ b/tests/core/unit/middleware/cache.ts
@@ -1,0 +1,42 @@
+const { it, describe, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { stub } from 'sinon';
+
+import cacheMiddleware from '../../../../src/core/middleware/cache';
+
+const destroyStub = stub();
+
+describe('cache middleware', () => {
+	afterEach(() => {
+		destroyStub.resetHistory();
+	});
+
+	it('should be able to store and retrieve values from the cache', () => {
+		const { callback } = cacheMiddleware();
+		const cache = callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub
+			},
+			properties: {}
+		});
+		assert.isUndefined(cache.get('test'));
+		cache.set('test', 'value');
+		assert.strictEqual(cache.get('test'), 'value');
+	});
+
+	it('should register destroy to clear the map', () => {
+		const { callback } = cacheMiddleware();
+		const cache = callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub
+			},
+			properties: {}
+		});
+		cache.set('test', 'value');
+		assert.isTrue(destroyStub.calledOnce);
+		destroyStub.getCall(0).callArg(0);
+		assert.isUndefined(cache.get('test'));
+	});
+});

--- a/tests/core/unit/middleware/cache.ts
+++ b/tests/core/unit/middleware/cache.ts
@@ -39,4 +39,20 @@ describe('cache middleware', () => {
 		destroyStub.getCall(0).callArg(0);
 		assert.isUndefined(cache.get('test'));
 	});
+
+	it('should be able to clear the cache', () => {
+		const { callback } = cacheMiddleware();
+		const cache = callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub
+			},
+			properties: {}
+		});
+		assert.isUndefined(cache.get('test'));
+		cache.set('test', 'value');
+		assert.strictEqual(cache.get('test'), 'value');
+		cache.clear();
+		assert.isUndefined(cache.get('test'));
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds a basic cache middleware for setting and getting values.

Resolves #366 
