### PR TITLE
Injector Middleware

### DIFF
--- a/src/core/middleware/injector.ts
+++ b/src/core/middleware/injector.ts
@@ -1,0 +1,31 @@
+import { create, getRegistry, invalidator } from '../vdom';
+import { RegistryLabel } from '../interfaces';
+
+const injectorFactory = create({ getRegistry, invalidator });
+
+export const injector = injectorFactory(({ middleware: { getRegistry, invalidator } }) => {
+	const registry = getRegistry();
+	return {
+		subscribe(label: RegistryLabel, callback: Function = invalidator) {
+			if (registry) {
+				const item = registry.getInjector(label);
+				if (item) {
+					item.invalidator.on('invalidate', () => {
+						callback();
+					});
+				}
+			}
+		},
+		get<T>(label: RegistryLabel): T | null {
+			if (registry) {
+				const item = registry.getInjector<T>(label);
+				if (item) {
+					return item.injector();
+				}
+			}
+			return null;
+		}
+	};
+});
+
+export default injector;

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -1,1 +1,2 @@
 import './cache';
+import './injector';

--- a/tests/core/unit/middleware/injector.ts
+++ b/tests/core/unit/middleware/injector.ts
@@ -1,0 +1,154 @@
+const { it, describe, afterEach, beforeEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { sandbox } from 'sinon';
+
+import injectorMiddleware from '../../../../src/core/middleware/injector';
+
+const sb = sandbox.create();
+const getInjector = sb.stub();
+const registry = {
+	getInjector
+};
+const getRegistry = sb.stub();
+const invalidator = sb.stub();
+const eventStub = sb.stub();
+
+describe('injector middleware', () => {
+	beforeEach(() => {
+		getRegistry.returns(registry);
+	});
+
+	afterEach(() => {
+		sb.resetHistory();
+	});
+
+	describe('get', () => {
+		it('should should return the injector if it exists', () => {
+			registry.getInjector.returns({
+				injector() {
+					return 'Test Injector';
+				}
+			});
+			const { callback } = injectorMiddleware();
+			const injector = callback({
+				id: 'test',
+				middleware: {
+					getRegistry,
+					invalidator
+				},
+				properties: {}
+			});
+			const injectorItem = injector.get<string>('test');
+			assert.strictEqual(injectorItem, 'Test Injector');
+		});
+
+		it('should return null if there is no registry item', () => {
+			getInjector.returns(null);
+			const { callback } = injectorMiddleware();
+			const injector = callback({
+				id: 'test',
+				middleware: {
+					getRegistry,
+					invalidator
+				},
+				properties: {}
+			});
+			const injectorItem = injector.get<string>('test');
+			assert.isNull(injectorItem);
+		});
+
+		it('should return null if there is no registry', () => {
+			getRegistry.returns(null);
+			const { callback } = injectorMiddleware();
+			const injector = callback({
+				id: 'test',
+				middleware: {
+					getRegistry,
+					invalidator
+				},
+				properties: {}
+			});
+			const injectorItem = injector.get<string>('test');
+			assert.isNull(injectorItem);
+		});
+	});
+	describe('subscribe', () => {
+		it('should subscribe the widgets invalidator to the injectors invalidate event', () => {
+			registry.getInjector.returns({
+				invalidator: {
+					on: eventStub
+				}
+			});
+			const { callback } = injectorMiddleware();
+			const injector = callback({
+				id: 'test',
+				middleware: {
+					getRegistry,
+					invalidator
+				},
+				properties: {}
+			});
+			injector.subscribe('test');
+			assert.isTrue(eventStub.calledOnce);
+			eventStub.getCall(0).callArg(1);
+			assert.isTrue(invalidator.calledOnce);
+		});
+
+		it('should subscribe a custom function to the injectors invalidate event', () => {
+			registry.getInjector.returns({
+				invalidator: {
+					on: eventStub
+				}
+			});
+			const { callback } = injectorMiddleware();
+			const injector = callback({
+				id: 'test',
+				middleware: {
+					getRegistry,
+					invalidator
+				},
+				properties: {}
+			});
+			const customCallback = sb.stub();
+			injector.subscribe('test', customCallback);
+			assert.isTrue(eventStub.calledOnce);
+			eventStub.getCall(0).callArg(1);
+			assert.isTrue(customCallback.calledOnce);
+		});
+
+		it('should ignore the subscription if there is no registry item', () => {
+			getInjector.returns(null);
+			const { callback } = injectorMiddleware();
+			const injector = callback({
+				id: 'test',
+				middleware: {
+					getRegistry,
+					invalidator
+				},
+				properties: {}
+			});
+			injector.subscribe('test');
+			assert.isTrue(eventStub.notCalled);
+		});
+
+		it('should ignore the subscription if there is no registry', () => {
+			getRegistry.returns(null);
+			registry.getInjector.returns({
+				invalidator: {
+					on: eventStub
+				}
+			});
+			const { callback } = injectorMiddleware();
+			const injector = callback({
+				id: 'test',
+				middleware: {
+					getRegistry,
+					invalidator
+				},
+				properties: {}
+			});
+			injector.subscribe('test');
+			assert.isTrue(eventStub.notCalled);
+		});
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Injector middleware that supports returning an injector from the registry and subscribing to the injectors invalidator event.

Resolves #369 
