### PR TITLE
Defer Middleware

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1775,7 +1775,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		return processResult;
 	}
 
-	function _updateWidget({ current, next }: UpdateWidgetInstruction): ProcessResult | false {
+	function _updateWidget({ current, next }: UpdateWidgetInstruction): ProcessResult {
 		current = _idToWrapperMap.get(current.id) || current;
 		const { instance, domNode, hasAnimations } = current;
 		let {

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -9,6 +9,7 @@ import sendEvent from '../support/sendEvent';
 import {
 	create,
 	renderer,
+	defer,
 	destroy,
 	getRegistry,
 	invalidator,
@@ -3319,6 +3320,79 @@ jsdomDescribe('vdom', () => {
 						const div = document.createElement('div');
 						r.mount({ domNode: div, registry });
 						assert.strictEqual(div.outerHTML, '<div>hello world</div>');
+					});
+				});
+
+				describe('defer', () => {
+					it('should pause and resume rendering when merging', () => {
+						const iframe = document.createElement('iframe');
+						document.body.appendChild(iframe);
+						iframe.contentDocument!.write(`<div><div>Hello Dom Foo</div><div>Hello Dom Bar</div></div>`);
+						iframe.contentDocument!.close();
+						const createWidget = create({ defer, invalidator });
+						let shouldDefer = true;
+						let invalidateFoo: any;
+						const Foo = createWidget(function Foo({ middleware }) {
+							invalidateFoo = middleware.invalidator;
+							shouldDefer ? middleware.defer.pause() : middleware.defer.resume();
+							return v('div', ['Hello Foo']);
+						});
+						const Bar = createWidget(function Foo() {
+							return v('div', ['Hello Bar']);
+						});
+
+						const App = createWidget(function App() {
+							return v('div', [Foo({}), Bar({})]);
+						});
+						const r = renderer(() => App({}));
+						r.mount({ domNode: iframe.contentDocument!.body });
+						assert.strictEqual(
+							iframe.contentDocument!.body.outerHTML,
+							'<body><div><div>Hello Dom Foo</div><div>Hello Dom Bar</div></div></body>'
+						);
+						shouldDefer = false;
+						invalidateFoo();
+						resolvers.resolve();
+						assert.strictEqual(
+							iframe.contentDocument!.body.outerHTML,
+							'<body><div><div>Hello Foo</div><div>Hello Bar</div></div></body>'
+						);
+						document.body.removeChild(iframe);
+					});
+
+					it('should not pause and resume rendering not merging', () => {
+						const iframe = document.createElement('iframe');
+						document.body.appendChild(iframe);
+						iframe.contentDocument!.close();
+						const createWidget = create({ defer, invalidator });
+						let shouldDefer = true;
+						let invalidateFoo: any;
+						const Foo = createWidget(function Foo({ middleware }) {
+							invalidateFoo = middleware.invalidator;
+							shouldDefer ? middleware.defer.pause() : middleware.defer.resume();
+							return v('div', ['Hello Foo']);
+						});
+						const Bar = createWidget(function Foo() {
+							return v('div', ['Hello Bar']);
+						});
+
+						const App = createWidget(function App() {
+							return v('div', [Foo({}), Bar({})]);
+						});
+						const r = renderer(() => App({}));
+						r.mount({ domNode: iframe.contentDocument!.body });
+						assert.strictEqual(
+							iframe.contentDocument!.body.outerHTML,
+							'<body><div><div>Hello Foo</div><div>Hello Bar</div></div></body>'
+						);
+						shouldDefer = false;
+						invalidateFoo();
+						resolvers.resolve();
+						assert.strictEqual(
+							iframe.contentDocument!.body.outerHTML,
+							'<body><div><div>Hello Foo</div><div>Hello Bar</div></div></body>'
+						);
+						document.body.removeChild(iframe);
 					});
 				});
 			});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

A middleware that allows the rendering engine to control whether a widget is rendered using `pause` and `resume`. When performing a merge this pauses the rest of the vdom processing until the widget is set back to "resume" in order to ensure that the correct DOM nodes are matched and hydrated into the tree. In the non merge scenario the rest of the application is rendered, only skipping the widget that has been set to "pause".

```ts
import { create, defer, invalidator } from '@dojo/framework/core/vdom';
import { cache } from '@dojo/framework/core/middleware/cache';

const factory = create({ defer, cache });

const myExampleMiddleware = factory(({ middleware: { defer, cache, invalidator }}) => {
    return {
        get(value: string) {
            // check a cache
            const cachedValue = cache.get(value);
            if (cachedValue) {
                return cachedValue;
            }
            // if no cache, do something that returns a promise
            const promise = foo(value);
            // pause the rendering of the widget
            defer.pause();
            promise.then((result) => {
                // set cache
                cache.set(value, result);
                // resume rendering for widget
                defer.resume();
                // invalidate for a re-render
                invalidator();
            });
            return null;
        }
    };
});
```

resolves #379 