### PR TITLE
Block Middleware

### DIFF
--- a/src/core/middleware/block.ts
+++ b/src/core/middleware/block.ts
@@ -1,0 +1,43 @@
+import Map from '../../shim/Map';
+import { create, invalidator, destroy, defer } from '../vdom';
+
+const blockFactory = create({ invalidator, destroy, defer });
+
+export const block = blockFactory(({ middleware: { invalidator, destroy, defer } }) => {
+	const moduleMap = new Map();
+	destroy(() => {
+		moduleMap.clear();
+	});
+	return {
+		run<T extends (...args: any[]) => any>(module: T) {
+			return (...args: any[]): (ReturnType<T> extends Promise<infer U> ? U : ReturnType<T>) | null => {
+				const argsString = JSON.stringify(args);
+				let valueMap = moduleMap.get(module);
+				if (valueMap) {
+					const cachedValue = valueMap.get(argsString);
+					if (cachedValue !== undefined) {
+						return cachedValue;
+					}
+				}
+				const result = module(...args);
+				if (result && typeof result.then === 'function') {
+					defer.pause();
+					result.then((result: any) => {
+						defer.resume();
+						valueMap = moduleMap.get(module);
+						if (!valueMap) {
+							valueMap = new Map();
+							moduleMap.set(module, valueMap);
+						}
+						valueMap.set(argsString, result);
+						invalidator();
+					});
+					return null;
+				}
+				return result;
+			};
+		}
+	};
+});
+
+export default block;

--- a/src/core/middleware/block.ts
+++ b/src/core/middleware/block.ts
@@ -12,13 +12,12 @@ export const block = blockFactory(({ middleware: { cache, icache, defer } }) => 
 				const argsString = JSON.stringify(args);
 				const moduleId = cache.get(module) || id++;
 				cache.set(module, moduleId);
-				const cachedValue = icache.getOrSet(`${moduleId}-${argsString}`, () => {
+				const cachedValue = icache.getOrSet(`${moduleId}-${argsString}`, async () => {
 					const run = Promise.resolve(module(...args));
 					defer.pause();
-					return run.then((result: any) => {
-						defer.resume();
-						return result;
-					});
+					const result = await run;
+					defer.resume();
+					return result;
 				});
 				return cachedValue || null;
 			};

--- a/src/core/middleware/block.ts
+++ b/src/core/middleware/block.ts
@@ -13,7 +13,7 @@ export const block = blockFactory(({ middleware: { cache, icache, defer } }) => 
 				const moduleId = cache.get(module) || id++;
 				cache.set(module, moduleId);
 				const cachedValue = icache.getOrSet(`${moduleId}-${argsString}`, async () => {
-					const run = Promise.resolve(module(...args));
+					const run = module(...args);
 					defer.pause();
 					const result = await run;
 					defer.resume();

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -1,3 +1,4 @@
+import './block';
 import './cache';
 import './icache';
 import './injector';

--- a/tests/core/unit/middleware/block.ts
+++ b/tests/core/unit/middleware/block.ts
@@ -1,0 +1,135 @@
+const { it, describe, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { sandbox } from 'sinon';
+
+import blockMiddleware from '../../../../src/core/middleware/block';
+
+const sb = sandbox.create();
+const destroyStub = sb.stub();
+const invalidatorStub = sb.stub();
+const deferStub = {
+	pause: sb.stub(),
+	resume: sb.stub()
+};
+const { callback } = blockMiddleware();
+
+describe('block middleware', () => {
+	afterEach(() => {
+		sb.resetHistory();
+	});
+
+	it('block', () => {
+		const block = callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				invalidator: invalidatorStub,
+				defer: deferStub
+			},
+			properties: {}
+		});
+
+		let resolverOne: any;
+		let resolverTwo: any;
+		let resolverThree: any;
+		const promiseOne = new Promise<string>((resolve) => {
+			resolverOne = resolve;
+		});
+		const promiseTwo = new Promise<string>((resolve) => {
+			resolverTwo = resolve;
+		});
+		const promiseThree = new Promise<string>((resolve) => {
+			resolverThree = resolve;
+		});
+		function testModule(a: string) {
+			if (a === 'test') {
+				return promiseOne;
+			}
+			return promiseThree;
+		}
+
+		function testModuleOther(a: string) {
+			return promiseTwo;
+		}
+
+		const resultOne = block.run(testModule)('test');
+		assert.isTrue(deferStub.pause.calledOnce);
+		const resultTwo = block.run(testModuleOther)('test');
+		assert.isTrue(deferStub.pause.calledTwice);
+		const resultThree = block.run(testModule)('other');
+		assert.isTrue(deferStub.pause.calledThrice);
+		assert.isNull(resultOne);
+		assert.isNull(resultTwo);
+		assert.isNull(resultThree);
+		assert.isTrue(deferStub.resume.notCalled);
+
+		resolverOne('resultOne');
+		resolverTwo('resultTwo');
+		resolverThree('resultThree');
+		return Promise.all([promiseOne, promiseTwo, promiseThree]).then(() => {
+			assert.isTrue(deferStub.resume.calledThrice);
+			assert.isTrue(invalidatorStub.calledThrice);
+			const resultOne = block.run(testModule)('test');
+			assert.strictEqual(resultOne, 'resultOne');
+			const resultTwo = block.run(testModuleOther)('test');
+			assert.strictEqual(resultTwo, 'resultTwo');
+			const resultThree = block.run(testModule)('other');
+			assert.strictEqual(resultThree, 'resultThree');
+			assert.isTrue(deferStub.pause.calledThrice);
+		});
+	});
+
+	it('Should return the result immediately when sync', () => {
+		const block = callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				invalidator: invalidatorStub,
+				defer: deferStub
+			},
+			properties: {}
+		});
+
+		function testModule(a: string) {
+			return 'sync';
+		}
+
+		let resultOne = block.run(testModule)('test');
+		assert.strictEqual(resultOne, 'sync');
+		resultOne = block.run(testModule)('test');
+		assert.strictEqual(resultOne, 'sync');
+	});
+
+	it('Should register destroy to clear module map', () => {
+		const block = callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				invalidator: invalidatorStub,
+				defer: deferStub
+			},
+			properties: {}
+		});
+
+		assert.isTrue(destroyStub.calledOnce);
+
+		let resolverOne: any;
+		const promiseOne = new Promise<string>((resolve) => {
+			resolverOne = resolve;
+		});
+		function testModule(a: string) {
+			return promiseOne;
+		}
+
+		let resultOne = block.run(testModule)('test');
+		assert.isNull(resultOne);
+		resolverOne('resultOne');
+		return promiseOne.then(() => {
+			resultOne = block.run(testModule)('test');
+			assert.strictEqual(resultOne, 'resultOne');
+			destroyStub.getCall(0).callArg(0);
+			resultOne = block.run(testModule)('test');
+			assert.isNull(resultOne);
+		});
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Middleware to be used with Dojo blocks, as per the existing meta runs blocks and caches the results for unique calls.

Resolves #370 
