### PR TITLE
Invalidating Cache Middleware

### DIFF
--- a/src/core/middleware/cache.ts
+++ b/src/core/middleware/cache.ts
@@ -9,7 +9,7 @@ export const cache = factory(({ middleware: { destroy } }) => {
 		cacheMap.clear();
 	});
 	return {
-		get<T = any>(key: any): T | null {
+		get<T = any>(key: any): T | undefined {
 			return cacheMap.get(key);
 		},
 		set<T = any>(key: any, value: T): void {

--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -10,12 +10,19 @@ interface CacheWrapper<T = any> {
 
 export const icache = factory(({ middleware: { invalidator, cache } }) => {
 	return {
-		getOrSet<T = any>(key: any, value?: any): T | undefined {
+		getOrSet<T = any>(key: any, value: any): T | undefined {
 			let cachedValue = cache.get<CacheWrapper<T>>(key);
-			if (!cachedValue && value) {
+			if (!cachedValue) {
 				this.set(key, value);
 			}
 			cachedValue = cache.get<CacheWrapper<T>>(key);
+			if (!cachedValue || cachedValue.status === 'pending') {
+				return undefined;
+			}
+			return cachedValue.value;
+		},
+		get<T = any>(key: any): T | undefined {
+			const cachedValue = cache.get<CacheWrapper<T>>(key);
 			if (!cachedValue || cachedValue.status === 'pending') {
 				return undefined;
 			}

--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -1,0 +1,63 @@
+import { create, invalidator } from '../vdom';
+import cache from './cache';
+
+const factory = create({ cache, invalidator });
+
+interface CacheWrapper<T = any> {
+	status: 'pending' | 'resolved';
+	value: T;
+}
+
+export const icache = factory(({ middleware: { invalidator, cache } }) => {
+	return {
+		getOrSet<T = any>(key: any, value?: any): T | undefined {
+			let cachedValue = cache.get<CacheWrapper<T>>(key);
+			if (cachedValue && cachedValue.status !== 'pending') {
+				return cachedValue.value;
+			} else if (cachedValue && cachedValue.status === 'pending') {
+				return undefined;
+			}
+			if (value) {
+				this.set(key, value);
+				cachedValue = cache.get<CacheWrapper<T>>(key);
+				if (!cachedValue || cachedValue.status === 'pending') {
+					return undefined;
+				}
+				return cachedValue.value;
+			}
+			return undefined;
+		},
+		set(key: any, value: any): void {
+			if (typeof value === 'function') {
+				value = value();
+				if (value && typeof value.then === 'function') {
+					cache.set(key, {
+						status: 'pending',
+						value
+					});
+					value.then((result: any) => {
+						const cachedValue = cache.get<CacheWrapper<any>>(key);
+						if (cachedValue && cachedValue.value === value) {
+							cache.set(key, {
+								status: 'resolved',
+								value: result
+							});
+							invalidator();
+						}
+					});
+					return;
+				}
+			}
+			cache.set(key, {
+				status: 'resolved',
+				value
+			});
+			invalidator();
+		},
+		clear(): void {
+			cache.clear();
+		}
+	};
+});
+
+export default icache;

--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -12,20 +12,14 @@ export const icache = factory(({ middleware: { invalidator, cache } }) => {
 	return {
 		getOrSet<T = any>(key: any, value?: any): T | undefined {
 			let cachedValue = cache.get<CacheWrapper<T>>(key);
-			if (cachedValue && cachedValue.status !== 'pending') {
-				return cachedValue.value;
-			} else if (cachedValue && cachedValue.status === 'pending') {
+			if (!cachedValue && value) {
+				this.set(key, value);
+			}
+			cachedValue = cache.get<CacheWrapper<T>>(key);
+			if (!cachedValue || cachedValue.status === 'pending') {
 				return undefined;
 			}
-			if (value) {
-				this.set(key, value);
-				cachedValue = cache.get<CacheWrapper<T>>(key);
-				if (!cachedValue || cachedValue.status === 'pending') {
-					return undefined;
-				}
-				return cachedValue.value;
-			}
-			return undefined;
+			return cachedValue.value;
 		},
 		set(key: any, value: any): void {
 			if (typeof value === 'function') {

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -1,2 +1,3 @@
 import './cache';
+import './icache';
 import './injector';

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -28,7 +28,7 @@ describe('icache middleware', () => {
 			},
 			properties: {}
 		});
-		assert.isUndefined(icache.getOrSet('test'));
+		assert.isUndefined(icache.get('test'));
 		assert.strictEqual('test', icache.getOrSet('test', 'test'));
 		assert.isTrue(invalidatorStub.calledOnce);
 		assert.strictEqual('test-two', icache.getOrSet('test-two', () => 'test-two'));
@@ -93,9 +93,9 @@ describe('icache middleware', () => {
 			resolverTwo = resolve;
 		});
 		icache.set('test', () => promiseOne);
-		assert.isUndefined(icache.getOrSet('test'));
+		assert.isUndefined(icache.get('test'));
 		icache.set('test', () => promiseTwo);
-		assert.isUndefined(icache.getOrSet('test'));
+		assert.isUndefined(icache.get('test'));
 		resolverTwo('two');
 		return promiseTwo.then(() => {
 			assert.isTrue(invalidatorStub.calledOnce);
@@ -121,10 +121,10 @@ describe('icache middleware', () => {
 			},
 			properties: {}
 		});
-		assert.isUndefined(icache.getOrSet('test'));
+		assert.isUndefined(icache.get('test'));
 		icache.set('test', 'value');
-		assert.strictEqual(icache.getOrSet('test'), 'value');
+		assert.strictEqual(icache.get('test'), 'value');
 		icache.clear();
-		assert.isUndefined(icache.getOrSet('test'));
+		assert.isUndefined(icache.get('test'));
 	});
 });

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -1,0 +1,130 @@
+const { it, describe, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { sandbox } from 'sinon';
+
+import iCacheMiddleware from '../../../../src/core/middleware/icache';
+import cacheMiddleware from '../../../../src/core/middleware/cache';
+
+const sb = sandbox.create();
+const invalidatorStub = sb.stub();
+const { callback } = iCacheMiddleware();
+
+describe('icache middleware', () => {
+	afterEach(() => {
+		sb.resetHistory();
+	});
+
+	it('should invalidate when value is set to the cache', () => {
+		const cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: sb.stub() },
+			properties: {}
+		});
+		const icache = callback({
+			id: 'test',
+			middleware: {
+				cache,
+				invalidator: invalidatorStub
+			},
+			properties: {}
+		});
+		assert.isUndefined(icache.getOrSet('test'));
+		assert.strictEqual('test', icache.getOrSet('test', 'test'));
+		assert.isTrue(invalidatorStub.calledOnce);
+		assert.strictEqual('test-two', icache.getOrSet('test-two', () => 'test-two'));
+		assert.isTrue(invalidatorStub.calledTwice);
+	});
+
+	it('should invalidate when cache value is resolved and set resolved value as result', () => {
+		const cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: sb.stub() },
+			properties: {}
+		});
+		const icache = callback({
+			id: 'test',
+			middleware: {
+				cache,
+				invalidator: invalidatorStub
+			},
+			properties: {}
+		});
+		let resolverOne: any;
+		let resolverTwo: any;
+		const promiseOne = new Promise<string>((resolve) => {
+			resolverOne = resolve;
+		});
+		const promiseTwo = new Promise<string>((resolve) => {
+			resolverTwo = resolve;
+		});
+		assert.isUndefined(icache.getOrSet('test', () => promiseOne));
+		assert.isUndefined(icache.getOrSet('test', () => promiseTwo));
+		resolverTwo('two');
+		return promiseTwo.then(() => {
+			assert.isTrue(invalidatorStub.notCalled);
+			resolverOne('one');
+			return promiseOne.then(() => {
+				assert.isTrue(invalidatorStub.calledOnce);
+				assert.strictEqual('one', icache.getOrSet('test', () => promiseOne));
+			});
+		});
+	});
+
+	it('should invalidate allow cache value to replaced when calling set directly', () => {
+		const cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: sb.stub() },
+			properties: {}
+		});
+		const icache = callback({
+			id: 'test',
+			middleware: {
+				cache,
+				invalidator: invalidatorStub
+			},
+			properties: {}
+		});
+		let resolverOne: any;
+		let resolverTwo: any;
+		const promiseOne = new Promise<string>((resolve) => {
+			resolverOne = resolve;
+		});
+		const promiseTwo = new Promise<string>((resolve) => {
+			resolverTwo = resolve;
+		});
+		icache.set('test', () => promiseOne);
+		assert.isUndefined(icache.getOrSet('test'));
+		icache.set('test', () => promiseTwo);
+		assert.isUndefined(icache.getOrSet('test'));
+		resolverTwo('two');
+		return promiseTwo.then(() => {
+			assert.isTrue(invalidatorStub.calledOnce);
+			resolverOne('one');
+			return promiseOne.then(() => {
+				assert.isTrue(invalidatorStub.calledOnce);
+				assert.strictEqual('two', icache.getOrSet('test', () => promiseOne));
+			});
+		});
+	});
+
+	it('should be able to clear the cache', () => {
+		const cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: sb.stub() },
+			properties: {}
+		});
+		const icache = callback({
+			id: 'test',
+			middleware: {
+				cache,
+				invalidator: invalidatorStub
+			},
+			properties: {}
+		});
+		assert.isUndefined(icache.getOrSet('test'));
+		icache.set('test', 'value');
+		assert.strictEqual(icache.getOrSet('test'), 'value');
+		icache.clear();
+		assert.isUndefined(icache.getOrSet('test'));
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Built on top of the `cache` middleware, the `icache` middleware manages lazily value resolution and invalidation.

`getOrSet`: Gets an existing resolved value if it exists in the cache, otherwise sets the value passed.
`set`: Sets the value passed, if the value is a function it will be called and the returned result stored in the cache, or if the result is a promise then it will be added as pending and when the promise is resolved will update the value and invalidate.
`get`: Gets the value for the key or returns undefined if there is no entry or the result is pending.
