### PR TITLE
Resize Middleware

### DIFF
--- a/src/core/middleware/resize.ts
+++ b/src/core/middleware/resize.ts
@@ -1,11 +1,10 @@
-import ResizeObserver from '../../shim/ResizeObserver';
-import { create, node, invalidator, destroy } from '../vdom';
-import { cache } from './cache';
-import { ContentRect } from '../meta/Resize';
+import ResizeObserver, { DOMRectReadOnly } from '../../shim/ResizeObserver';
+import { create, node, destroy } from '../vdom';
+import { icache } from './icache';
 
-const factory = create({ node, invalidator, destroy, cache });
+const factory = create({ node, destroy, icache });
 
-export const resize = factory(({ middleware: { node, invalidator, destroy, cache } }) => {
+export const resize = factory(({ middleware: { node, destroy, icache } }) => {
 	const keys: (string | number)[] = [];
 	const handles: Function[] = [];
 	destroy(() => {
@@ -15,7 +14,7 @@ export const resize = factory(({ middleware: { node, invalidator, destroy, cache
 		}
 	});
 	return {
-		get(key: string | number): ContentRect | null {
+		get(key: string | number): DOMRectReadOnly | null {
 			const domNode = node.get(key);
 			if (!domNode) {
 				return null;
@@ -24,13 +23,12 @@ export const resize = factory(({ middleware: { node, invalidator, destroy, cache
 			if (keys.indexOf(key) === -1) {
 				keys.push(key);
 				const resizeObserver = new ResizeObserver(([entry]) => {
-					cache.set(key, entry.contentRect);
-					invalidator();
+					icache.set(key, entry.contentRect);
 				});
 				resizeObserver.observe(domNode);
 				handles.push(() => resizeObserver.disconnect());
 			}
-			return cache.get<ContentRect>(key) || null;
+			return icache.get<DOMRectReadOnly>(key) || null;
 		}
 	};
 });

--- a/src/core/middleware/resize.ts
+++ b/src/core/middleware/resize.ts
@@ -1,0 +1,38 @@
+import ResizeObserver from '../../shim/ResizeObserver';
+import { create, node, invalidator, destroy } from '../vdom';
+import { cache } from './cache';
+import { ContentRect } from '../meta/Resize';
+
+const factory = create({ node, invalidator, destroy, cache });
+
+export const resize = factory(({ middleware: { node, invalidator, destroy, cache } }) => {
+	const keys: (string | number)[] = [];
+	const handles: Function[] = [];
+	destroy(() => {
+		let handle: any;
+		while ((handle = handles.pop())) {
+			handle && handle();
+		}
+	});
+	return {
+		get(key: string | number): ContentRect | null {
+			const domNode = node.get(key);
+			if (!domNode) {
+				return null;
+			}
+
+			if (keys.indexOf(key) === -1) {
+				keys.push(key);
+				const resizeObserver = new ResizeObserver(([entry]) => {
+					cache.set(key, entry.contentRect);
+					invalidator();
+				});
+				resizeObserver.observe(domNode);
+				handles.push(() => resizeObserver.disconnect());
+			}
+			return cache.get<ContentRect>(key) || null;
+		}
+	};
+});
+
+export default resize;

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -75,7 +75,7 @@ export interface WidgetMeta {
 	registryHandler: RegistryHandler;
 	properties: any;
 	children?: DNode[];
-	nodeMap: Map<string | number, Node>;
+	nodeMap: Map<string | number, HTMLElement>;
 	destroyMap: Map<string, () => void>;
 	deferRefs: number;
 	diffMap: Map<string, (current: any, next: any) => void>;
@@ -699,7 +699,7 @@ const requestedDomNodes = new Set();
 let wrapperId = 0;
 let metaId = 0;
 
-function addNodeToMap(id: string, key: string | number, node: Node) {
+function addNodeToMap(id: string, key: string | number, node: HTMLElement) {
 	const widgetMeta = widgetMetaMap.get(id);
 	if (widgetMeta) {
 		const existingNode = widgetMeta.nodeMap.get(key);
@@ -736,7 +736,7 @@ export const invalidator = factory(({ id }) => {
 
 export const node = factory(({ id }) => {
 	return {
-		get(key: string | number) {
+		get(key: string | number): HTMLElement | null {
 			const [widgetId] = id.split('-');
 			const widgetMeta = widgetMetaMap.get(widgetId);
 			if (widgetMeta) {
@@ -1416,7 +1416,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 						const instanceData = widgetInstanceMap.get(owningWrapper.instance);
 						instanceData && instanceData.nodeHandler.add(domNode as HTMLElement, `${node.properties.key}`);
 					} else {
-						addNodeToMap(owningWrapper.id, node.properties.key, domNode!);
+						addNodeToMap(owningWrapper.id, node.properties.key, domNode as HTMLElement);
 					}
 				}
 				item.next.inserted = true;

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -3,3 +3,4 @@ import './cache';
 import './icache';
 import './injector';
 import './intersection';
+import './resize';

--- a/tests/core/unit/middleware/resize.ts
+++ b/tests/core/unit/middleware/resize.ts
@@ -1,0 +1,114 @@
+import global from '../../../../src/shim/global';
+const { it, describe, afterEach, beforeEach, before, after } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { sandbox, SinonStub } from 'sinon';
+
+import resizeMiddleware from '../../../../src/core/middleware/resize';
+import cacheMiddleware from '../../../../src/core/middleware/cache';
+
+const sb = sandbox.create();
+let resizeObserver: any;
+let resizeCallback: ([]: any[]) => void;
+const destroyStub = sb.stub();
+let observer: {
+	observe: SinonStub;
+	disconnect: SinonStub;
+};
+let globalResizeObserver: any;
+let nodeStub = {
+	get: sb.stub()
+};
+let invalidatorStub = sb.stub();
+
+describe('resize middleware', () => {
+	before(() => {
+		resizeObserver = sandbox
+			.create()
+			.stub()
+			.callsFake(function(callback: any) {
+				resizeCallback = callback;
+				return observer;
+			});
+		globalResizeObserver = global.ResizeObserver;
+		global.ResizeObserver = resizeObserver;
+	});
+
+	after(() => {
+		global.ResizeObserver = globalResizeObserver;
+	});
+
+	beforeEach(() => {
+		observer = {
+			observe: sb.stub(),
+			disconnect: sb.stub()
+		};
+	});
+
+	afterEach(() => {
+		sb.resetHistory();
+	});
+
+	it('Should observe node with with resize and invalidate when the resize callback is called ', () => {
+		const cache = cacheMiddleware().callback({
+			properties: {},
+			id: 'test-cache',
+			middleware: { destroy: destroyStub }
+		});
+		const { callback } = resizeMiddleware();
+		const resize = callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				cache,
+				invalidator: invalidatorStub,
+				node: nodeStub
+			},
+			properties: {}
+		});
+		assert.isNull(resize.get('key'));
+		const mockNode = sb.stub();
+		nodeStub.get.returns(mockNode);
+		assert.isNull(resize.get('key'));
+		assert.isTrue(observer.observe.calledOnce);
+		assert.isTrue(resizeObserver.calledOnce);
+		assert.isNull(resize.get('key'));
+		assert.isTrue(resizeObserver.calledOnce);
+		let contentRect: any = {
+			width: 10
+		};
+		resizeCallback([{ contentRect }]);
+		assert.isTrue(invalidatorStub.calledOnce);
+		assert.strictEqual(resize.get('key'), contentRect);
+		contentRect = {
+			width: 100
+		};
+		resizeCallback([{ contentRect }]);
+		assert.isTrue(invalidatorStub.calledTwice);
+		assert.strictEqual(resize.get('key'), contentRect);
+	});
+
+	it('Should register disconnect with destroy', () => {
+		const cache = cacheMiddleware().callback({
+			properties: {},
+			id: 'test-cache',
+			middleware: { destroy: sb.stub() }
+		});
+		const { callback } = resizeMiddleware();
+		const resize = callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				cache,
+				invalidator: invalidatorStub,
+				node: nodeStub
+			},
+			properties: {}
+		});
+
+		const mockNode = sb.stub();
+		nodeStub.get.returns(mockNode);
+		assert.isNull(resize.get('key'));
+		destroyStub.getCall(0).callArg(0);
+		assert.isTrue(observer.disconnect.calledOnce);
+	});
+});

--- a/tests/core/unit/middleware/resize.ts
+++ b/tests/core/unit/middleware/resize.ts
@@ -4,6 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import { sandbox, SinonStub } from 'sinon';
 
 import resizeMiddleware from '../../../../src/core/middleware/resize';
+import icacheMiddleware from '../../../../src/core/middleware/icache';
 import cacheMiddleware from '../../../../src/core/middleware/cache';
 
 const sb = sandbox.create();
@@ -54,13 +55,17 @@ describe('resize middleware', () => {
 			id: 'test-cache',
 			middleware: { destroy: destroyStub }
 		});
+		const icache = icacheMiddleware().callback({
+			properties: {},
+			id: 'test-cache',
+			middleware: { invalidator: invalidatorStub, cache }
+		});
 		const { callback } = resizeMiddleware();
 		const resize = callback({
 			id: 'test',
 			middleware: {
 				destroy: destroyStub,
-				cache,
-				invalidator: invalidatorStub,
+				icache,
 				node: nodeStub
 			},
 			properties: {}
@@ -93,13 +98,17 @@ describe('resize middleware', () => {
 			id: 'test-cache',
 			middleware: { destroy: sb.stub() }
 		});
+		const icache = icacheMiddleware().callback({
+			properties: {},
+			id: 'test-cache',
+			middleware: { invalidator: invalidatorStub, cache }
+		});
 		const { callback } = resizeMiddleware();
 		const resize = callback({
 			id: 'test',
 			middleware: {
 				destroy: destroyStub,
-				cache,
-				invalidator: invalidatorStub,
+				icache,
 				node: nodeStub
 			},
 			properties: {}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Middleware using ResizeObservers, invalidates when a node resizes and returns the ContentRect dimensions.

Resolves #383
