### PR TITLE
Intersection Middleware

### DIFF
--- a/src/core/meta/Intersection.ts
+++ b/src/core/meta/Intersection.ts
@@ -3,11 +3,11 @@ import Map from '../../shim/Map';
 import { Base } from './Base';
 import IntersectionObserver from '../../shim/IntersectionObserver';
 
-interface ExtendedIntersectionObserverEntry extends IntersectionObserverEntry {
+export interface ExtendedIntersectionObserverEntry extends IntersectionObserverEntry {
 	readonly isIntersecting: boolean;
 }
 
-interface IntersectionDetail extends IntersectionGetOptions {
+export interface IntersectionDetail extends IntersectionGetOptions {
 	entries: WeakMap<Element, IntersectionResult>;
 	observer: IntersectionObserver;
 }

--- a/src/core/middleware/intersection.ts
+++ b/src/core/middleware/intersection.ts
@@ -1,0 +1,78 @@
+import WeakMap from '../../shim/WeakMap';
+import IntersectionObserver from '../../shim/IntersectionObserver';
+import { create, node, invalidator, destroy } from '../vdom';
+import cache from './cache';
+import {
+	IntersectionResult,
+	IntersectionGetOptions,
+	IntersectionDetail,
+	ExtendedIntersectionObserverEntry
+} from '../meta/Intersection';
+
+const defaultIntersection: IntersectionResult = Object.freeze({
+	intersectionRatio: 0,
+	isIntersecting: false
+});
+
+const factory = create({ cache, node, invalidator, destroy });
+
+export const intersection = factory(({ middleware: { cache, node, invalidator, destroy } }) => {
+	const handles: Function[] = [];
+	destroy(() => {
+		let handle: any;
+		while ((handle = handles.pop())) {
+			handle && handle();
+		}
+	});
+
+	function _createDetails(options: IntersectionGetOptions, rootNode?: HTMLElement): IntersectionDetail {
+		const entries = new WeakMap<HTMLElement, ExtendedIntersectionObserverEntry>();
+		const observer = new IntersectionObserver(_onIntersect(entries), {
+			...options,
+			root: rootNode
+		});
+		const details = { observer, entries, ...options };
+		cache.set(JSON.stringify(options), details);
+		handles.push(() => observer.disconnect());
+		return details;
+	}
+
+	function _getDetails(options: IntersectionGetOptions = {}): IntersectionDetail | undefined {
+		return cache.get(JSON.stringify(options));
+	}
+
+	function _onIntersect(detailEntries: WeakMap<Element, IntersectionResult>) {
+		return (entries: ExtendedIntersectionObserverEntry[]) => {
+			for (const { intersectionRatio, isIntersecting, target } of entries) {
+				detailEntries.set(target, { intersectionRatio, isIntersecting });
+			}
+			invalidator();
+		};
+	}
+
+	return {
+		get(key: string | number, options: IntersectionGetOptions = {}): IntersectionResult {
+			let rootNode: HTMLElement | undefined;
+			if (options.root) {
+				rootNode = node.get(options.root) as HTMLElement;
+				if (!rootNode) {
+					return defaultIntersection;
+				}
+			}
+			const domNode = node.get(key) as HTMLElement | null;
+			if (!domNode) {
+				return defaultIntersection;
+			}
+
+			let details = _getDetails(options) || _createDetails(options, rootNode);
+			if (!details.entries.get(domNode)) {
+				details.entries.set(domNode, defaultIntersection);
+				details.observer.observe(domNode);
+			}
+
+			return details.entries.get(domNode) || defaultIntersection;
+		}
+	};
+});
+
+export default intersection;

--- a/tests/core/support/jsdom-plugin.ts
+++ b/tests/core/support/jsdom-plugin.ts
@@ -67,6 +67,7 @@ intern.registerPlugin('jsdom', async () => {
 			}
 		});
 	};
+	initialize();
 
 	const uninitialize = () => {
 		global.document = global.window = global.Element = global.requestAnimationFrame = global.cancelAnimationFrame = global.IntersectionObserver = global.fakeActiveElement = undefined;

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -1,3 +1,4 @@
 import './cache';
 import './icache';
 import './injector';
+import './intersection';

--- a/tests/core/unit/middleware/intersection.ts
+++ b/tests/core/unit/middleware/intersection.ts
@@ -1,0 +1,231 @@
+const { it, afterEach, before, after } = intern.getInterface('bdd');
+const { describe } = intern.getPlugin('jsdom');
+const { assert } = intern.getPlugin('chai');
+import { sandbox, SinonStub, SinonSpy, stub } from 'sinon';
+import global from '../../../../src/shim/global';
+import cacheMiddleware from '../../../../src/core/middleware/cache';
+import intersectionMiddleware from '../../../../src/core/middleware/intersection';
+
+const sb = sandbox.create();
+const destroyStub = sb.stub();
+
+let intersectionObserver: any;
+const observers: ([
+	{
+		observe: SinonStub;
+		takeRecords: SinonStub;
+		disconnect: SinonSpy;
+	},
+	Function
+])[] = [];
+let globalIntersectionObserver: any;
+let nodeStub = {
+	get: sb.stub()
+};
+let invalidatorStub = sb.stub();
+
+describe('intersection middleware', () => {
+	before(() => {
+		globalIntersectionObserver = global.IntersectionObserver;
+		intersectionObserver = stub().callsFake(function(callback: any) {
+			const observer = {
+				observe: sb.stub(),
+				takeRecords: sb.stub().returns([]),
+				disconnect: sb.spy()
+			};
+			observers.push([observer, callback]);
+			return observer;
+		});
+		global.IntersectionObserver = intersectionObserver;
+	});
+
+	afterEach(() => {
+		sb.resetHistory();
+		sb.resetBehavior();
+		intersectionObserver.resetHistory();
+		observers.length = 0;
+	});
+
+	after(() => {
+		global.IntersectionObserver = globalIntersectionObserver;
+	});
+
+	it('no intersection', () => {
+		const cache = cacheMiddleware().callback({
+			properties: {},
+			id: 'test-cache',
+			middleware: { destroy: destroyStub }
+		});
+		const intersection = intersectionMiddleware().callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				cache,
+				invalidator: invalidatorStub,
+				node: nodeStub
+			},
+			properties: {}
+		});
+
+		const info = intersection.get('root');
+		assert.deepEqual(info, {
+			intersectionRatio: 0,
+			isIntersecting: false
+		});
+	});
+
+	it('no intersection with options', () => {
+		const cache = cacheMiddleware().callback({
+			properties: {},
+			id: 'test-cache',
+			middleware: { destroy: destroyStub }
+		});
+		const intersection = intersectionMiddleware().callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				cache,
+				invalidator: invalidatorStub,
+				node: nodeStub
+			},
+			properties: {}
+		});
+
+		const info = intersection.get('root', { root: 'root' });
+		assert.deepEqual(info, {
+			intersectionRatio: 0,
+			isIntersecting: false
+		});
+	});
+
+	it('Should return the registered intersection', () => {
+		const cache = cacheMiddleware().callback({
+			properties: {},
+			id: 'test-cache',
+			middleware: { destroy: destroyStub }
+		});
+		const intersection = intersectionMiddleware().callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				cache,
+				invalidator: invalidatorStub,
+				node: nodeStub
+			},
+			properties: {}
+		});
+
+		const mockNode = sb.stub();
+		nodeStub.get.returns(mockNode);
+		intersection.get('root');
+
+		const [observer, callback] = observers[0];
+		assert.isTrue(observer.observe.calledOnce);
+
+		callback(
+			[
+				{
+					target: mockNode,
+					intersectionRatio: 0.1,
+					isIntersecting: true
+				}
+			],
+			observer
+		);
+
+		const info = intersection.get('root');
+		assert.deepEqual(info, {
+			intersectionRatio: 0.1,
+			isIntersecting: true
+		});
+	});
+
+	it('intersections calls waits for root node before invalidating', () => {
+		const cache = cacheMiddleware().callback({
+			properties: {},
+			id: 'test-cache',
+			middleware: { destroy: destroyStub }
+		});
+		const intersection = intersectionMiddleware().callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				cache,
+				invalidator: invalidatorStub,
+				node: nodeStub
+			},
+			properties: {}
+		});
+
+		let info = intersection.get('foo', { root: 'root' });
+
+		assert.lengthOf(observers, 0);
+		assert.deepEqual(info, {
+			intersectionRatio: 0,
+			isIntersecting: false
+		});
+
+		const mockFoo = sb.stub();
+		nodeStub.get.withArgs('foo').returns(mockFoo);
+
+		info = intersection.get('foo', { root: 'root' });
+
+		assert.lengthOf(observers, 0);
+		assert.deepEqual(info, {
+			intersectionRatio: 0,
+			isIntersecting: false
+		});
+
+		const mockRoot = sb.stub();
+		nodeStub.get.withArgs('root').returns(mockRoot);
+		info = intersection.get('foo', { root: 'root' });
+
+		assert.lengthOf(observers, 1);
+		assert.deepEqual(info, {
+			intersectionRatio: 0,
+			isIntersecting: false
+		});
+		assert.isTrue(intersectionObserver.calledOnce);
+		const [observer, callback] = observers[0];
+
+		callback(
+			[
+				{
+					target: mockFoo,
+					intersectionRatio: 0.1,
+					isIntersecting: true
+				}
+			],
+			observer
+		);
+
+		const result = intersection.get('foo', { root: 'root' });
+		assert.deepEqual(result, { intersectionRatio: 0.1, isIntersecting: true });
+	});
+
+	it('Should register disconnect with destroy', () => {
+		const cache = cacheMiddleware().callback({
+			properties: {},
+			id: 'test-cache',
+			middleware: { destroy: sb.stub() }
+		});
+		const intersection = intersectionMiddleware().callback({
+			id: 'test',
+			middleware: {
+				destroy: destroyStub,
+				cache,
+				invalidator: invalidatorStub,
+				node: nodeStub
+			},
+			properties: {}
+		});
+
+		const mockNode = sb.stub();
+		nodeStub.get.returns(mockNode);
+		intersection.get('key');
+		destroyStub.getCall(0).callArg(0);
+		assert.lengthOf(observers, 1);
+		const [observer] = observers[0];
+		assert.isTrue(observer.disconnect.calledOnce);
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Middleware that leverages Intersection Observers to determine if a node with a given key is intersecting with the view port or with a specified root node.

Resolves #374 
