### PR TITLE
Breakpoint middleware

### DIFF
--- a/src/core/middleware/breakpoint.ts
+++ b/src/core/middleware/breakpoint.ts
@@ -1,37 +1,50 @@
 import { create } from '../vdom';
 import { resize } from './resize';
 
+export interface Breakpoints {
+	[index: string]: number;
+}
+
 const factory = create({ resize });
 
-const defaultBreakpoints: any = { SM: 0, MD: 576, LG: 768, XL: 960 };
+export function createBreakpointMiddleware(breakpoints: Breakpoints = { SM: 0, MD: 576, LG: 768, XL: 960 }) {
+	const defaultBreakpoints: Breakpoints = breakpoints;
+	const breakpoint = factory(({ middleware: { resize } }) => {
+		return {
+			get: (key: string | number, breakpoints: Breakpoints = defaultBreakpoints) => {
+				const contentRect = resize.get(key);
+				if (!contentRect) {
+					return null;
+				}
+				let currentBreakpoint = null;
 
-export const breakpoint = factory(({ middleware: { resize } }) => {
-	return (key: string | number, breakpoints: any = defaultBreakpoints) => {
-		const contentRect = resize.get(key);
-		if (!contentRect) {
-			return null;
-		}
-		let currentBreakpoint = null;
+				const keys = Object.keys(breakpoints);
+				for (let i = 0; i < keys.length; i++) {
+					const breakpoint = breakpoints[keys[i]];
+					if (
+						contentRect.width >= breakpoint &&
+						(!currentBreakpoint || breakpoint > currentBreakpoint.size)
+					) {
+						currentBreakpoint = {
+							name: keys[i],
+							size: breakpoint
+						};
+					}
+				}
 
-		const keys = Object.keys(breakpoints);
-		for (let i = 0; i < keys.length; i++) {
-			const breakpoint = breakpoints[keys[i]];
-			if (contentRect.width >= breakpoint && (!currentBreakpoint || breakpoint > currentBreakpoint.size)) {
-				currentBreakpoint = {
-					name: keys[i],
-					size: breakpoint
-				};
+				if (currentBreakpoint) {
+					return {
+						breakpoint: currentBreakpoint.name,
+						contentRect
+					};
+				}
+				return null;
 			}
-		}
+		};
+	});
+	return breakpoint;
+}
 
-		if (currentBreakpoint) {
-			return {
-				breakpoint: currentBreakpoint.name,
-				contentRect
-			};
-		}
-		return null;
-	};
-});
+const breakpoint = createBreakpointMiddleware();
 
 export default breakpoint;

--- a/src/core/middleware/breakpoint.ts
+++ b/src/core/middleware/breakpoint.ts
@@ -1,0 +1,37 @@
+import { create } from '../vdom';
+import { resize } from './resize';
+
+const factory = create({ resize });
+
+const defaultBreakpoints: any = { SM: 0, MD: 576, LG: 768, XL: 960 };
+
+export const breakpoint = factory(({ middleware: { resize } }) => {
+	return (key: string | number, breakpoints: any = defaultBreakpoints) => {
+		const contentRect = resize.get(key);
+		if (!contentRect) {
+			return null;
+		}
+		let currentBreakpoint = null;
+
+		const keys = Object.keys(breakpoints);
+		for (let i = 0; i < keys.length; i++) {
+			const breakpoint = breakpoints[keys[i]];
+			if (contentRect.width >= breakpoint && (!currentBreakpoint || breakpoint > currentBreakpoint.size)) {
+				currentBreakpoint = {
+					name: keys[i],
+					size: breakpoint
+				};
+			}
+		}
+
+		if (currentBreakpoint) {
+			return {
+				breakpoint: currentBreakpoint.name,
+				contentRect
+			};
+		}
+		return null;
+	};
+});
+
+export default breakpoint;

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -1,4 +1,5 @@
 import './block';
+import './breakpoint';
 import './cache';
 import './dimensions';
 import './i18n';

--- a/tests/core/unit/middleware/breakpoint.ts
+++ b/tests/core/unit/middleware/breakpoint.ts
@@ -1,0 +1,154 @@
+const { it, describe, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { sandbox } from 'sinon';
+
+import breakpointMiddleware, { createBreakpointMiddleware } from '../../../../src/core/middleware/breakpoint';
+
+const sb = sandbox.create();
+let resizeStub = {
+	get: sb.stub()
+};
+
+const domRects = {
+	x: 0,
+	y: 0,
+	width: 0,
+	height: 0,
+	top: 0,
+	right: 0,
+	bottom: 0,
+	left: 0
+};
+
+describe('breakpoint middleware', () => {
+	afterEach(() => {
+		sb.resetHistory();
+	});
+
+	it('Should return null when no content rects available', () => {
+		const { callback } = breakpointMiddleware();
+		const breakpoint = callback({
+			id: 'test',
+			middleware: {
+				resize: resizeStub
+			},
+			properties: {}
+		});
+		assert.isNull(breakpoint.get('root'));
+	});
+
+	it('Should return the content rects and the matched breakpoint', () => {
+		const { callback } = breakpointMiddleware();
+		const breakpoint = callback({
+			id: 'test',
+			middleware: {
+				resize: resizeStub
+			},
+			properties: {}
+		});
+
+		resizeStub.get
+			.onFirstCall()
+			.returns({ ...domRects, width: 10 })
+			.onSecondCall()
+			.returns({ ...domRects, width: 600 })
+			.onThirdCall()
+			.returns({ ...domRects, width: 800 })
+			.onCall(3)
+			.returns({ ...domRects, width: 1000 });
+		assert.deepEqual(breakpoint.get('root'), {
+			breakpoint: 'SM',
+			contentRect: { ...domRects, width: 10 }
+		});
+		assert.deepEqual(breakpoint.get('root'), {
+			breakpoint: 'MD',
+			contentRect: { ...domRects, width: 600 }
+		});
+		assert.deepEqual(breakpoint.get('root'), {
+			breakpoint: 'LG',
+			contentRect: { ...domRects, width: 800 }
+		});
+		assert.deepEqual(breakpoint.get('root'), {
+			breakpoint: 'XL',
+			contentRect: { ...domRects, width: 1000 }
+		});
+	});
+
+	it('Should be able to use custom breakpoints', () => {
+		const { callback } = breakpointMiddleware();
+		const breakpoint = callback({
+			id: 'test',
+			middleware: {
+				resize: resizeStub
+			},
+			properties: {}
+		});
+
+		resizeStub.get
+			.onFirstCall()
+			.returns({ ...domRects, width: 10 })
+			.onSecondCall()
+			.returns({ ...domRects, width: 600 })
+			.onThirdCall()
+			.returns({ ...domRects, width: 800 })
+			.onCall(3)
+			.returns({ ...domRects, width: 1000 });
+
+		assert.isNull(breakpoint.get('root', { 'custom-small': 100, 'custom-large': 700 }));
+		assert.deepEqual(breakpoint.get('root', { 'custom-small': 100, 'custom-large': 700 }), {
+			breakpoint: 'custom-small',
+			contentRect: { ...domRects, width: 600 }
+		});
+		assert.deepEqual(breakpoint.get('root', { 'custom-small': 100, 'custom-large': 700 }), {
+			breakpoint: 'custom-large',
+			contentRect: { ...domRects, width: 800 }
+		});
+		assert.deepEqual(breakpoint.get('root', { 'custom-small': 100, 'custom-large': 700 }), {
+			breakpoint: 'custom-large',
+			contentRect: { ...domRects, width: 1000 }
+		});
+	});
+
+	it('Should use custom breakpoints passed to the breakpoint middleware factory', () => {
+		const breakpointMiddleware = createBreakpointMiddleware({
+			SM: 0,
+			MD: 300,
+			LG: 400,
+			XL: 700
+		});
+		const { callback } = breakpointMiddleware();
+		const breakpoint = callback({
+			id: 'test',
+			middleware: {
+				resize: resizeStub
+			},
+			properties: {}
+		});
+
+		resizeStub.get
+			.onFirstCall()
+			.returns({ ...domRects, width: 10 })
+			.onSecondCall()
+			.returns({ ...domRects, width: 600 })
+			.onThirdCall()
+			.returns({ ...domRects, width: 800 })
+			.onCall(3)
+			.returns({ ...domRects, width: 1000 });
+		assert.deepEqual(breakpoint.get('root'), {
+			breakpoint: 'SM',
+			contentRect: { ...domRects, width: 10 }
+		});
+		assert.deepEqual(breakpoint.get('root'), {
+			breakpoint: 'LG',
+			contentRect: { ...domRects, width: 600 }
+		});
+		assert.deepEqual(breakpoint.get('root'), {
+			breakpoint: 'XL',
+			contentRect: { ...domRects, width: 800 }
+		});
+		assert.deepEqual(breakpoint.get('root'), {
+			breakpoint: 'XL',
+			contentRect: { ...domRects, width: 1000 }
+		});
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Breakpoint meta that returns the matching breakpoint based on the width of a node. Provides a factory that can be used to create breakpoint meta with a custom set of breakpoints that can be used throughout an application. By default the breakpoint meta uses:

```ts
{
  SM: 0,
  MD: 576,
  LG: 768,
  XL: 960 
}
```

The breakpoints can also be overridden when using the `.get` 

```ts
breakpoint.get('root', { 'custom-small': 100, 'custom-large': 700 }
```