### PR TITLE
Focus Middleware

### DIFF
--- a/src/core/middleware/focus.ts
+++ b/src/core/middleware/focus.ts
@@ -1,0 +1,38 @@
+import { create, diffProperties, invalidator } from '../vdom';
+import { cache } from './cache';
+
+export interface FocusProperties {
+	focus?: (() => boolean);
+}
+
+const factory = create({ cache, diffProperties, invalidator }).properties<FocusProperties>();
+
+export const focus = factory(({ middleware: { cache, diffProperties, invalidator } }) => {
+	cache.set('current', 0);
+	cache.set('previous', 0);
+	diffProperties((_: FocusProperties, next: FocusProperties) => {
+		const result = next.focus && next.focus();
+		if (result) {
+			let current = cache.get('current') || 0;
+			current++;
+			cache.set('current', current);
+			invalidator();
+		}
+	});
+	return {
+		shouldFocus(): boolean {
+			const current = cache.get('current') || 0;
+			const previous = cache.get('previous') || 0;
+			cache.set('previous', current);
+			return current !== previous;
+		},
+		focus(): void {
+			let current = cache.get('current') || 0;
+			current++;
+			cache.set('current', current);
+			invalidator();
+		}
+	};
+});
+
+export default focus;

--- a/src/core/middleware/focus.ts
+++ b/src/core/middleware/focus.ts
@@ -19,7 +19,7 @@ export const focus = factory(({ middleware: { icache, cache, diffProperty, node,
 	function onFocusChange() {
 		const currentElement = cache.get('active-element');
 		const activeElement = global.document.activeElement;
-		if (nodeSet.has(currentElement) || nodeSet.has(activeElement)) {
+		if ((nodeSet.has(currentElement) || nodeSet.has(activeElement)) && currentElement !== activeElement) {
 			invalidator();
 		}
 		cache.set('active-element', activeElement);

--- a/src/core/middleware/focus.ts
+++ b/src/core/middleware/focus.ts
@@ -1,36 +1,28 @@
-import { create, diffProperties, invalidator } from '../vdom';
+import { create, diffProperty } from '../vdom';
+import { icache } from './icache';
 import { cache } from './cache';
+import { FocusProperties } from '../mixins/Focus';
 
-export interface FocusProperties {
-	focus?: (() => boolean);
-}
+const factory = create({ icache, cache, diffProperty }).properties<FocusProperties>();
 
-const factory = create({ cache, diffProperties, invalidator }).properties<FocusProperties>();
-
-export const focus = factory(({ middleware: { cache, diffProperties, invalidator } }) => {
-	cache.set('current', 0);
-	cache.set('previous', 0);
-	diffProperties((_: FocusProperties, next: FocusProperties) => {
+export const focus = factory(({ middleware: { icache, cache, diffProperty } }) => {
+	diffProperty('focus', (_: FocusProperties, next: FocusProperties) => {
 		const result = next.focus && next.focus();
 		if (result) {
-			let current = cache.get('current') || 0;
-			current++;
-			cache.set('current', current);
-			invalidator();
+			let current = icache.get('current') || 0;
+			icache.set('current', current + 1);
 		}
 	});
 	return {
 		shouldFocus(): boolean {
-			const current = cache.get('current') || 0;
+			const current = icache.get('current') || 0;
 			const previous = cache.get('previous') || 0;
 			cache.set('previous', current);
 			return current !== previous;
 		},
 		focus(): void {
 			let current = cache.get('current') || 0;
-			current++;
-			cache.set('current', current);
-			invalidator();
+			icache.set('current', current + 1);
 		}
 	};
 });

--- a/src/core/middleware/focus.ts
+++ b/src/core/middleware/focus.ts
@@ -1,17 +1,26 @@
-import { create, diffProperty } from '../vdom';
+import global from '../../shim/global';
+import { create, diffProperty, node, destroy, invalidator } from '../vdom';
 import { icache } from './icache';
 import { cache } from './cache';
 import { FocusProperties } from '../mixins/Focus';
 
-const factory = create({ icache, cache, diffProperty }).properties<FocusProperties>();
+const factory = create({ icache, cache, diffProperty, node, destroy, invalidator }).properties<FocusProperties>();
 
-export const focus = factory(({ middleware: { icache, cache, diffProperty } }) => {
+export const focus = factory(({ middleware: { icache, cache, diffProperty, node, destroy, invalidator } }) => {
+	let initialized = false;
 	diffProperty('focus', (_: FocusProperties, next: FocusProperties) => {
 		const result = next.focus && next.focus();
 		if (result) {
 			let current = icache.get('current') || 0;
 			icache.set('current', current + 1);
 		}
+	});
+	function onFocusChange() {
+		invalidator();
+	}
+	destroy(() => {
+		global.document.removeEventListener('focusin', onFocusChange);
+		global.document.removeEventListener('focusout', onFocusChange);
 	});
 	return {
 		shouldFocus(): boolean {
@@ -23,6 +32,18 @@ export const focus = factory(({ middleware: { icache, cache, diffProperty } }) =
 		focus(): void {
 			let current = cache.get('current') || 0;
 			icache.set('current', current + 1);
+		},
+		isFocused(key: string | number): boolean {
+			const domNode = node.get(key);
+			if (!domNode) {
+				return false;
+			}
+			if (!initialized) {
+				global.document.addEventListener('focusin', onFocusChange);
+				global.document.addEventListener('focusout', onFocusChange);
+				initialized = true;
+			}
+			return global.document.activeElement === domNode;
 		}
 	};
 });

--- a/src/core/middleware/focus.ts
+++ b/src/core/middleware/focus.ts
@@ -12,7 +12,7 @@ export const focus = factory(({ middleware: { icache, cache, diffProperty, node,
 	diffProperty('focus', (_: FocusProperties, next: FocusProperties) => {
 		const result = next.focus && next.focus();
 		if (result) {
-			let current = icache.get('current') || 0;
+			const current = icache.get('current') || 0;
 			icache.set('current', current + 1);
 		}
 	});
@@ -37,7 +37,7 @@ export const focus = factory(({ middleware: { icache, cache, diffProperty, node,
 			return current !== previous;
 		},
 		focus(): void {
-			let current = cache.get('current') || 0;
+			const current = cache.get('current') || 0;
 			icache.set('current', current + 1);
 		},
 		isFocused(key: string | number): boolean {

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -2,6 +2,7 @@ import './block';
 import './cache';
 import './dimensions';
 import './i18n';
+import './focus';
 import './icache';
 import './injector';
 import './intersection';

--- a/tests/core/unit/middleware/focus.ts
+++ b/tests/core/unit/middleware/focus.ts
@@ -1,0 +1,74 @@
+const { it, describe, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { sandbox } from 'sinon';
+
+import focusMiddleware from '../../../../src/core/middleware/focus';
+import cacheMiddleware from '../../../../src/core/middleware/cache';
+import icacheMiddleware from '../../../../src/core/middleware/icache';
+
+const sb = sandbox.create();
+const diffPropertyStub = sb.stub();
+
+function cacheFactory() {
+	return cacheMiddleware().callback({ id: 'test-cache', properties: {}, middleware: { destroy: sb.stub() } });
+}
+
+function icacheFactory() {
+	return icacheMiddleware().callback({
+		id: 'test-cache',
+		properties: {},
+		middleware: { cache: cacheFactory(), invalidator: sb.stub() }
+	});
+}
+
+describe('focus middleware', () => {
+	afterEach(() => {
+		sb.resetHistory();
+	});
+
+	it('`shouldFocus` is controlled by calls to `focus`', () => {
+		const { callback } = focusMiddleware();
+		const focus = callback({
+			id: 'test',
+			middleware: {
+				diffProperty: diffPropertyStub,
+				cache: cacheFactory(),
+				icache: icacheFactory()
+			},
+			properties: {}
+		});
+		assert.isFalse(focus.shouldFocus());
+		focus.focus();
+		assert.isTrue(focus.shouldFocus());
+	});
+
+	it('`shouldFocus` returns true when focus property returns true', () => {
+		const { callback } = focusMiddleware();
+		const focus = callback({
+			id: 'test',
+			middleware: {
+				diffProperty: diffPropertyStub,
+				cache: cacheFactory(),
+				icache: icacheFactory()
+			},
+			properties: {}
+		});
+		diffPropertyStub.getCall(0).callArgWith(1, {}, { focus: () => true });
+		assert.isTrue(focus.shouldFocus());
+	});
+
+	it('`shouldFocus` returns false when focus property returns false', () => {
+		const { callback } = focusMiddleware();
+		const focus = callback({
+			id: 'test',
+			middleware: {
+				diffProperty: diffPropertyStub,
+				cache: cacheFactory(),
+				icache: icacheFactory()
+			},
+			properties: {}
+		});
+		diffPropertyStub.getCall(0).callArgWith(1, {}, { focus: () => false });
+		assert.isFalse(focus.shouldFocus());
+	});
+});

--- a/tests/core/unit/middleware/focus.ts
+++ b/tests/core/unit/middleware/focus.ts
@@ -121,8 +121,11 @@ describe('focus middleware', () => {
 		});
 		const div = global.document.createElement('div');
 		const buttonOne = global.document.createElement('button');
+		buttonOne.setAttribute('id', 'one');
 		const buttonTwo = global.document.createElement('button');
+		buttonTwo.setAttribute('id', 'two');
 		const buttonThree = global.document.createElement('button');
+		buttonThree.setAttribute('id', 'three');
 		div.appendChild(buttonOne);
 		div.appendChild(buttonTwo);
 		div.appendChild(buttonThree);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Focus middleware builds on the primitive focus functionality provided by vdom and enables management of focus across widget boundaries.

The focus middleware provides a function called `shouldFocus` that manages when a widget or their child widgets can apply focus, `shouldFocus` will only return true the first time it is called until focus is called again on the widget.

Resolves #400
