### PR TITLE
I18n Middleware

### DIFF
--- a/src/core/middleware/i18n.ts
+++ b/src/core/middleware/i18n.ts
@@ -1,0 +1,146 @@
+/* tslint:disable:interface-name */
+import i18nCore, { Bundle, formatMessage, getCachedMessages, Messages } from '../../i18n/i18n';
+import { create, invalidator, injector, diffProperties } from '../vdom';
+import Map from '../../shim/Map';
+import Injector from '../Injector';
+
+export interface LocaleData {
+	/**
+	 * The locale for the widget. If not specified, then the root locale (as determined by `@dojo/i18n`) is assumed.
+	 * If specified, the widget's node will have a `lang` property set to the locale.
+	 */
+	locale?: string;
+
+	/**
+	 * An optional flag indicating the widget's text direction. If `true`, then the underlying node's `dir`
+	 * property is set to "rtl". If it is `false`, then the `dir` property is set to "ltr". Otherwise, the property
+	 * is not set.
+	 */
+	rtl?: boolean;
+}
+
+export interface I18nProperties extends LocaleData {
+	/**
+	 * An optional override for the bundle passed to the `localizeBundle`. If the override contains a `messages` object,
+	 * then it will completely replace the underlying bundle. Otherwise, a new bundle will be created with the additional
+	 * locale loaders.
+	 */
+	i18nBundle?: Bundle<Messages> | Map<Bundle<Messages>, Bundle<Messages>>;
+}
+
+export type LocalizedMessages<T extends Messages> = {
+	/**
+	 * Indicates whether the messages are placeholders while waiting for the actual localized messages to load.
+	 * This is always `false` if the associated bundle does not list any supported locales.
+	 */
+	readonly isPlaceholder: boolean;
+
+	/**
+	 * Formats an ICU-formatted message template for the represented bundle.
+	 *
+	 * @param key
+	 * The message key.
+	 *
+	 * @param options
+	 * The values to pass to the formatter.
+	 *
+	 * @return
+	 * The formatted string.
+	 */
+	format(key: string, options?: any): string;
+
+	/**
+	 * The localized messages if available, or either the default messages or a blank bundle depending on the
+	 * call signature for `localizeBundle`.
+	 */
+	readonly messages: T;
+};
+
+const factory = create({ invalidator, injector, diffProperties }).properties<I18nProperties>();
+
+export const i18n = factory(({ middleware: { invalidator, injector, diffProperties }, properties }) => {
+	injector.subscribe('__i18n_injector');
+	diffProperties((current: I18nProperties, next: I18nProperties) => {
+		if (current.locale !== next.locale || current.rtl !== next.rtl) {
+			invalidator();
+		}
+	});
+
+	function getLocaleMessages(bundle: Bundle<Messages>): Messages | void {
+		let locale = properties.locale;
+		if (!locale) {
+			const injectedLocale = injector.get<Injector<LocaleData>>('__i18n_injector');
+			if (injectedLocale) {
+				locale = injectedLocale.get().locale;
+			}
+		}
+		locale = locale || i18nCore.locale;
+		const localeMessages = getCachedMessages(bundle, locale);
+
+		if (localeMessages) {
+			return localeMessages;
+		}
+
+		i18nCore(bundle, locale).then(() => {
+			invalidator();
+		});
+	}
+
+	function resolveBundle<T extends Messages>(bundle: Bundle<T>): Bundle<T> {
+		let { i18nBundle } = properties;
+		if (i18nBundle) {
+			if (i18nBundle instanceof Map) {
+				i18nBundle = i18nBundle.get(bundle);
+
+				if (!i18nBundle) {
+					return bundle;
+				}
+			}
+
+			return i18nBundle as Bundle<T>;
+		}
+		return bundle;
+	}
+
+	function getBlankMessages<T extends Messages>(bundle: Bundle<T>): T {
+		const blank = {} as Messages;
+		return Object.keys(bundle.messages).reduce((blank, key) => {
+			blank[key] = '';
+			return blank;
+		}, blank) as T;
+	}
+
+	return {
+		get<T extends Messages>(bundle: Bundle<T>, useDefaults = false): LocalizedMessages<T> {
+			bundle = resolveBundle(bundle);
+			const messages = getLocaleMessages(bundle);
+			const isPlaceholder = !messages;
+			let locale = properties.locale;
+			if (!locale) {
+				const injectedLocale = injector.get<Injector<LocaleData>>('__i18n_injector');
+				if (injectedLocale) {
+					locale = injectedLocale.get().locale;
+				}
+			}
+
+			const format =
+				isPlaceholder && !useDefaults
+					? () => ''
+					: (key: string, options?: any) => formatMessage(bundle, key, options, locale);
+
+			return Object.create({
+				format,
+				isPlaceholder,
+				messages: messages || (useDefaults ? bundle.messages : getBlankMessages(bundle))
+			});
+		},
+		set(localeData?: LocaleData) {
+			const currentLocale = injector.get<Injector<LocaleData | undefined>>('__i18n_injector');
+			if (currentLocale) {
+				currentLocale.set(localeData);
+			}
+		}
+	};
+});
+
+export default i18n;

--- a/src/core/mixins/I18n.ts
+++ b/src/core/mixins/I18n.ts
@@ -98,7 +98,7 @@ export function registerI18nInjector(localeData: LocaleData, registry: Registry)
 	const injector = new Injector(localeData);
 	registry.defineInjector(INJECTOR_KEY, (invalidator) => {
 		injector.setInvalidator(invalidator);
-		return () => injector.get();
+		return () => injector;
 	});
 	return injector;
 }
@@ -106,8 +106,8 @@ export function registerI18nInjector(localeData: LocaleData, registry: Registry)
 export function I18nMixin<T extends Constructor<WidgetBase<any>>>(Base: T): T & Constructor<I18nMixin> {
 	@inject({
 		name: INJECTOR_KEY,
-		getProperties: (localeData: LocaleData, properties: I18nProperties) => {
-			const { locale = localeData.locale, rtl = localeData.rtl } = properties;
+		getProperties: (localeData: Injector<LocaleData>, properties: I18nProperties) => {
+			const { locale = localeData.get().locale, rtl = localeData.get().rtl } = properties;
 			return { locale, rtl };
 		}
 	})

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -1,6 +1,7 @@
 import './block';
 import './cache';
 import './dimensions';
+import './i18n';
 import './icache';
 import './injector';
 import './intersection';

--- a/tests/core/unit/middleware/i18n.ts
+++ b/tests/core/unit/middleware/i18n.ts
@@ -1,0 +1,303 @@
+const { it, describe, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { sandbox } from 'sinon';
+import bundle from '../../support/nls/greetings';
+
+import i18nMiddleware from '../../../../src/core/middleware/i18n';
+import coreI18n, { switchLocale, invalidate, systemLocale } from '../../../../src/i18n/i18n';
+import Injector from '../../../../src/core/Injector';
+
+const sb = sandbox.create();
+const invalidatorStub = sb.stub();
+const injectorStub = {
+	get: sb.stub(),
+	subscribe: sb.stub()
+};
+const defineInjector = sb.stub();
+const getRegistryStub = sb.stub();
+const registryHandler = {
+	base: {
+		defineInjector
+	}
+};
+getRegistryStub.returns(registryHandler);
+
+const overrideBundle = {
+	locales: {
+		es: () => ({
+			hello: 'Hola',
+			goodbye: 'Adiós',
+			welcome: 'Bienvenido, {name}'
+		})
+	},
+	messages: {
+		hello: 'Hi!',
+		goodbye: 'Bye!',
+		welcome: 'Salutations, {name}!'
+	}
+};
+
+describe('i18n middleware', () => {
+	afterEach(() => {
+		invalidate();
+		switchLocale(systemLocale);
+		sb.resetHistory();
+		defineInjector.resetBehavior();
+		injectorStub.get.resetBehavior();
+	});
+
+	it('Returns blank messages when locale bundle not loaded', () => {
+		switchLocale('fr');
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {}
+		});
+		const { format, isPlaceholder, messages } = i18n.localize(bundle);
+
+		assert.isTrue(isPlaceholder);
+		assert.strictEqual(messages.hello, '');
+		assert.strictEqual(messages.goodbye, '');
+		assert.strictEqual(format('hello'), '');
+	});
+
+	it('Returns default messages with second argument when locale bundle not loaded', () => {
+		switchLocale('fr');
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {}
+		});
+		const { format, isPlaceholder, messages } = i18n.localize(bundle, true);
+
+		assert.isTrue(isPlaceholder);
+		assert.strictEqual(messages.hello, 'Hello');
+		assert.strictEqual(messages.goodbye, 'Goodbye');
+		assert.strictEqual(format('hello'), 'Hello');
+	});
+
+	it('Returns default messages when bundle has no supported locales', () => {
+		switchLocale('fr');
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {}
+		});
+		const { isPlaceholder, messages } = i18n.localize({
+			messages: {
+				hello: 'Hello',
+				goodbye: 'Goodbye'
+			}
+		});
+
+		assert.isFalse(isPlaceholder);
+		assert.strictEqual(messages.hello, 'Hello');
+		assert.strictEqual(messages.goodbye, 'Goodbye');
+	});
+
+	it('Uses `properties.locale` when available', async () => {
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {
+				locale: 'fr'
+			}
+		});
+		await coreI18n(bundle, 'fr');
+		const { isPlaceholder, messages } = i18n.localize(bundle);
+		assert.isFalse(isPlaceholder);
+		assert.strictEqual(messages.hello, 'Bonjour');
+		assert.strictEqual(messages.goodbye, 'Au revoir');
+	});
+
+	it('Uses default locale when no locale is set', async () => {
+		switchLocale('fr');
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {}
+		});
+		await coreI18n(bundle, 'fr');
+		const { isPlaceholder, messages } = i18n.localize(bundle);
+		assert.isFalse(isPlaceholder);
+		assert.strictEqual(messages.hello, 'Bonjour');
+		assert.strictEqual(messages.goodbye, 'Au revoir');
+	});
+
+	it('Returns an object with a `format` method', async () => {
+		switchLocale('fr');
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {}
+		});
+		await coreI18n(bundle, 'fr');
+		const { format } = i18n.localize(bundle);
+		assert.strictEqual(format('welcome', { name: 'Jean' }), 'Bienvenue, Jean!');
+	});
+
+	it('localizeBundle() with an override using the `i18nBundle` property', async () => {
+		switchLocale('es');
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {
+				i18nBundle: overrideBundle
+			}
+		});
+		await coreI18n(bundle, 'es');
+		await coreI18n(overrideBundle, 'es');
+		const { format, messages } = i18n.localize(bundle);
+		assert.strictEqual(messages.hello, 'Hola');
+		assert.strictEqual(messages.goodbye, 'Adiós');
+		assert.strictEqual(format('welcome', { name: 'Jean' }), 'Bienvenido, Jean');
+	});
+
+	it('localizeBundle() with an override using a map for the `i18nBundle` property', async () => {
+		switchLocale('es');
+		const i18nBundleMap = new Map<any, any>();
+		i18nBundleMap.set(bundle, overrideBundle);
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {
+				i18nBundle: i18nBundleMap
+			}
+		});
+		await coreI18n(bundle, 'es');
+		await coreI18n(overrideBundle, 'es');
+		const { format, messages } = i18n.localize(bundle);
+		assert.strictEqual(messages.hello, 'Hola');
+		assert.strictEqual(messages.goodbye, 'Adiós');
+		assert.strictEqual(format('welcome', { name: 'Jean' }), 'Bienvenido, Jean');
+	});
+
+	it('Uses the base bundle when the `i18nBundle` map does not contain an override', async () => {
+		switchLocale('es');
+		const i18nBundleMap = new Map<any, any>();
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {
+				i18nBundle: i18nBundleMap
+			}
+		});
+		await coreI18n(bundle, 'es');
+		await coreI18n(overrideBundle, 'es');
+		const { format, messages } = i18n.localize(bundle);
+		assert.strictEqual(messages.hello, 'Hello');
+		assert.strictEqual(messages.goodbye, 'Goodbye');
+		assert.strictEqual(format('hello'), 'Hello');
+	});
+
+	it('defaults to the injector data', async () => {
+		const injector = new Injector({ locale: 'fr', rtl: true });
+		injectorStub.get.returns(injector);
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {}
+		});
+		await coreI18n(bundle, 'fr');
+		const { isPlaceholder, messages } = i18n.localize(bundle);
+		assert.isFalse(isPlaceholder);
+		assert.strictEqual(messages.hello, 'Bonjour');
+		assert.strictEqual(messages.goodbye, 'Au revoir');
+	});
+
+	it('injected locale does not override properties', async () => {
+		const injector = new Injector({ locale: 'es', rtl: true });
+		injectorStub.get.returns(injector);
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {
+				locale: 'fr'
+			}
+		});
+		await coreI18n(bundle, 'fr');
+		const { isPlaceholder, messages } = i18n.localize(bundle);
+		assert.isFalse(isPlaceholder);
+		assert.strictEqual(messages.hello, 'Bonjour');
+		assert.strictEqual(messages.goodbye, 'Au revoir');
+	});
+
+	it('can set and get the locale', async () => {
+		defineInjector.callsFake(() => {
+			injectorStub.get.returns(new Injector({ locale: 'es', rtl: true }));
+		});
+		const { callback } = i18nMiddleware();
+		const i18n = callback({
+			id: 'test',
+			middleware: {
+				injector: injectorStub,
+				invalidator: invalidatorStub,
+				getRegistry: getRegistryStub
+			},
+			properties: {}
+		});
+		assert.isTrue(defineInjector.calledOnce);
+		await coreI18n(bundle, 'fr');
+		i18n.set({ locale: 'fr', rtl: true });
+		const { isPlaceholder, messages } = i18n.localize(bundle);
+		assert.isFalse(isPlaceholder);
+		assert.strictEqual(messages.hello, 'Bonjour');
+		assert.strictEqual(messages.goodbye, 'Au revoir');
+		assert.deepEqual<any>(i18n.get(), { locale: 'fr', rtl: true });
+	});
+});

--- a/tests/core/unit/mixins/I18n.ts
+++ b/tests/core/unit/mixins/I18n.ts
@@ -9,6 +9,7 @@ import bundle from '../../support/nls/greetings';
 import { fetchCldrData } from '../../support/util';
 import { v, w } from './../../../../src/core/vdom';
 import { ThemedMixin } from './../../../../src/core/mixins/Themed';
+import Injector from '../../../../src/core/Injector';
 
 class Localized extends I18nMixin(ThemedMixin(WidgetBase))<I18nProperties> {}
 
@@ -190,7 +191,7 @@ registerSuite('mixins/I18nMixin', {
 		},
 		'locale data can be injected by defining an Injector with a registry': {
 			'defaults to the injector data'() {
-				const injector = () => () => ({ locale: 'ar', rtl: true });
+				const injector = () => () => new Injector({ locale: 'ar', rtl: true });
 				const registry = new Registry();
 
 				registry.defineInjector(INJECTOR_KEY, injector);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

An i18n middleware that returns localised messages and formatters. Provides an API to get and set the locale details (`locale` and `rtl`).

**Note:** Does not automatically decorate the top node of a widget with `rtl` and `locale` properties as the current mixin does.

Resolves #372 
