### PR TITLE
Fix custom element initialization

### DIFF
--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -84,6 +84,7 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 		}
 
 		private _waitTillReady() {
+			this._initialised = true;
 			if (this._hasBeenParsed()) {
 				this._readyCallback();
 			} else {
@@ -178,7 +179,6 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 				this.style.display = display;
 			}
 
-			this._initialised = true;
 			this.dispatchEvent(
 				new CustomEvent('dojo-ce-connected', {
 					bubbles: true,

--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -57,12 +57,40 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 		private _children: any[] = [];
 		private _eventProperties: any = {};
 		private _initialised = false;
+		private _parentNodes: any[] = [];
 
 		public connectedCallback() {
 			if (this._initialised) {
 				return;
 			}
+			// collect ancestor nodes
+			let el = this.parentNode;
+			while (el) {
+				this._parentNodes.push(el);
+				el = el.parentNode;
+			}
+			// check if the parser has already passed the end tag of the component
+			// in which case this element, or one of its parents, should have a nextSibling
+			// if not (no whitespace at all between tags and no nextElementSiblings either)
+			// resort to DOMContentLoaded or load having triggered
+			if ([this, ...this._parentNodes].some((el) => el.nextSibling) || document.readyState !== 'loading') {
+				this._childrenAvailableCallback();
+			} else {
+				const mutationObserver = new MutationObserver(() => {
+					if (
+						[this, ...this._parentNodes].some((el) => el.nextSibling) ||
+						document.readyState !== 'loading'
+					) {
+						this._childrenAvailableCallback();
+						mutationObserver.disconnect();
+					}
+				});
 
+				mutationObserver.observe(this, { childList: true });
+			}
+		}
+
+		private _childrenAvailableCallback() {
 			const domProperties: any = {};
 			const { properties = [], events = [] } = descriptor;
 

--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -57,40 +57,43 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 		private _children: any[] = [];
 		private _eventProperties: any = {};
 		private _initialised = false;
-		private _parentNodes: any[] = [];
 
 		public connectedCallback() {
 			if (this._initialised) {
 				return;
 			}
-			// collect ancestor nodes
-			let el = this.parentNode;
-			while (el) {
-				this._parentNodes.push(el);
-				el = el.parentNode;
-			}
-			// check if the parser has already passed the end tag of the component
-			// in which case this element, or one of its parents, should have a nextSibling
-			// if not (no whitespace at all between tags and no nextElementSiblings either)
-			// resort to DOMContentLoaded or load having triggered
-			if ([this, ...this._parentNodes].some((el) => el.nextSibling) || document.readyState !== 'loading') {
-				this._childrenAvailableCallback();
-			} else {
-				const mutationObserver = new MutationObserver(() => {
-					if (
-						[this, ...this._parentNodes].some((el) => el.nextSibling) ||
-						document.readyState !== 'loading'
-					) {
-						this._childrenAvailableCallback();
-						mutationObserver.disconnect();
-					}
-				});
 
-				mutationObserver.observe(this, { childList: true });
+			this._waitTillReady();
+		}
+
+		private _hasBeenParsed() {
+			if (document.readyState !== 'loading') {
+				return true;
+			}
+
+			let element: any = this;
+			while (element) {
+				if (element.nextSibling) {
+					return true;
+				}
+
+				element = element.parentNode;
+			}
+
+			return false;
+		}
+
+		private _waitTillReady() {
+			if (this._hasBeenParsed()) {
+				this._readyCallback();
+			} else {
+				setTimeout(() => {
+					this._waitTillReady();
+				}, 100);
 			}
 		}
 
-		private _childrenAvailableCallback() {
+		private _readyCallback() {
 			const domProperties: any = {};
 			const { properties = [], events = [] } = descriptor;
 

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -40,6 +40,28 @@ class DisplayElementDefault extends WidgetBase {
 	}
 }
 
+@customElement({
+	tag: 'delayed-children-element',
+	childType: CustomElementChildType.TEXT
+})
+class DelayedChildrenWidget extends WidgetBase {
+	render() {
+		return v(
+			'div',
+			{},
+			this.children.map((child, i) =>
+				v(
+					'div',
+					{
+						'data-key': `child-${i}`
+					},
+					[child]
+				)
+			)
+		);
+	}
+}
+
 function createTestWidget(options: any) {
 	const { properties, attributes, events, childType = CustomElementChildType.DOJO } = options;
 	@customElement<any>({
@@ -348,5 +370,40 @@ describe('registerCustomElement', () => {
 		document.body.appendChild(element);
 		const { display } = global.getComputedStyle(element);
 		assert.equal(display, 'block');
+	});
+
+	it('handles children being appended as document is still loading', () => {
+		register(DelayedChildrenWidget);
+
+		Object.defineProperty(document, 'readyState', {
+			configurable: true,
+			get() {
+				return 'loading';
+			}
+		});
+		element = document.createElement('delayed-children-element');
+		document.body.appendChild(element);
+
+		let child = document.createTextNode('foo');
+		element!.appendChild(child);
+
+		Object.defineProperty(document, 'readyState', {
+			configurable: true,
+			get() {
+				return 'complete';
+			}
+		});
+		child = document.createTextNode('bar');
+		element!.appendChild(child);
+
+		return new Promise((resolve) => {
+			setTimeout(() => {
+				assert.equal(
+					element!.outerHTML,
+					'<delayed-children-element style="display: block;"><div><div data-key="child-0">foo</div><div data-key="child-1">bar</div></div></delayed-children-element>'
+				);
+				resolve();
+			});
+		});
 	});
 });

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -373,7 +373,8 @@ describe('registerCustomElement', () => {
 		assert.equal(display, 'block');
 	});
 
-	it('handles children being appended as document is still loading', async () => {
+	it('handles children being appended as document is still loading', () => {
+		resolvers.restore();
 		register(DelayedChildrenWidget);
 
 		Object.defineProperty(document, 'readyState', {
@@ -397,7 +398,7 @@ describe('registerCustomElement', () => {
 		child = document.createTextNode('bar');
 		element!.appendChild(child);
 
-		waitFor(
+		return waitFor(
 			() =>
 				element!.outerHTML ===
 				'<delayed-children-element style="display: block;"><div><div data-key="child-0">foo</div><div data-key="child-1">bar</div></div></delayed-children-element>'

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -404,4 +404,32 @@ describe('registerCustomElement', () => {
 				'<delayed-children-element style="display: block;"><div><div data-key="child-0">foo</div><div data-key="child-1">bar</div></div></delayed-children-element>'
 		);
 	});
+
+	it('eventually parses an element processed while loading', () => {
+		resolvers.restore();
+
+		Object.defineProperty(document, 'readyState', {
+			configurable: true,
+			get() {
+				return 'loading';
+			}
+		});
+		element = document.createElement('foo-element');
+		document.body.appendChild(element);
+
+		const nextSibling = document.createElement('div');
+		document.body.appendChild(nextSibling);
+
+		assert.notEqual(element.outerHTML, '<foo-element style="display: block;"><div>hello world</div></foo-element>');
+		return waitFor(
+			() => element!.outerHTML === '<foo-element style="display: block;"><div>hello world</div></foo-element>'
+		).finally(() => {
+			Object.defineProperty(document, 'readyState', {
+				configurable: true,
+				get() {
+					return 'complete';
+				}
+			});
+		});
+	});
 });

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -9,6 +9,7 @@ import { v, w } from '../../../src/core/vdom';
 import register, { create, CustomElementChildType } from '../../../src/core/registerCustomElement';
 import { createResolvers } from '../support/util';
 import { ThemedMixin, theme } from '../../../src/core/mixins/Themed';
+import { waitFor } from './waitFor';
 
 const { describe, it, beforeEach, afterEach, before } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
@@ -372,7 +373,7 @@ describe('registerCustomElement', () => {
 		assert.equal(display, 'block');
 	});
 
-	it('handles children being appended as document is still loading', () => {
+	it('handles children being appended as document is still loading', async () => {
 		register(DelayedChildrenWidget);
 
 		Object.defineProperty(document, 'readyState', {
@@ -396,14 +397,10 @@ describe('registerCustomElement', () => {
 		child = document.createTextNode('bar');
 		element!.appendChild(child);
 
-		return new Promise((resolve) => {
-			setTimeout(() => {
-				assert.equal(
-					element!.outerHTML,
-					'<delayed-children-element style="display: block;"><div><div data-key="child-0">foo</div><div data-key="child-1">bar</div></div></delayed-children-element>'
-				);
-				resolve();
-			});
-		});
+		waitFor(
+			() =>
+				element!.outerHTML ===
+				'<delayed-children-element style="display: block;"><div><div data-key="child-0">foo</div><div data-key="child-1">bar</div></div></delayed-children-element>'
+		);
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
It's evidently not guaranteed that a custom element's children will be available when it is connected ([see discussion here](https://github.com/w3c/webcomponents/issues/551)), but our `connectedCallback` was setup as if it was. I've setup a mutation observer so that the element will wait till the document is loaded  or an element after it in the HTML hierarchy is present to perform setup logic. 

Resolves #342 
