### PR TITLE
Destroy Injector Subscribe Handles

### DIFF
--- a/src/core/middleware/injector.ts
+++ b/src/core/middleware/injector.ts
@@ -1,18 +1,34 @@
-import { create, getRegistry, invalidator } from '../vdom';
+import { create, getRegistry, invalidator, destroy } from '../vdom';
 import { RegistryLabel } from '../interfaces';
+import { Handle } from '../Destroyable';
 
-const injectorFactory = create({ getRegistry, invalidator });
+const injectorFactory = create({ getRegistry, invalidator, destroy });
 
-export const injector = injectorFactory(({ middleware: { getRegistry, invalidator } }) => {
+export const injector = injectorFactory(({ middleware: { getRegistry, invalidator, destroy } }) => {
+	const handles: Handle[] = [];
+	destroy(() => {
+		let handle: Handle | undefined;
+		while ((handle = handles.pop())) {
+			handle.destroy();
+		}
+	});
 	const registry = getRegistry();
 	return {
 		subscribe(label: RegistryLabel, callback: Function = invalidator) {
 			if (registry) {
 				const item = registry.getInjector(label);
 				if (item) {
-					item.invalidator.on('invalidate', () => {
+					const handle = item.invalidator.on('invalidate', () => {
 						callback();
 					});
+					handles.push(handle);
+					return () => {
+						const index = handles.indexOf(handle);
+						if (index !== -1) {
+							handles.splice(index, 1);
+							handle.destroy();
+						}
+					};
 				}
 			}
 		},

--- a/tests/core/unit/middleware/injector.ts
+++ b/tests/core/unit/middleware/injector.ts
@@ -12,6 +12,7 @@ const registry = {
 const getRegistry = sb.stub();
 const invalidator = sb.stub();
 const eventStub = sb.stub();
+const destroy = sb.stub();
 
 describe('injector middleware', () => {
 	beforeEach(() => {
@@ -34,7 +35,8 @@ describe('injector middleware', () => {
 				id: 'test',
 				middleware: {
 					getRegistry,
-					invalidator
+					invalidator,
+					destroy
 				},
 				properties: {}
 			});
@@ -49,7 +51,8 @@ describe('injector middleware', () => {
 				id: 'test',
 				middleware: {
 					getRegistry,
-					invalidator
+					invalidator,
+					destroy
 				},
 				properties: {}
 			});
@@ -64,7 +67,8 @@ describe('injector middleware', () => {
 				id: 'test',
 				middleware: {
 					getRegistry,
-					invalidator
+					invalidator,
+					destroy
 				},
 				properties: {}
 			});
@@ -84,7 +88,8 @@ describe('injector middleware', () => {
 				id: 'test',
 				middleware: {
 					getRegistry,
-					invalidator
+					invalidator,
+					destroy
 				},
 				properties: {}
 			});
@@ -105,7 +110,8 @@ describe('injector middleware', () => {
 				id: 'test',
 				middleware: {
 					getRegistry,
-					invalidator
+					invalidator,
+					destroy
 				},
 				properties: {}
 			});
@@ -123,7 +129,8 @@ describe('injector middleware', () => {
 				id: 'test',
 				middleware: {
 					getRegistry,
-					invalidator
+					invalidator,
+					destroy
 				},
 				properties: {}
 			});
@@ -143,12 +150,47 @@ describe('injector middleware', () => {
 				id: 'test',
 				middleware: {
 					getRegistry,
-					invalidator
+					invalidator,
+					destroy
 				},
 				properties: {}
 			});
 			injector.subscribe('test');
 			assert.isTrue(eventStub.notCalled);
+		});
+
+		it('should destory subscriptions', () => {
+			const handle = {
+				destroy: sb.stub()
+			};
+			registry.getInjector.returns({
+				invalidator: {
+					on: eventStub.returns(handle)
+				}
+			});
+			const { callback } = injectorMiddleware();
+			const injector = callback({
+				id: 'test',
+				middleware: {
+					getRegistry,
+					invalidator,
+					destroy
+				},
+				properties: {}
+			});
+			const customCallback = sb.stub();
+			const injectorHandle = injector.subscribe('test', customCallback);
+			assert.isTrue(eventStub.calledOnce);
+			eventStub.getCall(0).callArg(1);
+			assert.isTrue(customCallback.calledOnce);
+			injectorHandle!();
+			assert.isTrue(handle.destroy.calledOnce);
+			injectorHandle!();
+			assert.isTrue(handle.destroy.calledOnce);
+			injector.subscribe('test', customCallback);
+			assert.isTrue(eventStub.calledTwice);
+			destroy.getCall(0).callArg(0);
+			assert.isTrue(handle.destroy.calledTwice);
 		});
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

For the injector middleware the subscription handles need to be destroy when the widget is destroyed and also allow the consumer to destroy them with a handle.
