### PR TITLE
Invalidate if there are new or old children

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1824,6 +1824,9 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			if (widgetMeta) {
 				widgetMeta.properties = next.properties;
 				runDiffs(widgetMeta, current.properties, next.properties);
+				if (current.node.children.length > 0 || next.node.children.length > 0) {
+					widgetMeta.dirty = true;
+				}
 				if (!widgetMeta.dirty) {
 					propertiesDiff(
 						current.properties,

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -2991,6 +2991,30 @@ jsdomDescribe('vdom', () => {
 		});
 
 		describe('functional', () => {
+			it('children', () => {
+				const createWidget = create({ invalidator });
+
+				let text = 'first';
+				let updateText: any;
+
+				const Foo = createWidget(({ children }) => children);
+				const App = createWidget(({ middleware }) => {
+					updateText = () => {
+						text = 'second';
+						middleware.invalidator();
+					};
+					return v('div', [Foo({}, [text])]);
+				});
+				const r = renderer(() => App({}));
+				const div = document.createElement('div');
+				r.mount({ domNode: div });
+				resolvers.resolve();
+				assert.strictEqual(div.outerHTML, '<div><div>first</div></div>');
+				updateText();
+				resolvers.resolve();
+				assert.strictEqual(div.outerHTML, '<div><div>second</div></div>');
+			});
+
 			it('Should render nodes in the correct order with mix of vnode and wnodes', () => {
 				const createWidget = create();
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure functional widgets are invalidated when they have or had children.

Related to #352 
