### PR TITLE
Fix store `state` interface call stack error

### DIFF
--- a/src/stores/process.ts
+++ b/src/stores/process.ts
@@ -168,7 +168,15 @@ export function createCommandFactory<T, P extends object = DefaultPayload>(): Co
 export type Commands<T = any, P extends object = DefaultPayload> = (Command<T, P>[] | Command<T, P>)[];
 
 const processMap = new Map();
-export const valueSymbol = Symbol('value');
+const valueSymbol = Symbol('value');
+
+export function isStateProxy(value: any) {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	return Boolean(value[valueSymbol]);
+}
 
 export function getProcess(id: string) {
 	return processMap.get(id);

--- a/src/stores/process.ts
+++ b/src/stores/process.ts
@@ -182,17 +182,13 @@ function removeProxies(value: any) {
 			value = value[valueSymbol];
 		}
 
-		if (Array.isArray(value)) {
-			value = value.map(removeProxies);
-		} else {
-			value = Object.keys(value).reduce(
-				(newValue, key) => {
-					newValue[key] = removeProxies(value[key]);
-					return newValue;
-				},
-				{} as typeof value
-			);
+		const newValue: typeof value = Array.isArray(value) ? [] : {};
+		const keys = Object.keys(value);
+		for (let i = 0; i < keys.length; i++) {
+			newValue[keys[i]] = removeProxies(value[keys[i]]);
 		}
+
+		value = newValue;
 	}
 
 	return value;

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -274,6 +274,8 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 						state.foo = state.foo.filter(({ bar }: any) => bar !== 'baz');
 						assert.isTrue(isStateProxy(state.foo));
 						assert.isTrue(isStateProxy(state.foo[0]));
+						// Literals should be returned as is
+						assert.isFalse(isStateProxy(state.foo[0].bar));
 						state.bar = 0;
 					}
 				]);

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -275,7 +275,9 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 				]);
 				process(store)({});
 
-				assert.isUndefined(store.get(store.at(store.path('foo'), 0))[valueSymbol]);
+				if (typeof Proxy !== 'undefined') {
+					assert.isUndefined(store.get(store.at(store.path('foo'), 0))[valueSymbol]);
+				}
 			});
 		});
 

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -273,7 +273,7 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 						state.bar = 0;
 					}
 				]);
-				process(store)({});
+				await process(store)({});
 
 				if (typeof Proxy !== 'undefined') {
 					assert.isUndefined(store.get(store.at(store.path('foo'), 0))[valueSymbol]);

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -11,7 +11,8 @@ import {
 	ProcessCallback,
 	ProcessCallbackAfter,
 	ProcessError,
-	ProcessResult
+	ProcessResult,
+	valueSymbol
 } from '../../../src/stores/process';
 import { MutableState, Store } from '../../../src/stores/Store';
 import { add, replace } from '../../../src/stores/state/operations';
@@ -258,6 +259,23 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 				} else {
 					await Promise.all(promises);
 				}
+			});
+		});
+
+		it('removes nested proxy values', async () => {
+			await assertProxyError(async () => {
+				const process = createProcess('test', [
+					({ state }) => {
+						state.foo = [{ bar: 'baz' }, { bar: 'buzz' }, { bar: 'biz' }];
+					},
+					({ state }) => {
+						state.foo = state.foo.filter(({ bar }: any) => bar !== 'baz');
+						state.bar = 0;
+					}
+				]);
+				process(store)({});
+
+				assert.isUndefined(store.get(store.at(store.path('foo'), 0))[valueSymbol]);
 			});
 		});
 


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Any object and array values returned when accessing the state object are also proxies, in order to handle nested updates. When one of these values is set back on the state object there is a check to get the object value instead of the proxy. However in the case of `filter`, and any number of other possible scenarios, the object that is being set is not a proxy and is not known by the proxy, but contains proxies. This resulted in proxies being set as properties on the state which leads to an infinite regress.

To fix this the proxy removal check is now recursive. 

todo-mvc with fix:
https://dev-kxynqtvhqn.now.sh/

Fork:
https://github.com/maier49/todomvc/tree/fixed
Resolves #404 
