### PR TITLE
Do not break on undefined/false/null nodes

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -943,8 +943,8 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	}
 
 	function mapNodeToInstance(nodes: DNode[], wrapper: WNodeWrapper) {
-		let node: DNode;
-		while ((node = nodes.pop())) {
+		while (nodes.length) {
+			let node = nodes.pop();
 			if (isWNode(node) || isVNode(node)) {
 				if (!_nodeToWrapperMap.has(node)) {
 					_nodeToWrapperMap.set(node, wrapper);

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3219,14 +3219,14 @@ jsdomDescribe('vdom', () => {
 						let divNode: any;
 						const App = createWidget(({ middleware }) => {
 							divNode = middleware.node.get('div');
-							return v('div', { key: 'div' });
+							return v('div', [undefined, v('div', { key: 'div' }), undefined]);
 						});
 						const r = renderer(() => App({}));
 						const root = document.createElement('div');
 						r.mount({ domNode: root });
 						assert.isNull(divNode);
 						resolvers.resolve();
-						assert.strictEqual(root.childNodes[0], divNode);
+						assert.strictEqual(root.childNodes[0].childNodes[0], divNode);
 					});
 
 					it('should remove nodes from the map', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

When setting the owning node, do not break on `undefined`, `null` or `false` nodes as these are valid.
