### PR TITLE
Wrap Proxy code in has flag

### DIFF
--- a/src/stores/process.ts
+++ b/src/stores/process.ts
@@ -168,7 +168,71 @@ export function createCommandFactory<T, P extends object = DefaultPayload>(): Co
 export type Commands<T = any, P extends object = DefaultPayload> = (Command<T, P>[] | Command<T, P>)[];
 
 const processMap = new Map();
-const valueSymbol = Symbol('value');
+let valueSymbol: any = undefined;
+let createProxy: <T>({ get, path }: Store<T>) => any = <T>({ get, path }: Store<T>) => {};
+if (has('es6-symbol')) {
+	valueSymbol = Symbol('value');
+	createProxy = <T>({ get, path }: Store<T>) => {
+		const proxies = new Map<string, any>();
+		const proxied = new Map<string, any>();
+
+		const proxyOperations: PatchOperation[] = [];
+		const createHandler = (partialPath?: Path<T, any>) => ({
+			get(obj: any, prop: string): any {
+				const fullPath = partialPath ? path(partialPath, prop) : path(prop as keyof T);
+				const stringPath = fullPath.path;
+
+				if (typeof prop === 'symbol' && prop === valueSymbol) {
+					return proxied.get(stringPath);
+				}
+
+				let value = partialPath || obj.hasOwnProperty(prop) ? obj[prop] : get(fullPath);
+
+				if (typeof value === 'object' && value !== null) {
+					let proxiedValue;
+					if (!proxies.has(stringPath)) {
+						if (Array.isArray(value)) {
+							value = value.slice();
+						} else {
+							value = { ...value };
+						}
+						proxiedValue = new Proxy(value, createHandler(fullPath));
+						proxies.set(stringPath, proxiedValue);
+						proxied.set(stringPath, value);
+					} else {
+						proxiedValue = proxies.get(stringPath);
+					}
+
+					obj[prop] = value;
+					return proxiedValue;
+				}
+
+				obj[prop] = value;
+				return value;
+			},
+
+			set(obj: any, prop: string, value: any) {
+				if (typeof value === 'object' && value !== null && value[valueSymbol]) {
+					value = value[valueSymbol];
+				}
+
+				proxyOperations.push(replace(partialPath ? path(partialPath, prop) : path(prop as keyof T), value));
+				obj[prop] = value;
+
+				return true;
+			},
+
+			deleteProperty(obj: any, prop: string) {
+				proxyOperations.push(remove(partialPath ? path(partialPath, prop) : path(prop as keyof T)));
+				delete obj[prop];
+
+				return true;
+			}
+		});
+
+		return { proxy: new Proxy({}, createHandler()) as T, operations: proxyOperations };
+	};
+}
 
 export function getProcess(id: string) {
 	return processMap.get(id);
@@ -208,67 +272,6 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 			}
 		}
 
-		function createProxy() {
-			const proxies = new Map<string, any>();
-			const proxied = new Map<string, any>();
-
-			const proxyOperations: PatchOperation[] = [];
-			const createHandler = (partialPath?: Path<T, any>) => ({
-				get(obj: any, prop: string): any {
-					const fullPath = partialPath ? path(partialPath, prop) : path(prop as keyof T);
-					const stringPath = fullPath.path;
-
-					if (typeof prop === 'symbol' && prop === valueSymbol) {
-						return proxied.get(stringPath);
-					}
-
-					let value = partialPath || obj.hasOwnProperty(prop) ? obj[prop] : get(fullPath);
-
-					if (typeof value === 'object' && value !== null) {
-						let proxiedValue;
-						if (!proxies.has(stringPath)) {
-							if (Array.isArray(value)) {
-								value = value.slice();
-							} else {
-								value = { ...value };
-							}
-							proxiedValue = new Proxy(value, createHandler(fullPath));
-							proxies.set(stringPath, proxiedValue);
-							proxied.set(stringPath, value);
-						} else {
-							proxiedValue = proxies.get(stringPath);
-						}
-
-						obj[prop] = value;
-						return proxiedValue;
-					}
-
-					obj[prop] = value;
-					return value;
-				},
-
-				set(obj: any, prop: string, value: any) {
-					if (typeof value === 'object' && value !== null && value[valueSymbol]) {
-						value = value[valueSymbol];
-					}
-
-					proxyOperations.push(replace(partialPath ? path(partialPath, prop) : path(prop as keyof T), value));
-					obj[prop] = value;
-
-					return true;
-				},
-
-				deleteProperty(obj: any, prop: string) {
-					proxyOperations.push(remove(partialPath ? path(partialPath, prop) : path(prop as keyof T)));
-					delete obj[prop];
-
-					return true;
-				}
-			});
-
-			return { proxy: new Proxy({}, createHandler()) as T, operations: proxyOperations };
-		}
-
 		try {
 			while (command) {
 				let results = [];
@@ -278,7 +281,7 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 					let state: T;
 					let proxyOperations: PatchOperation[] = [];
 					if (typeof Proxy !== 'undefined') {
-						const { operations, proxy } = createProxy();
+						const { operations, proxy } = createProxy(store);
 						state = proxy;
 						proxyOperations = operations;
 					}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Should only need the `Proxy` code when `es6-proxy`'s are supported - wraps the proxy symbol and function with `has('es6-proxy')`.