### PR TITLE
Providing process ID to all middleware callbacks

### DIFF
--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -830,23 +830,26 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 		});
 
 		it('passes process id to middleware callbacks', () => {
-			let beforeId = '';
-			let afterId = '';
+			let before: string[] = [];
+			let after: string[] = [];
 
-			const process = createProcess('test', [], () => ({
-				before(payload, store, id) {
-					beforeId = id;
-				},
-				after(errorState, result) {
-					afterId = result.id;
-				}
-			}));
+			function middleware(): ProcessCallback {
+				return () => ({
+					before(payload, store, id) {
+						before.push(id);
+					},
+					after(errorState, result) {
+						after.push(result.id);
+					}
+				});
+			}
 
+			const process = createProcess('test', [], [middleware(), middleware()]);
 			const executor = process(store);
 			executor({});
 
-			assert.strictEqual(beforeId, 'test');
-			assert.strictEqual(afterId, 'test');
+			assert.deepEqual(before, ['test', 'test']);
+			assert.deepEqual(after, ['test', 'test']);
 		});
 	});
 };

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -828,6 +828,26 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 			executor({});
 			assert.strictEqual(store.get(store.path('foo')), 'bar');
 		});
+
+		it('passes process id to middleware callbacks', () => {
+			let beforeId = '';
+			let afterId = '';
+
+			const process = createProcess('test', [], () => ({
+				before(payload, store, id) {
+					beforeId = id;
+				},
+				after(errorState, result) {
+					afterId = result.id;
+				}
+			}));
+
+			const executor = process(store);
+			executor({});
+
+			assert.strictEqual(beforeId, 'test');
+			assert.strictEqual(afterId, 'test');
+		});
 	});
 };
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Providing the process `id` to `before` callbacks in process middleware.

Resolves #308 
