### PR TITLE
Assertion template enhancements

### DIFF
--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -325,9 +325,13 @@ insertAfter(selector: string, children: DNode[]): AssertionTemplateResult;
 insertSiblings(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
 append(selector: string, children: DNode[]): AssertionTemplateResult;
 prepend(selector: string, children: DNode[]): AssertionTemplateResult;
-replace(selector: string, children: DNode[]): AssertionTemplateResult;
+replaceChildren(selector: string, children: DNode[]): AssertionTemplateResult;
 setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
+setProperties(selector: string, value: any | PropertiesComparatorFunction): AssertionTemplateResult;
 getChildren(selector: string): DNode[];
 getProperty(selector: string, property: string): any;
+getProperties(selector: string): any;
+replace(selector: string, node: DNode): AssertionTemplateResult;
+remove(selector: string): AssertionTemplateResult;
 ```

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -69,7 +69,7 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 	assertionTemplateResult.setProperties = (selector: string, value: any | PropertiesComparatorFunction) => {
 		return assertionTemplate(() => {
 			const render = renderFunc();
-			const node = guard(findOne(render, selector));
+			const node = findOne(render, selector);
 			node.properties = value;
 			return render;
 		});
@@ -143,7 +143,7 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 	};
 	assertionTemplateResult.getProperties = (selector: string, property: string) => {
 		const render = renderFunc();
-		const node = guard(findOne(render, selector));
+		const node = findOne(render, selector);
 		return node.properties;
 	};
 	assertionTemplateResult.getChildren = (selector: string) => {
@@ -154,7 +154,7 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 	assertionTemplateResult.replace = (selector: string, newNode: DNode) => {
 		return assertionTemplate(() => {
 			const render = renderFunc();
-			const node = guard(findOne(render, selector));
+			const node = findOne(render, selector);
 			const parent = (node as any).parent;
 			const children = [...parent.children];
 			children.splice(children.indexOf(node), 1, newNode);
@@ -165,7 +165,7 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 	assertionTemplateResult.remove = (selector: string) => {
 		return assertionTemplate(() => {
 			const render = renderFunc();
-			const node = guard(findOne(render, selector));
+			const node = findOne(render, selector);
 			const parent = (node as any).parent;
 			const children = [...parent.children];
 			children.splice(children.indexOf(node), 1);

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -157,8 +157,8 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			const node = guard(findOne(render, selector));
 			const parent = (node as any).parent;
 			const children = [...parent.children];
-			children.splice(children.indexOf(node), 1);
-			parent.children = [node, ...children];
+			children.splice(children.indexOf(node), 1, node);
+			parent.children = children;
 			return render;
 		});
 	};

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -151,13 +151,13 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		const node = findOne(render, selector);
 		return node.children || [];
 	};
-	assertionTemplateResult.replace = (selector: string, node: DNode) => {
+	assertionTemplateResult.replace = (selector: string, newNode: DNode) => {
 		return assertionTemplate(() => {
 			const render = renderFunc();
 			const node = guard(findOne(render, selector));
 			const parent = (node as any).parent;
 			const children = [...parent.children];
-			children.splice(children.indexOf(node), 1, node);
+			children.splice(children.indexOf(node), 1, newNode);
 			parent.children = children;
 			return render;
 		});

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -45,7 +45,7 @@ const findOne = (nodes: DNode | DNode[], selector: string): NodeWithProperties =
 	return node;
 };
 
-export class Mimic extends WidgetBase {}
+export class Ignore extends WidgetBase {}
 
 export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 	const assertionTemplateResult: any = () => {

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -21,6 +21,7 @@ export interface AssertionTemplateResult {
 	getProperty(selector: string, property: string): any;
 	getProperties(selector: string): any;
 	replace(selector: string, node: DNode): AssertionTemplateResult;
+	remove(selector: string): AssertionTemplateResult;
 }
 
 type NodeWithProperties = (VNode | WNode) & { properties: { [index: string]: any } };
@@ -158,6 +159,17 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			const children = [...parent.children];
 			children.splice(children.indexOf(node), 1);
 			parent.children = [node, ...children];
+			return render;
+		});
+	};
+	assertionTemplateResult.remove = (selector: string) => {
+		return assertionTemplate(() => {
+			const render = renderFunc();
+			const node = guard(findOne(render, selector));
+			const parent = (node as any).parent;
+			const children = [...parent.children];
+			children.splice(children.indexOf(node), 1);
+			parent.children = [...children];
 			return render;
 		});
 	};

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -99,16 +99,6 @@ function formatNode(node: WNode | VNode, tabs: any): string {
 	return `v("${node.tag}", ${properties}`;
 }
 
-const assertionWidgets = [
-	{
-		type: Ignore,
-		value(actual: DNode, expected: DNode) {
-			const node = actual ? actual : expected;
-			return [actual, node];
-		}
-	}
-];
-
 function isNode(node: any): node is VNode | WNode {
 	return isVNode(node) || isWNode(node);
 }
@@ -123,21 +113,14 @@ function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[],
 		let actualNode = actual[i];
 		let expectedNode = expected[i];
 
-		if (isWNode(expectedNode)) {
-			[actualNode, expectedNode] = assertionWidgets.reduce(
-				(result, assertionWidget) => {
-					if ((expectedNode as any).widgetConstructor === assertionWidget.type) {
-						return assertionWidget.value(result[0], result[1]);
-					}
-					return [result[0], result[1]];
-				},
-				[actualNode, expectedNode]
-			);
+		if (expectedNode && (expectedNode as any).widgetConstructor === Ignore) {
+			expectedNode = actualNode || expectedNode;
 		}
+
 		if (isNode(expectedNode)) {
 			if (typeof expectedNode.properties === 'function') {
 				const actualProperties = isNode(actualNode) ? actualNode.properties : {};
-				expectedNode.properties = expectedNode.properties(actualProperties);
+				expectedNode.properties = (expectedNode as any).properties(actualProperties);
 			}
 		}
 		const childrenA = isNode(actualNode) ? actualNode.children : [];

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -5,6 +5,7 @@ import Set from '../../shim/Set';
 import Map from '../../shim/Map';
 import { from as arrayFrom } from '../../shim/array';
 import { isVNode, isWNode } from '../../core/vdom';
+import { Mimic } from '../assertionTemplate';
 
 let widgetClassCounter = 0;
 const widgetMap = new WeakMap<Constructor<DefaultWidgetBaseInterface>, number>();
@@ -98,9 +99,55 @@ function formatNode(node: WNode | VNode, tabs: any): string {
 	return `v("${node.tag}", ${properties}`;
 }
 
+const assertionWidgets = [
+	{
+		type: Mimic,
+		value(actual: DNode, expected: DNode) {
+			return [actual, actual];
+		}
+	}
+];
+
+function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[], DNode[]] {
+	actual = Array.isArray(actual) ? actual : [actual];
+	expected = Array.isArray(expected) ? expected : [expected];
+	let actualDecoratedNodes = [];
+	let expectedDecoratedNodes = [];
+	for (let i = 0; i < expected.length; i++) {
+		let actualNode = actual[i];
+		let expectedNode = expected[i];
+
+		if (isWNode(expectedNode)) {
+			[actualNode, expectedNode] = assertionWidgets.reduce(
+				(result, assertionWidget) => {
+					if ((expectedNode as any).widgetConstructor === assertionWidget.type) {
+						return assertionWidget.value(result[0], result[1]);
+					}
+					return [result[0], result[1]];
+				},
+				[actualNode, expectedNode]
+			);
+		}
+		if ((isWNode(actualNode) || isVNode(actualNode)) && (isWNode(expectedNode) || isVNode(expectedNode))) {
+			if (typeof expectedNode.properties === 'function') {
+				expectedNode.properties = expectedNode.properties(expectedNode.properties, actualNode.properties);
+			}
+			if (actualNode.children && expectedNode.children) {
+				const [actualChildren, expectedChildren] = decorate(actualNode.children, expectedNode.children);
+				actualNode.children = actualChildren;
+				expectedNode.children = expectedChildren;
+			}
+		}
+		actualDecoratedNodes.push(actualNode);
+		expectedDecoratedNodes.push(expectedNode);
+	}
+	return [actualDecoratedNodes, expectedDecoratedNodes];
+}
+
 export function assertRender(actual: DNode | DNode[], expected: DNode | DNode[], message?: string): void {
-	const parsedActual = formatDNodes(actual);
-	const parsedExpected = formatDNodes(expected);
+	const [decoratedActual, decoratedExpected] = decorate(actual, expected);
+	const parsedActual = formatDNodes(Array.isArray(actual) ? decoratedActual : decoratedActual[0]);
+	const parsedExpected = formatDNodes(Array.isArray(expected) ? decoratedExpected : decoratedExpected[0]);
 	const diffResult = diff.diffLines(parsedActual, parsedExpected);
 	let diffFound = false;
 	const parsedDiff = diffResult.reduce((result: string, part, index) => {

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -103,7 +103,8 @@ const assertionWidgets = [
 	{
 		type: Mimic,
 		value(actual: DNode, expected: DNode) {
-			return [actual, actual];
+			const node = actual ? actual : expected;
+			return [actual, node];
 		}
 	}
 ];

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -137,7 +137,7 @@ function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[],
 		if (isNode(expectedNode)) {
 			if (typeof expectedNode.properties === 'function') {
 				const actualProperties = isNode(actualNode) ? actualNode.properties : {};
-				expectedNode.properties = expectedNode.properties(expectedNode.properties, actualProperties);
+				expectedNode.properties = expectedNode.properties(actualProperties);
 			}
 		}
 		const childrenA = isNode(actualNode) ? actualNode.children : [];

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -5,7 +5,7 @@ import Set from '../../shim/Set';
 import Map from '../../shim/Map';
 import { from as arrayFrom } from '../../shim/array';
 import { isVNode, isWNode } from '../../core/vdom';
-import { Mimic } from '../assertionTemplate';
+import { Ignore } from '../assertionTemplate';
 
 let widgetClassCounter = 0;
 const widgetMap = new WeakMap<Constructor<DefaultWidgetBaseInterface>, number>();
@@ -101,7 +101,7 @@ function formatNode(node: WNode | VNode, tabs: any): string {
 
 const assertionWidgets = [
 	{
-		type: Mimic,
+		type: Ignore,
 		value(actual: DNode, expected: DNode) {
 			const node = actual ? actual : expected;
 			return [actual, node];

--- a/src/testing/support/assertRender.ts
+++ b/src/testing/support/assertRender.ts
@@ -109,7 +109,7 @@ const assertionWidgets = [
 	}
 ];
 
-function isWNodeOrVNode(node: any): node is VNode | WNode {
+function isNode(node: any): node is VNode | WNode {
 	return isVNode(node) || isWNode(node);
 }
 
@@ -134,20 +134,20 @@ function decorate(actual: DNode | DNode[], expected: DNode | DNode[]): [DNode[],
 				[actualNode, expectedNode]
 			);
 		}
-		if (isWNodeOrVNode(expectedNode)) {
+		if (isNode(expectedNode)) {
 			if (typeof expectedNode.properties === 'function') {
-				const actualProperties = isWNodeOrVNode(actualNode) ? actualNode.properties : {};
+				const actualProperties = isNode(actualNode) ? actualNode.properties : {};
 				expectedNode.properties = expectedNode.properties(expectedNode.properties, actualProperties);
 			}
 		}
-		const childrenA = isWNodeOrVNode(actualNode) ? actualNode.children : [];
-		const childrenB = isWNodeOrVNode(expectedNode) ? expectedNode.children : [];
+		const childrenA = isNode(actualNode) ? actualNode.children : [];
+		const childrenB = isNode(expectedNode) ? expectedNode.children : [];
 
 		const [actualChildren, expectedChildren] = decorate(childrenA, childrenB);
-		if (isWNodeOrVNode(actualNode)) {
+		if (isNode(actualNode)) {
 			actualNode.children = actualChildren;
 		}
-		if (isWNodeOrVNode(expectedNode)) {
+		if (isNode(expectedNode)) {
 			expectedNode.children = expectedChildren;
 		}
 		actualDecoratedNodes.push(actualNode);

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -170,7 +170,8 @@ describe('assertionTemplate', () => {
 		const h = harness(() => w(ListWidget, {}));
 		const childListAssertion = baseListAssertion.replaceChildren('ul', [
 			v('li', ['item: 0']),
-			...new Array(29).fill(w(Mimic, {}))
+			...new Array(28).fill(w(Mimic, {})),
+			v('li', ['item: 29'])
 		]);
 		h.expect(childListAssertion);
 	});

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -4,7 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import { harness } from '../../../src/testing/harness';
 import { WidgetBase } from '../../../src/core/WidgetBase';
 import { v, w, tsx } from '../../../src/core/vdom';
-import assertionTemplate from '../../../src/testing/assertionTemplate';
+import assertionTemplate, { Mimic } from '../../../src/testing/assertionTemplate';
 
 class MyWidget extends WidgetBase<{
 	toggleProperty?: boolean;
@@ -61,6 +61,11 @@ describe('assertionTemplate', () => {
 		assert.deepEqual(classes, ['root']);
 	});
 
+	it('can get properties', () => {
+		const properties = baseAssertion.getProperties('~root');
+		assert.deepEqual(properties, { '~key': 'root', classes: ['root'] });
+	});
+
 	it('can get a child', () => {
 		const children = baseAssertion.getChildren('~header');
 		assert.equal(children[0], 'hello');
@@ -74,6 +79,20 @@ describe('assertionTemplate', () => {
 	it('can set a property', () => {
 		const h = harness(() => w(MyWidget, { toggleProperty: true }));
 		const propertyAssertion = baseAssertion.setProperty('~li-one', 'foo', 'b');
+		h.expect(propertyAssertion);
+	});
+
+	it('can set properties', () => {
+		const h = harness(() => w(MyWidget, { toggleProperty: true }));
+		const propertyAssertion = baseAssertion.setProperties('~li-one', { foo: 'b' });
+		h.expect(propertyAssertion);
+	});
+
+	it('can set properties and use the actual properties', () => {
+		const h = harness(() => w(MyWidget, { toggleProperty: true }));
+		const propertyAssertion = baseAssertion.setProperties('~li-one', (expectedProps: any, actualProps: any) => {
+			return actualProps;
+		});
 		h.expect(propertyAssertion);
 	});
 
@@ -125,6 +144,12 @@ describe('assertionTemplate', () => {
 			() => h.expect(baseAssertion.setProperty('~cant-spell', 'foo', 'b')),
 			'Node not found for selector "~cant-spell"'
 		);
+	});
+
+	it('can use mimic', () => {
+		const h = harness(() => w(MyWidget, {}));
+		const childAssertion = baseAssertion.replace('~header', [w(Mimic, {})]);
+		h.expect(childAssertion);
 	});
 
 	it('should be immutable', () => {

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -42,6 +42,18 @@ const baseAssertion = assertionTemplate(() =>
 	])
 );
 
+class ListWidget extends WidgetBase {
+	render() {
+		let children = [];
+		for (let i = 0; i < 30; i++) {
+			children.push(v('li', [`item: ${i}`]));
+		}
+		return v('div', { classes: ['root'] }, [v('ul', children)]);
+	}
+}
+
+const baseListAssertion = assertionTemplate(() => v('div', { classes: ['root'] }, [v('ul', [])]));
+
 const tsxAssertion = assertionTemplate(() => (
 	<div classes={['root']}>
 		<h2>hello</h2>
@@ -147,9 +159,12 @@ describe('assertionTemplate', () => {
 	});
 
 	it('can use mimic', () => {
-		const h = harness(() => w(MyWidget, {}));
-		const childAssertion = baseAssertion.replace('~header', [w(Mimic, {})]);
-		h.expect(childAssertion);
+		const h = harness(() => w(ListWidget, {}));
+		const childListAssertion = baseListAssertion.replace('ul', [
+			v('li', ['item: 0']),
+			...new Array(29).fill(w(Mimic, {}))
+		]);
+		h.expect(childListAssertion);
 	});
 
 	it('should be immutable', () => {

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -181,7 +181,7 @@ describe('assertionTemplate', () => {
 		);
 	});
 
-	it('can use mimic', () => {
+	it('can use ignore', () => {
 		const h = harness(() => w(ListWidget, {}));
 		const childListAssertion = baseListAssertion.replaceChildren('ul', [
 			v('li', ['item: 0']),

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -4,7 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import { harness } from '../../../src/testing/harness';
 import { WidgetBase } from '../../../src/core/WidgetBase';
 import { v, w, tsx } from '../../../src/core/vdom';
-import assertionTemplate, { Mimic } from '../../../src/testing/assertionTemplate';
+import assertionTemplate, { Ignore } from '../../../src/testing/assertionTemplate';
 
 class MyWidget extends WidgetBase<{
 	toggleProperty?: boolean;
@@ -185,7 +185,7 @@ describe('assertionTemplate', () => {
 		const h = harness(() => w(ListWidget, {}));
 		const childListAssertion = baseListAssertion.replaceChildren('ul', [
 			v('li', ['item: 0']),
-			...new Array(28).fill(w(Mimic, {})),
+			...[...new Array(28)].map(() => w(Ignore, {})),
 			v('li', ['item: 29'])
 		]);
 		h.expect(childListAssertion);

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -183,9 +183,13 @@ describe('assertionTemplate', () => {
 
 	it('can use ignore', () => {
 		const h = harness(() => w(ListWidget, {}));
+		const nodes = [];
+		for (let i = 0; i < 28; i++) {
+			nodes.push(w(Ignore, {}));
+		}
 		const childListAssertion = baseListAssertion.replaceChildren('ul', [
 			v('li', ['item: 0']),
-			...[...new Array(28)].map(() => w(Ignore, {})),
+			...nodes,
 			v('li', ['item: 29'])
 		]);
 		h.expect(childListAssertion);

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -11,11 +11,20 @@ class MyWidget extends WidgetBase<{
 	prependChild?: boolean;
 	appendChild?: boolean;
 	replaceChild?: boolean;
+	removeHeader?: boolean;
 	before?: boolean;
 	after?: boolean;
 }> {
 	render() {
-		const { toggleProperty, prependChild, appendChild, replaceChild, before, after } = this.properties;
+		const {
+			toggleProperty,
+			prependChild,
+			appendChild,
+			replaceChild,
+			removeHeader,
+			before,
+			after
+		} = this.properties;
 		let children = ['hello'];
 		if (prependChild) {
 			children = ['prepend', ...children];
@@ -27,7 +36,7 @@ class MyWidget extends WidgetBase<{
 			children = ['replace'];
 		}
 		return v('div', { classes: ['root'] }, [
-			v('h2', children),
+			removeHeader ? undefined : v('h2', children),
 			before ? v('span', ['before']) : undefined,
 			v('ul', [v('li', { foo: toggleProperty ? 'b' : 'a' }, ['one']), v('li', ['two']), v('li', ['three'])]),
 			after ? v('span', ['after']) : undefined
@@ -113,6 +122,12 @@ describe('assertionTemplate', () => {
 	it('can replace a node', () => {
 		const h = harness(() => w(MyWidget, {}));
 		const childAssertion = baseAssertion.replace('~header', v('h2', { '~key': 'header' }, ['hello']));
+		h.expect(childAssertion);
+	});
+
+	it('can remove a node', () => {
+		const h = harness(() => w(MyWidget, { removeHeader: true }));
+		const childAssertion = baseAssertion.remove('~header');
 		h.expect(childAssertion);
 	});
 

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -38,7 +38,9 @@ class MyWidget extends WidgetBase<{
 const baseAssertion = assertionTemplate(() =>
 	v('div', { '~key': 'root', classes: ['root'] }, [
 		v('h2', { '~key': 'header' }, ['hello']),
-		v('ul', [v('li', { '~key': 'li-one', foo: 'a' }, ['one']), v('li', ['two']), v('li', ['three'])])
+		undefined,
+		v('ul', [v('li', { '~key': 'li-one', foo: 'a' }, ['one']), v('li', ['two']), v('li', ['three'])]),
+		undefined
 	])
 );
 
@@ -102,10 +104,16 @@ describe('assertionTemplate', () => {
 
 	it('can set properties and use the actual properties', () => {
 		const h = harness(() => w(MyWidget, { toggleProperty: true }));
-		const propertyAssertion = baseAssertion.setProperties('~li-one', (expectedProps: any, actualProps: any) => {
+		const propertyAssertion = baseAssertion.setProperties('~li-one', (actualProps: any) => {
 			return actualProps;
 		});
 		h.expect(propertyAssertion);
+	});
+
+	it('can replace a node', () => {
+		const h = harness(() => w(MyWidget, {}));
+		const childAssertion = baseAssertion.replace('~header', v('h2', { '~key': 'header' }, ['hello']));
+		h.expect(childAssertion);
 	});
 
 	it('can set a child', () => {
@@ -116,7 +124,7 @@ describe('assertionTemplate', () => {
 
 	it('can set a child with replace', () => {
 		const h = harness(() => w(MyWidget, { replaceChild: true }));
-		const childAssertion = baseAssertion.replace('~header', ['replace']);
+		const childAssertion = baseAssertion.replaceChildren('~header', ['replace']);
 		h.expect(childAssertion);
 	});
 
@@ -160,7 +168,7 @@ describe('assertionTemplate', () => {
 
 	it('can use mimic', () => {
 		const h = harness(() => w(ListWidget, {}));
-		const childListAssertion = baseListAssertion.replace('ul', [
+		const childListAssertion = baseListAssertion.replaceChildren('ul', [
 			v('li', ['item: 0']),
 			...new Array(29).fill(w(Mimic, {}))
 		]);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Refines the assertion template API, providing additional helper APIs and changes one API to clarify the functionality.

Adds primitive for ignoring widgets during the assertion, useful for lists where there is no need to assert every single item.

### Assertion Template Enhancements

####  API's changed:
```
replace -> replaceChildren
```
(this https://github.com/dojo/framework/pull/247#discussion_r256571684 came back to haunt me*)

*Actually @matt-gadd 😄 

####  API's added:
```
replace
remove
setProperties
getProperties
```

#### New Assertion Template primitive:
```
Ignore
```

Supersedes https://github.com/dojo/framework/pull/314 fixing the conflicts and unit tests on IE