### PR TITLE
Support factory functions for children replace on assertion templates

### DIFF
--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -320,13 +320,13 @@ Here we're using the `setChildren()` api on the baseAssertion, and we're using t
 Assertion Template has the following api's:
 
 ```
-insertBefore(selector: string, children: DNode[]): AssertionTemplateResult;
-insertAfter(selector: string, children: DNode[]): AssertionTemplateResult;
-insertSiblings(selector: string, children: DNode[], type?: 'before' | 'after'): AssertionTemplateResult;
-append(selector: string, children: DNode[]): AssertionTemplateResult;
-prepend(selector: string, children: DNode[]): AssertionTemplateResult;
-replaceChildren(selector: string, children: DNode[]): AssertionTemplateResult;
-setChildren(selector: string, children: DNode[], type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
+insertBefore(selector: string, children: DNode[] | (() => DNode[])): AssertionTemplateResult;
+insertAfter(selector: string, children: DNode[] | (() => DNode[])): AssertionTemplateResult;
+insertSiblings(selector: string, children: DNode[] | (() => DNode[]), type?: 'before' | 'after'): AssertionTemplateResult;
+append(selector: string, children: DNode[] | (() => DNode[])): AssertionTemplateResult;
+prepend(selector: string, children: DNode[] | (() => DNode[])): AssertionTemplateResult;
+replaceChildren(selector: string, children: DNode[] | (() => DNode[])): AssertionTemplateResult;
+setChildren(selector: string, children: DNode[] | (() => DNode[]), type?: 'prepend' | 'replace' | 'append'): AssertionTemplateResult;
 setProperty(selector: string, property: string, value: any): AssertionTemplateResult;
 setProperties(selector: string, value: any | PropertiesComparatorFunction): AssertionTemplateResult;
 getChildren(selector: string): DNode[];

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -102,7 +102,7 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 				children = children();
 			} else {
 				console.warn(
-					'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+					'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 				);
 			}
 			switch (type) {
@@ -140,7 +140,7 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 				children = children();
 			} else {
 				console.warn(
-					'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+					'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 				);
 			}
 			switch (type) {

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -94,16 +94,17 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		children: TemplateChildren,
 		type: 'prepend' | 'replace' | 'append' = 'replace'
 	) => {
+		if (Array.isArray(children)) {
+			console.warn(
+				'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
+			);
+		}
 		return assertionTemplate(() => {
 			const render = renderFunc();
 			const node = findOne(render, selector);
 			node.children = node.children || [];
 			if (typeof children === 'function') {
 				children = children();
-			} else {
-				console.warn(
-					'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
-				);
 			}
 			switch (type) {
 				case 'prepend':
@@ -130,6 +131,11 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		children: TemplateChildren,
 		type: 'before' | 'after' = 'after'
 	) => {
+		if (Array.isArray(children)) {
+			console.warn(
+				'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
+			);
+		}
 		return assertionTemplate(() => {
 			const render = renderFunc();
 			const node = findOne(render, selector);
@@ -138,10 +144,6 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			let newChildren = [...parent.children];
 			if (typeof children === 'function') {
 				children = children();
-			} else {
-				console.warn(
-					'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
-				);
 			}
 			switch (type) {
 				case 'before':

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -149,7 +149,7 @@ describe('assertionTemplate', () => {
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
-			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
 	});
 
@@ -166,7 +166,7 @@ describe('assertionTemplate', () => {
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
-			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
 	});
 
@@ -183,7 +183,7 @@ describe('assertionTemplate', () => {
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
-			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
 	});
 
@@ -200,7 +200,7 @@ describe('assertionTemplate', () => {
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
-			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
 	});
 
@@ -217,7 +217,7 @@ describe('assertionTemplate', () => {
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
-			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
 	});
 
@@ -234,7 +234,7 @@ describe('assertionTemplate', () => {
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
-			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
 	});
 

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -1,5 +1,6 @@
-const { describe, it } = intern.getInterface('bdd');
+const { describe, it, after, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
+import { stub } from 'sinon';
 
 import { harness } from '../../../src/testing/harness';
 import { WidgetBase } from '../../../src/core/WidgetBase';
@@ -78,7 +79,17 @@ const tsxAssertion = assertionTemplate(() => (
 	</div>
 ));
 
+let consoleStub = stub(console, 'warn');
+
 describe('assertionTemplate', () => {
+	afterEach(() => {
+		consoleStub.resetHistory();
+	});
+
+	after(() => {
+		consoleStub.restore();
+	});
+
 	it('can get a property', () => {
 		const classes = baseAssertion.getProperty('~root', 'classes');
 		assert.deepEqual(classes, ['root']);
@@ -135,11 +146,33 @@ describe('assertionTemplate', () => {
 		const h = harness(() => w(MyWidget, { replaceChild: true }));
 		const childAssertion = baseAssertion.setChildren('~header', ['replace']);
 		h.expect(childAssertion);
+		assert.isTrue(consoleStub.calledOnce);
+		assert.strictEqual(
+			consoleStub.firstCall.args[0],
+			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+		);
+	});
+
+	it('can set a child with a factory function', () => {
+		const h = harness(() => w(MyWidget, { replaceChild: true }));
+		const childAssertion = baseAssertion.setChildren('~header', () => ['replace']);
+		h.expect(childAssertion);
 	});
 
 	it('can set a child with replace', () => {
 		const h = harness(() => w(MyWidget, { replaceChild: true }));
 		const childAssertion = baseAssertion.replaceChildren('~header', ['replace']);
+		h.expect(childAssertion);
+		assert.isTrue(consoleStub.calledOnce);
+		assert.strictEqual(
+			consoleStub.firstCall.args[0],
+			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+		);
+	});
+
+	it('can set a child with replace with a factory function', () => {
+		const h = harness(() => w(MyWidget, { replaceChild: true }));
+		const childAssertion = baseAssertion.replaceChildren('~header', () => ['replace']);
 		h.expect(childAssertion);
 	});
 
@@ -147,11 +180,33 @@ describe('assertionTemplate', () => {
 		const h = harness(() => w(MyWidget, { prependChild: true }));
 		const childAssertion = baseAssertion.prepend('~header', ['prepend']);
 		h.expect(childAssertion);
+		assert.isTrue(consoleStub.calledOnce);
+		assert.strictEqual(
+			consoleStub.firstCall.args[0],
+			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+		);
+	});
+
+	it('can set a child with prepend with a factory function', () => {
+		const h = harness(() => w(MyWidget, { prependChild: true }));
+		const childAssertion = baseAssertion.prepend('~header', () => ['prepend']);
+		h.expect(childAssertion);
 	});
 
 	it('can set a child with append', () => {
 		const h = harness(() => w(MyWidget, { appendChild: true }));
 		const childAssertion = baseAssertion.append('~header', ['append']);
+		h.expect(childAssertion);
+		assert.isTrue(consoleStub.calledOnce);
+		assert.strictEqual(
+			consoleStub.firstCall.args[0],
+			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+		);
+	});
+
+	it('can set a child with append with a factory function', () => {
+		const h = harness(() => w(MyWidget, { appendChild: true }));
+		const childAssertion = baseAssertion.append('~header', () => ['append']);
 		h.expect(childAssertion);
 	});
 
@@ -159,11 +214,33 @@ describe('assertionTemplate', () => {
 		const h = harness(() => w(MyWidget, { after: true }));
 		const childAssertion = baseAssertion.insertAfter('ul', [v('span', ['after'])]);
 		h.expect(childAssertion);
+		assert.isTrue(consoleStub.calledOnce);
+		assert.strictEqual(
+			consoleStub.firstCall.args[0],
+			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+		);
+	});
+
+	it('can set children after with insert with a factory function', () => {
+		const h = harness(() => w(MyWidget, { after: true }));
+		const childAssertion = baseAssertion.insertAfter('ul', () => [v('span', ['after'])]);
+		h.expect(childAssertion);
 	});
 
 	it('can set children before with insert', () => {
 		const h = harness(() => w(MyWidget, { before: true }));
 		const childAssertion = baseAssertion.insertBefore('ul', [v('span', ['before'])]);
+		h.expect(childAssertion);
+		assert.isTrue(consoleStub.calledOnce);
+		assert.strictEqual(
+			consoleStub.firstCall.args[0],
+			'The array API (`children: DNode[]`) has been deprecated. Replacing children should use a factory to avoid issues with mutation.'
+		);
+	});
+
+	it('can set children before with insert with a factory function', () => {
+		const h = harness(() => w(MyWidget, { before: true }));
+		const childAssertion = baseAssertion.insertBefore('ul', () => [v('span', ['before'])]);
 		h.expect(childAssertion);
 	});
 

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -145,12 +145,12 @@ describe('assertionTemplate', () => {
 	it('can set a child', () => {
 		const h = harness(() => w(MyWidget, { replaceChild: true }));
 		const childAssertion = baseAssertion.setChildren('~header', ['replace']);
-		h.expect(childAssertion);
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
 			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
+		h.expect(childAssertion);
 	});
 
 	it('can set a child with a factory function', () => {
@@ -162,12 +162,12 @@ describe('assertionTemplate', () => {
 	it('can set a child with replace', () => {
 		const h = harness(() => w(MyWidget, { replaceChild: true }));
 		const childAssertion = baseAssertion.replaceChildren('~header', ['replace']);
-		h.expect(childAssertion);
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
 			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
+		h.expect(childAssertion);
 	});
 
 	it('can set a child with replace with a factory function', () => {
@@ -179,12 +179,12 @@ describe('assertionTemplate', () => {
 	it('can set a child with prepend', () => {
 		const h = harness(() => w(MyWidget, { prependChild: true }));
 		const childAssertion = baseAssertion.prepend('~header', ['prepend']);
-		h.expect(childAssertion);
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
 			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
+		h.expect(childAssertion);
 	});
 
 	it('can set a child with prepend with a factory function', () => {
@@ -196,12 +196,12 @@ describe('assertionTemplate', () => {
 	it('can set a child with append', () => {
 		const h = harness(() => w(MyWidget, { appendChild: true }));
 		const childAssertion = baseAssertion.append('~header', ['append']);
-		h.expect(childAssertion);
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
 			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
+		h.expect(childAssertion);
 	});
 
 	it('can set a child with append with a factory function', () => {
@@ -213,12 +213,12 @@ describe('assertionTemplate', () => {
 	it('can set children after with insert', () => {
 		const h = harness(() => w(MyWidget, { after: true }));
 		const childAssertion = baseAssertion.insertAfter('ul', [v('span', ['after'])]);
-		h.expect(childAssertion);
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
 			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
+		h.expect(childAssertion);
 	});
 
 	it('can set children after with insert with a factory function', () => {
@@ -230,12 +230,12 @@ describe('assertionTemplate', () => {
 	it('can set children before with insert', () => {
 		const h = harness(() => w(MyWidget, { before: true }));
 		const childAssertion = baseAssertion.insertBefore('ul', [v('span', ['before'])]);
-		h.expect(childAssertion);
 		assert.isTrue(consoleStub.calledOnce);
 		assert.strictEqual(
 			consoleStub.firstCall.args[0],
 			'The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.'
 		);
+		h.expect(childAssertion);
 	});
 
 	it('can set children before with insert with a factory function', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Extends the API for `AssertionTemplate` methods that work with children to support a function. This is the recommended way to work with these APIs to avoid issues with mutability.

Adds warning that the `DNode[]` API has been deprecated in favour of using a function `() => DNode[]`.

Warning: 

```
The array API (`children: DNode[]`) has been deprecated. Working with children should use a factory to avoid issues with mutation.
```

Resolves #333 
