### PR TITLE
Convert routing widgets to functional widgets and use middleware

### DIFF
--- a/src/routing/ActiveLink.ts
+++ b/src/routing/ActiveLink.ts
@@ -1,11 +1,10 @@
-import WidgetBase from '../core/WidgetBase';
-import { WNode, SupportedClassName } from '../core/interfaces';
-import diffProperty from '../core/decorators/diffProperty';
-import { LinkProperties } from './interfaces';
-import Link from './Link';
+import { create, diffProperty, invalidator, w } from '../core/vdom';
+import { Handle } from '../core/Destroyable';
+import injector from '../core/middleware/injector';
+import cache from '../core/middleware/cache';
+import { SupportedClassName } from '../core/interfaces';
+import Link, { LinkProperties } from './Link';
 import Router from './Router';
-import { Handle } from '../shim/interfaces';
-import { w } from '../core/vdom';
 
 export interface ActiveLinkProperties extends LinkProperties {
 	activeClasses: SupportedClassName[];
@@ -15,50 +14,55 @@ function paramsEqual(linkParams: any = {}, contextParams: any = {}) {
 	return Object.keys(linkParams).every((key) => linkParams[key] === contextParams[key]);
 }
 
-export class ActiveLink extends WidgetBase<ActiveLinkProperties> {
-	private _outletHandle: Handle | undefined;
+const factory = create({ injector, diffProperty, cache, invalidator }).properties<ActiveLinkProperties>();
 
-	private _renderLink(isActive = false) {
-		let { activeClasses, classes = [], ...props } = this.properties;
+export const ActiveLink = factory(function ActiveLink({
+	middleware: { diffProperty, injector, cache, invalidator },
+	properties,
+	children
+}) {
+	const { to, routerKey = 'router', params } = properties;
+	let { activeClasses, classes = [], ...props } = properties;
+
+	diffProperty('to', (current: ActiveLinkProperties, next: ActiveLinkProperties) => {
+		if (current.to !== next.to) {
+			const router = injector.get<Router>(routerKey);
+			const currentHandle = cache.get<Handle>('handle');
+			if (currentHandle) {
+				currentHandle.destroy();
+			}
+			if (router) {
+				const handle = router.on('outlet', ({ outlet }) => {
+					if (outlet.id === to) {
+						invalidator();
+					}
+				});
+				cache.set('handle', handle);
+			}
+			invalidator();
+		}
+	});
+
+	const router = injector.get<Router>(routerKey);
+	if (router) {
+		if (!cache.get('handle')) {
+			const handle = router.on('outlet', ({ outlet }) => {
+				if (outlet.id === to) {
+					invalidator();
+				}
+			});
+			cache.set('handle', handle);
+		}
+		const context = router.getOutlet(to);
+		const isActive = context && paramsEqual(params, context.params);
+
 		classes = Array.isArray(classes) ? classes : [classes];
 		if (isActive) {
 			classes = [...classes, ...activeClasses];
 		}
 		props = { ...props, classes };
-		return w(Link, props, this.children);
 	}
-
-	@diffProperty('to')
-	protected _onOutletPropertyChange(previous: ActiveLinkProperties, current: ActiveLinkProperties) {
-		const { to, routerKey = 'router' } = current;
-		const item = this.registry.getInjector<Router>(routerKey);
-		if (this._outletHandle) {
-			this._outletHandle.destroy();
-			this._outletHandle = undefined;
-		}
-		if (item) {
-			const router = item.injector();
-			this._outletHandle = router.on('outlet', ({ outlet }) => {
-				if (outlet.id === to) {
-					this.invalidate();
-				}
-			});
-		}
-	}
-
-	protected render(): WNode {
-		const { to, routerKey = 'router', params } = this.properties;
-		const item = this.registry.getInjector<Router>(routerKey);
-		if (!item) {
-			return this._renderLink();
-		}
-		const router = item.injector();
-		const context = router.getOutlet(to);
-
-		const isActive = context && paramsEqual(params, context.params);
-
-		return this._renderLink(isActive);
-	}
-}
+	return w(Link, props, children);
+});
 
 export default ActiveLink;

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -1,16 +1,12 @@
 const { describe, it } = intern.getInterface('bdd');
-const { assert } = intern.getPlugin('chai');
-const { describe: jsdomDescribe } = intern.getPlugin('jsdom');
-
 import { Registry } from '../../../src/core/Registry';
 
 import { Router } from '../../../src/routing/Router';
 import { MemoryHistory } from '../../../src/routing/history/MemoryHistory';
 import Link from '../../../src/routing/Link';
 import ActiveLink from '../../../src/routing/ActiveLink';
-import { registerRouterInjector } from '../../../src/routing/RouterInjector';
-import { renderer, w, v } from '../../../src/core/vdom';
-import WidgetBase from '../../../src/core/WidgetBase';
+import { w, create, getRegistry } from '../../../src/core/vdom';
+
 import harness from '../../../src/testing/harness';
 
 const registry = new Registry();
@@ -47,205 +43,99 @@ const router = new Router(
 
 registry.defineInjector('router', () => () => router);
 
-class BaseActiveLink extends ActiveLink {
-	constructor() {
-		super();
-		this.registry.base = registry;
-	}
-}
+const factory = create();
+
+const mockGetRegistry = factory(() => {
+	return () => {
+		return registry;
+	};
+});
 
 describe('ActiveLink', () => {
-	it('should invalidate when the outlet has been matched', () => {
-		let invalidateCallCount = 0;
-
-		class MyActiveLink extends BaseActiveLink {
-			invalidate() {
-				super.invalidate();
-				invalidateCallCount++;
-			}
-		}
-
-		const h = harness(() => w(MyActiveLink, { to: 'foo', activeClasses: ['foo'] }));
-		h.expect(() => w(Link, { classes: [], to: 'foo' }));
-
-		invalidateCallCount = 0;
-		router.setPath('/foo');
-		assert.strictEqual(invalidateCallCount, 1);
-		router.setPath('/foo/bar');
-		assert.strictEqual(invalidateCallCount, 1);
-		router.setPath('/baz');
-		assert.strictEqual(invalidateCallCount, 2);
-	});
-
-	it('Does not add active class when outlet is not active', () => {
+	it('Should add and remove active class as the outlet match status changes', () => {
 		router.setPath('/other');
-		const h = harness(() => w(BaseActiveLink, { to: 'foo', activeClasses: ['foo', undefined, null] }));
+		const h = harness(() => w(ActiveLink, { to: 'foo', activeClasses: ['foo', undefined, null] }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
 		h.expect(() => w(Link, { classes: [], to: 'foo' }));
-	});
-
-	it('Should add the active class when the outlet is active', () => {
 		router.setPath('/foo');
-		const h = harness(() => w(BaseActiveLink, { to: 'foo', activeClasses: ['foo', undefined, null] }));
 		h.expect(() => w(Link, { classes: ['foo', undefined, null], to: 'foo' }));
 	});
 
 	it('Should render the ActiveLink children', () => {
 		router.setPath('/foo');
-		const h = harness(() => w(BaseActiveLink, { to: 'foo', activeClasses: ['foo'] }, ['hello']));
+		const h = harness(() => w(ActiveLink, { to: 'foo', activeClasses: ['foo'] }, ['hello']), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
 		h.expect(() => w(Link, { classes: ['foo'], to: 'foo' }, ['hello']));
 	});
 
 	it('Should mix the active class onto existing string class when the outlet is active', () => {
 		router.setPath('/foo');
-		const h = harness(() => w(BaseActiveLink, { to: 'foo', activeClasses: ['foo'], classes: 'bar' }));
+		const h = harness(() => w(ActiveLink, { to: 'foo', activeClasses: ['foo'], classes: 'bar' }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
 		h.expect(() => w(Link, { classes: ['bar', 'foo'], to: 'foo' }));
 	});
 
 	it('Should mix the active class onto existing array of classes when the outlet is active', () => {
 		router.setPath('/foo');
-		const h = harness(() =>
-			w(BaseActiveLink, { to: 'foo', activeClasses: ['foo', 'qux'], classes: ['bar', 'baz'] })
-		);
+		const h = harness(() => w(ActiveLink, { to: 'foo', activeClasses: ['foo', 'qux'], classes: ['bar', 'baz'] }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
 		h.expect(() => w(Link, { classes: ['bar', 'baz', 'foo', 'qux'], to: 'foo' }));
 	});
 
-	it('Should invalidate and re-render when link becomes active', () => {
-		let invalidateCount = 0;
-		router.setPath('/foo');
-
-		class TestActiveLink extends BaseActiveLink {
-			invalidate() {
-				invalidateCount++;
-				super.invalidate();
-			}
-		}
-
-		const h = harness(() => w(TestActiveLink, { to: 'foo', activeClasses: ['foo'] }));
-		h.expect(() => w(Link, { to: 'foo', classes: ['foo'] }));
-
-		invalidateCount = 0;
-		router.setPath('/other');
-		assert.strictEqual(invalidateCount, 1);
-		h.expect(() => w(Link, { to: 'foo', classes: [] }));
-		router.setPath('/foo');
-		assert.strictEqual(invalidateCount, 2);
-		h.expect(() => w(Link, { to: 'foo', classes: ['foo'] }));
-	});
-
 	it('Should support changing the target outlet', () => {
-		let invalidateCount = 0;
 		router.setPath('/foo');
-
-		class TestActiveLink extends BaseActiveLink {
-			invalidate() {
-				invalidateCount++;
-				super.invalidate();
-			}
-		}
 
 		let properties: any = { to: 'foo', activeClasses: ['foo'] };
 
-		const h = harness(() => w(TestActiveLink, properties));
+		const h = harness(() => w(ActiveLink, properties), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
 		h.expect(() => w(Link, { to: 'foo', classes: ['foo'] }));
 
-		invalidateCount = 0;
 		properties = { to: 'other', activeClasses: ['foo'] };
 		h.expect(() => w(Link, { to: 'other', classes: [] }));
-		assert.strictEqual(invalidateCount, 1);
 
 		router.setPath('/foo/bar');
-		assert.strictEqual(invalidateCount, 1);
 		h.expect(() => w(Link, { to: 'other', classes: [] }));
 
 		router.setPath('/other');
-		assert.strictEqual(invalidateCount, 2);
 		h.expect(() => w(Link, { to: 'other', classes: ['foo'] }));
-	});
-
-	it('Should return link when the router injector is not available', () => {
-		router.setPath('/foo');
-		const h = harness(() =>
-			w(BaseActiveLink, { to: 'foo', activeClasses: ['foo'], classes: 'bar', routerKey: 'other' })
-		);
-		h.expect(() => w(Link, { to: 'foo', classes: ['bar'], routerKey: 'other' }));
 	});
 
 	it('should look at route params when determining active', () => {
 		router.setPath('/param/one');
-		const h1 = harness(() =>
-			w(BaseActiveLink, {
-				to: 'suffixed-param',
-				activeClasses: ['foo'],
-				params: {
-					suffix: 'one'
-				}
-			})
+		const h1 = harness(
+			() =>
+				w(ActiveLink, {
+					to: 'suffixed-param',
+					activeClasses: ['foo'],
+					params: {
+						suffix: 'one'
+					}
+				}),
+			{
+				middleware: [[getRegistry, mockGetRegistry]]
+			}
 		);
 		h1.expect(() => w(Link, { to: 'suffixed-param', classes: ['foo'], params: { suffix: 'one' } }));
 
-		const h2 = harness(() =>
-			w(BaseActiveLink, {
-				to: 'suffixed-param',
-				activeClasses: ['foo'],
-				params: {
-					suffix: 'two'
-				}
-			})
+		const h2 = harness(
+			() =>
+				w(ActiveLink, {
+					to: 'suffixed-param',
+					activeClasses: ['foo'],
+					params: {
+						suffix: 'two'
+					}
+				}),
+			{
+				middleware: [[getRegistry, mockGetRegistry]]
+			}
 		);
 		h2.expect(() => w(Link, { to: 'suffixed-param', classes: [], params: { suffix: 'two' } }));
-	});
-
-	jsdomDescribe('integration tests', () => {
-		it('should render outlets correctly', () => {
-			const registry = new Registry();
-			const router = registerRouterInjector(
-				[
-					{
-						path: 'foo',
-						outlet: 'foo',
-						defaultRoute: true
-					},
-					{
-						path: 'bar',
-						outlet: 'bar'
-					},
-					{
-						path: 'baz',
-						outlet: 'baz'
-					}
-				],
-				registry,
-				{ HistoryManager: MemoryHistory }
-			);
-
-			class App extends WidgetBase {
-				protected render() {
-					return v('div', [
-						w(ActiveLink, { to: 'foo', activeClasses: ['foo'] }),
-						w(ActiveLink, { to: 'bar', activeClasses: ['bar'] }),
-						w(ActiveLink, { to: 'baz', activeClasses: ['baz'] })
-					]);
-				}
-			}
-
-			const root = document.createElement('div') as any;
-			const r = renderer(() => w(App, {}));
-			r.mount({ domNode: root, sync: true, registry });
-			assert.strictEqual(root.childNodes[0].childNodes[0].getAttribute('class'), 'foo');
-			assert.isNull(root.childNodes[0].childNodes[1].getAttribute('class'));
-			assert.isNull(root.childNodes[0].childNodes[2].getAttribute('class'));
-			router.setPath('/bar');
-			assert.isNull(root.childNodes[0].childNodes[0].getAttribute('class'));
-			assert.strictEqual(root.childNodes[0].childNodes[1].getAttribute('class'), 'bar');
-			assert.isNull(root.childNodes[0].childNodes[2].getAttribute('class'));
-			router.setPath('/baz');
-			assert.isNull(root.childNodes[0].childNodes[0].getAttribute('class'));
-			assert.isNull(root.childNodes[0].childNodes[1].getAttribute('class'));
-			assert.strictEqual(root.childNodes[0].childNodes[2].getAttribute('class'), 'baz');
-			router.setPath('/foo');
-			assert.strictEqual(root.childNodes[0].childNodes[0].getAttribute('class'), 'foo');
-			assert.isNull(root.childNodes[0].childNodes[1].getAttribute('class'));
-			assert.isNull(root.childNodes[0].childNodes[2].getAttribute('class'));
-		});
 	});
 });

--- a/tests/routing/unit/Link.ts
+++ b/tests/routing/unit/Link.ts
@@ -2,7 +2,7 @@ const { beforeEach, afterEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { spy, SinonSpy } from 'sinon';
 
-import { v, w } from '../../../src/core/vdom';
+import { v, w, create, getRegistry } from '../../../src/core/vdom';
 import { Registry } from '../../../src/core/Registry';
 import { Link } from '../../../src/routing/Link';
 import { Router } from '../../../src/routing/Router';
@@ -49,14 +49,15 @@ function createMockEvent(
 	};
 }
 
-class TestLink extends Link {
-	constructor() {
-		super();
-		this.registry.base = registry;
-	}
-}
-
 const noop: any = () => {};
+
+const factory = create();
+
+const mockGetRegistry = factory(() => {
+	return () => {
+		return registry;
+	};
+});
 
 describe('Link', () => {
 	beforeEach(() => {
@@ -68,36 +69,44 @@ describe('Link', () => {
 	});
 
 	it('Generate link component for basic outlet', () => {
-		const h = harness(() => w(TestLink, { to: 'foo' }));
+		const h = harness(() => w(Link, { to: 'foo' }), { middleware: [[getRegistry, mockGetRegistry]] });
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 	});
 
 	it('Generate link component for outlet with specified params', () => {
-		const h = harness(() => w(TestLink, { to: 'foo2', params: { foo: 'foo' } }));
+		const h = harness(() => w(Link, { to: 'foo2', params: { foo: 'foo' } }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
 		h.expect(() => v('a', { href: 'foo/foo', onclick: noop }));
 	});
 
 	it('Generate link component for fixed href', () => {
-		const h = harness(() => w(TestLink, { to: '#foo/static', isOutlet: false }));
+		const h = harness(() => w(Link, { to: '#foo/static', isOutlet: false }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
 		h.expect(() => v('a', { href: '#foo/static', onclick: noop }));
 	});
 
 	it('Set router path on click', () => {
-		const h = harness(() => w(TestLink, { to: '#foo/static', isOutlet: false }));
+		const h = harness(() => w(Link, { to: '#foo/static', isOutlet: false }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
 		h.expect(() => v('a', { href: '#foo/static', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent());
 		assert.isTrue(routerSetPathSpy.calledWith('#foo/static'));
 	});
 
 	it('Custom onClick handler can prevent default', () => {
-		const h = harness(() =>
-			w(TestLink, {
-				to: 'foo',
-				registry,
-				onClick(event: MouseEvent) {
-					event.preventDefault();
-				}
-			})
+		const h = harness(
+			() =>
+				w(Link, {
+					to: 'foo',
+					registry,
+					onClick(event: MouseEvent) {
+						event.preventDefault();
+					}
+				}),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
 		);
 		h.expect(() => v('a', { href: 'foo', registry, onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent());
@@ -105,28 +114,30 @@ describe('Link', () => {
 	});
 
 	it('Does not set router path when target attribute is set', () => {
-		const h = harness(() => w(TestLink, { to: 'foo', target: '_blank' }));
+		const h = harness(() => w(Link, { to: 'foo', target: '_blank' }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent());
 		assert.isTrue(routerSetPathSpy.notCalled);
 	});
 
 	it('Does not set router path on right click', () => {
-		const h = harness(() => w(TestLink, { to: 'foo' }));
+		const h = harness(() => w(Link, { to: 'foo' }), { middleware: [[getRegistry, mockGetRegistry]] });
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent({ isRightClick: true }));
 		assert.isTrue(routerSetPathSpy.notCalled);
 	});
 
 	it('Does not set router path on ctrl click', () => {
-		const h = harness(() => w(TestLink, { to: 'foo' }));
+		const h = harness(() => w(Link, { to: 'foo' }), { middleware: [[getRegistry, mockGetRegistry]] });
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent({ ctrlKey: true }));
 		assert.isTrue(routerSetPathSpy.notCalled);
 	});
 
 	it('Does not set router path on meta click', () => {
-		const h = harness(() => w(TestLink, { to: 'foo' }));
+		const h = harness(() => w(Link, { to: 'foo' }), { middleware: [[getRegistry, mockGetRegistry]] });
 		h.expect(() => v('a', { href: 'foo', onclick: noop }));
 		h.trigger('a', 'onclick', createMockEvent({ metaKey: true }));
 		assert.isTrue(routerSetPathSpy.notCalled);
@@ -134,7 +145,9 @@ describe('Link', () => {
 
 	it('throw error if the injected router cannot be found with the router key', () => {
 		try {
-			harness(() => w(TestLink, { to: '#foo/static', isOutlet: false, routerKey: 'fake-key' }));
+			harness(() => w(Link, { to: '#foo/static', isOutlet: false, routerKey: 'fake-key' }), {
+				middleware: [[getRegistry, mockGetRegistry]]
+			});
 			assert.fail('Should throw an error when the injected router cannot be found with the routerKey');
 		} catch (err) {
 			// nothing to see here

--- a/tests/routing/unit/Outlet.ts
+++ b/tests/routing/unit/Outlet.ts
@@ -1,13 +1,12 @@
 const { beforeEach, describe, it } = intern.getInterface('bdd');
-const { describe: jsdomDescribe } = intern.getPlugin('jsdom');
 const { assert } = intern.getPlugin('chai');
 
 import { WidgetBase } from '../../../src/core/WidgetBase';
-import { MemoryHistory as HistoryManager, MemoryHistory } from '../../../src/routing/history/MemoryHistory';
+import { MemoryHistory as HistoryManager } from '../../../src/routing/history/MemoryHistory';
 import { Outlet } from '../../../src/routing/Outlet';
 import { Registry } from '../../../src/core/Registry';
 import { registerRouterInjector } from '../../../src/routing/RouterInjector';
-import { renderer, w, v } from '../../../src/core/vdom';
+import { w, create, getRegistry } from '../../../src/core/vdom';
 import harness from '../../../src/testing/harness';
 
 class Widget extends WidgetBase {
@@ -35,30 +34,32 @@ const routeConfig = [
 	}
 ];
 
-let BaseOutlet: new (...args: any[]) => Outlet;
+const factory = create();
+
+const mockGetRegistry = factory(() => {
+	return () => {
+		return registry;
+	};
+});
 
 describe('Outlet', () => {
 	beforeEach(() => {
 		registry = new Registry();
-		BaseOutlet = class extends Outlet {
-			constructor() {
-				super();
-				this.registry.base = registry;
-			}
-		};
 	});
 
 	it('Should render the result of the renderer when the outlet matches', () => {
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 
 		router.setPath('/foo');
-		const h = harness(() =>
-			w(BaseOutlet, {
-				id: 'foo',
-				renderer() {
-					return w(Widget, {});
-				}
-			})
+		const h = harness(
+			() =>
+				w(Outlet, {
+					id: 'foo',
+					renderer() {
+						return w(Widget, {});
+					}
+				}),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
 		);
 		h.expect(() => w(Widget, {}, []));
 	});
@@ -67,14 +68,16 @@ describe('Outlet', () => {
 		let matchType: string | undefined;
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo');
-		const h = harness(() =>
-			w(BaseOutlet, {
-				id: 'foo',
-				renderer(details: any) {
-					matchType = details.type;
-					return null;
-				}
-			})
+		const h = harness(
+			() =>
+				w(Outlet, {
+					id: 'foo',
+					renderer(details: any) {
+						matchType = details.type;
+						return null;
+					}
+				}),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
 		);
 		h.expect(() => null);
 		assert.strictEqual(matchType, 'index');
@@ -84,46 +87,19 @@ describe('Outlet', () => {
 		let matchType: string | undefined;
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/foo/other');
-		const h = harness(() =>
-			w(BaseOutlet, {
-				id: 'foo',
-				renderer(details: any) {
-					matchType = details.type;
-					return null;
-				}
-			})
+		const h = harness(
+			() =>
+				w(Outlet, {
+					id: 'foo',
+					renderer(details: any) {
+						matchType = details.type;
+						return null;
+					}
+				}),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
 		);
 		h.expect(() => null);
 		assert.strictEqual(matchType, 'error');
-	});
-
-	it('Should connect the outlet on attach', () => {
-		const routeConfig = [
-			{
-				path: '/foo',
-				outlet: 'foo'
-			}
-		];
-
-		let invalidateCount = 0;
-		class TestOutlet extends BaseOutlet {
-			onAttach() {
-				super.onAttach();
-			}
-
-			invalidate() {
-				invalidateCount++;
-			}
-		}
-
-		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
-		router.setPath('/foo');
-
-		const widget = new TestOutlet();
-		widget.onAttach();
-		invalidateCount = 0;
-		router.setPath('/other');
-		assert.strictEqual(invalidateCount, 1);
 	});
 
 	it('Should render nothing when if no router is available', () => {
@@ -134,126 +110,20 @@ describe('Outlet', () => {
 			}
 		];
 
-		class TestOutlet extends BaseOutlet {
-			onDetach() {
-				super.onDetach();
-			}
-		}
-
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 		router.setPath('/other');
-		const h = harness(() =>
-			w(TestOutlet, {
-				id: 'foo',
-				renderer(details: any) {
-					if (details.type === 'index') {
-						return w(Widget, {});
+		const h = harness(
+			() =>
+				w(Outlet, {
+					id: 'foo',
+					renderer(details: any) {
+						if (details.type === 'index') {
+							return w(Widget, {});
+						}
 					}
-				}
-			})
+				}),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
 		);
 		h.expect(() => null);
-	});
-
-	it('Should change the invalidator if the router key changes', () => {
-		const routeConfig = [
-			{
-				path: '/foo',
-				outlet: 'foo'
-			}
-		];
-
-		let invalidateCount = 0;
-		class TestOutlet extends BaseOutlet {
-			invalidate() {
-				invalidateCount++;
-			}
-		}
-
-		let properties: any = {
-			id: 'foo',
-			routerKey: 'my-router',
-			renderer(details: any) {
-				if (details.type === 'index') {
-					return w(Widget, {});
-				}
-			}
-		};
-
-		const routerOne = registerRouterInjector(routeConfig, registry, { HistoryManager, key: 'my-router' });
-		const routerTwo = registerRouterInjector(routeConfig, registry, { HistoryManager });
-		routerOne.setPath('/foo');
-		const h = harness(() => w(TestOutlet, properties));
-		invalidateCount = 0;
-		routerOne.setPath('/bar');
-		assert.strictEqual(invalidateCount, 1);
-		routerTwo.setPath('/foo');
-		assert.strictEqual(invalidateCount, 1);
-		properties = {
-			id: 'foo',
-			renderer(details: any) {
-				if (details.type === 'index') {
-					return w(Widget, {});
-				}
-			}
-		};
-		h.expect(() => w(Widget, {}));
-		assert.strictEqual(invalidateCount, 3);
-		routerOne.setPath('/bar');
-		assert.strictEqual(invalidateCount, 3);
-		routerTwo.setPath('/bar');
-		assert.strictEqual(invalidateCount, 4);
-	});
-
-	jsdomDescribe('integration tests', () => {
-		it('should render outlets correctly', () => {
-			const registry = new Registry();
-			const router = registerRouterInjector(
-				[
-					{
-						path: 'foo',
-						outlet: 'foo',
-						defaultRoute: true
-					},
-					{
-						path: 'bar',
-						outlet: 'bar'
-					},
-					{
-						path: 'baz',
-						outlet: 'baz'
-					}
-				],
-				registry,
-				{ HistoryManager: MemoryHistory }
-			);
-
-			class Item extends WidgetBase {
-				protected render() {
-					return `${this.properties.key}`;
-				}
-			}
-
-			class App extends WidgetBase {
-				protected render() {
-					return v('div', [
-						w(Outlet, { key: 'foo', id: 'foo', renderer: () => w(Item, { key: 'foo' }) }),
-						w(Outlet, { key: 'bar', id: 'bar', renderer: () => w(Item, { key: 'bar' }) }),
-						w(Outlet, { key: 'baz', id: 'baz', renderer: () => w(Item, { key: 'baz' }) })
-					]);
-				}
-			}
-
-			const root = document.createElement('div');
-			const r = renderer(() => w(App, {}));
-			r.mount({ domNode: root, sync: true, registry });
-			assert.strictEqual(root.outerHTML, '<div><div>foo</div></div>');
-			router.setPath('/bar');
-			assert.strictEqual(root.outerHTML, '<div><div>bar</div></div>');
-			router.setPath('/baz');
-			assert.strictEqual(root.outerHTML, '<div><div>baz</div></div>');
-			router.setPath('/foo');
-			assert.strictEqual(root.outerHTML, '<div><div>foo</div></div>');
-		});
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Converts the existing `Link`, `ActiveLink` and `Outlet` class widgets to function widgets leveraging middleware.

Related to #352 
