### PR TITLE
Default export for `Outlet`

### DIFF
--- a/src/routing/Outlet.ts
+++ b/src/routing/Outlet.ts
@@ -54,3 +54,5 @@ export const Outlet = factory(function Outlet({
 	}
 	return null;
 });
+
+export default Outlet;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Default export for `Outlet`.