### PR TITLE
Make middleware argument mandatory for create factory

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -651,7 +651,7 @@ function createFactory(callback: any, middlewares: any): any {
 }
 
 export function create<T extends MiddlewareMap<any>, MiddlewareProps = ReturnType<T[keyof T]>['properties']>(
-	middlewares: T = {} as T
+	middlewares: T
 ) {
 	function properties<Props extends {}>() {
 		function returns<ReturnValue>(
@@ -681,7 +681,7 @@ export function create<T extends MiddlewareMap<any>, MiddlewareProps = ReturnTyp
 	return returns;
 }
 
-const factory = create();
+const factory = create({});
 
 function wrapNodes(renderer: () => RenderResult) {
 	const result = renderer();

--- a/src/testing/harness.ts
+++ b/src/testing/harness.ts
@@ -52,7 +52,7 @@ interface HarnessOptions {
 	middleware?: [MiddlewareResultFactory<any, any, any>, MiddlewareResultFactory<any, any, any>][];
 }
 
-const factory = create();
+const factory = create({});
 
 export function harness(renderFunc: () => WNode, options?: HarnessOptions): HarnessAPI;
 export function harness(renderFunc: () => WNode, customComparator?: CustomComparator[]): HarnessAPI;

--- a/tests/core/unit/Registry.ts
+++ b/tests/core/unit/Registry.ts
@@ -182,7 +182,7 @@ registerSuite('Registry', {
 				factoryRegistry.define('my-widget', lazyFactory);
 				factoryRegistry.get('my-widget');
 
-				const factory = create();
+				const factory = create({});
 				const Widget = factory(() => 'factory');
 
 				resolveFunction!({

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3016,7 +3016,7 @@ jsdomDescribe('vdom', () => {
 			});
 
 			it('Should render nodes in the correct order with mix of vnode and wnodes', () => {
-				const createWidget = create();
+				const createWidget = create({});
 
 				const WidgetOne = createWidget(() => WidgetTwo({}));
 				const WidgetTwo = createWidget(() => v('div', ['dom2']));
@@ -3073,7 +3073,7 @@ jsdomDescribe('vdom', () => {
 
 			it('supports widget registry items', () => {
 				const registry = new Registry();
-				const createWidget = create();
+				const createWidget = create({});
 				const Foo = createWidget.properties<{ text: string }>()(({ properties }) => v('h1', [properties.text]));
 				const Bar = createWidget.properties<{ text: string }>()(({ properties }) => v('h1', [properties.text]));
 
@@ -3094,7 +3094,7 @@ jsdomDescribe('vdom', () => {
 			});
 
 			it('support top level registry items', () => {
-				const createWidget = create();
+				const createWidget = create({});
 				const registry = new Registry();
 				const Foo = createWidget(() => 'Top Level Registry');
 
@@ -3124,7 +3124,7 @@ jsdomDescribe('vdom', () => {
 			});
 
 			it('Should pause rendering while merging to allow lazily loaded widgets to be loaded', () => {
-				const createWidget = create();
+				const createWidget = create({});
 				const iframe = document.createElement('iframe');
 				document.body.appendChild(iframe);
 				iframe.contentDocument!.write(`<div><span>54321</span><span>98765</span><span>12345</span></div>`);
@@ -3183,7 +3183,7 @@ jsdomDescribe('vdom', () => {
 			});
 
 			it('registry items', () => {
-				const createWidget = create();
+				const createWidget = create({});
 				let resolver = () => {};
 				const registry = new Registry();
 				const Widget = createWidget(() => v('div', ['Hello, world!']));

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -43,7 +43,7 @@ const router = new Router(
 
 registry.defineInjector('router', () => () => router);
 
-const factory = create();
+const factory = create({});
 
 const mockGetRegistry = factory(() => {
 	return () => {

--- a/tests/routing/unit/Link.ts
+++ b/tests/routing/unit/Link.ts
@@ -51,7 +51,7 @@ function createMockEvent(
 
 const noop: any = () => {};
 
-const factory = create();
+const factory = create({});
 
 const mockGetRegistry = factory(() => {
 	return () => {

--- a/tests/routing/unit/Outlet.ts
+++ b/tests/routing/unit/Outlet.ts
@@ -34,7 +34,7 @@ const routeConfig = [
 	}
 ];
 
-const factory = create();
+const factory = create({});
 
 const mockGetRegistry = factory(() => {
 	return () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

In TypeScript 3.4.5, defaulting the middleware argument to `{}` works and `properties` are correctly inferred from middleware and the chained `.properties<{ props: number }>()` function.

However in 3.5.1, this inference breaks when the middleware argument is defaulted, this change makes the middleware argument mandatory (until we can find a better way...).

```ts
const factory = create();
```
becomes 
```ts
const factory = create({});
```