### PR TITLE
Fix property inference for middleware

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -365,7 +365,9 @@ export type LazyDefine<W extends WidgetBaseTypes = DefaultWidgetBaseInterface> =
 	registryItem: LazyWidget<W>;
 };
 
-export interface MiddlewareMap<Middleware extends () => { api: any; properties: any }> {
+export interface MiddlewareMap<
+	Middleware extends () => { api: {}; properties: {} } = () => { api: {}; properties: {} }
+> {
 	[index: string]: Middleware;
 }
 

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -650,7 +650,7 @@ function createFactory(callback: any, middlewares: any): any {
 	return factory;
 }
 
-export function create<T extends MiddlewareMap<any>, MiddlewareProps = ReturnType<T[keyof T]>['properties']>(
+export function create<T extends MiddlewareMap, MiddlewareProps = ReturnType<T[keyof T]>['properties']>(
 	middlewares: T = {} as T
 ) {
 	function properties<Props extends {}>() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Default the middleware type to ensure that property inference works for middleware and widgets.

Supersedes #419 
