### PR TITLE
Remove node from handler when DOM node is removed

### DIFF
--- a/src/core/NodeHandler.ts
+++ b/src/core/NodeHandler.ts
@@ -18,23 +18,27 @@ export type NodeHandlerEventMap = {
 };
 
 export class NodeHandler extends Evented<NodeHandlerEventMap> implements NodeHandlerInterface {
-	private _nodeMap = new Map<string, Element>();
+	private _nodeMap = new Map<string | number, Element>();
 
-	public get(key: string): Element | undefined {
+	public get(key: string | number): Element | undefined {
 		return this._nodeMap.get(key);
 	}
 
-	public has(key: string): boolean {
+	public has(key: string | number): boolean {
 		return this._nodeMap.has(key);
 	}
 
-	public add(element: Element, key: string): void {
+	public add(element: Element, key: string | number): void {
 		this._nodeMap.set(key, element);
-		this.emit({ type: key });
+		this.emit({ type: `${key}` });
 	}
 
 	public addRoot(): void {
 		this.emit({ type: NodeEventType.Widget });
+	}
+
+	public remove(key: string | number) {
+		this._nodeMap.delete(key);
 	}
 
 	public addProjector(): void {

--- a/src/core/WidgetBase.ts
+++ b/src/core/WidgetBase.ts
@@ -298,7 +298,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		}
 		const render = this._runBeforeRenders();
 		const dNode = this._runAfterRenders(render());
-		this._nodeHandler.clear();
 		return dNode;
 	}
 

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1402,23 +1402,9 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					next: { domNode },
 					current
 				} = item;
-				const parent = _parentWrapperMap.get(next);
-				if (parent && isWNodeWrapper(parent) && parent.instance) {
-					const instanceData = widgetInstanceMap.get(parent.instance);
-					instanceData && instanceData.nodeHandler.addRoot();
-				}
-
 				const previousProperties = buildPreviousProperties(domNode, current);
 				processProperties(next, previousProperties);
 				runDeferredProperties(next);
-
-				/*const owningWrapper = _nodeToWrapperMap.get(next.node);
-				if (owningWrapper && owningWrapper.instance) {
-					const instanceData = widgetInstanceMap.get(owningWrapper.instance);
-					if (instanceData && next.node.properties.key != null) {
-						instanceData.nodeHandler.add(next.domNode as HTMLElement, `${next.node.properties.key}`);
-					}
-				}*/
 			} else if (item.type === 'delete') {
 				const { current } = item;
 				const { exitAnimation, exitAnimationActive } = current.node.properties;

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1412,13 +1412,13 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				processProperties(next, previousProperties);
 				runDeferredProperties(next);
 
-				const owningWrapper = _nodeToWrapperMap.get(next.node);
+				/*const owningWrapper = _nodeToWrapperMap.get(next.node);
 				if (owningWrapper && owningWrapper.instance) {
 					const instanceData = widgetInstanceMap.get(owningWrapper.instance);
 					if (instanceData && next.node.properties.key != null) {
 						instanceData.nodeHandler.add(next.domNode as HTMLElement, `${next.node.properties.key}`);
 					}
-				}
+				}*/
 			} else if (item.type === 'delete') {
 				const { current } = item;
 				const { exitAnimation, exitAnimationActive } = current.node.properties;
@@ -1431,8 +1431,10 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			} else if (item.type === 'attach') {
 				const { instance, attached } = item;
 				const instanceData = widgetInstanceMap.get(instance);
-				instanceData && instanceData.nodeHandler.addRoot();
-				attached && instanceData && instanceData.onAttach();
+				if (instanceData) {
+					instanceData.nodeHandler.addRoot();
+					attached && instanceData.onAttach();
+				}
 			} else if (item.type === 'detach') {
 				if (item.current.instance) {
 					const instanceData = widgetInstanceMap.get(item.current.instance);
@@ -1973,10 +1975,17 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	function _removeDom({ current }: RemoveDomInstruction): ProcessResult {
 		_wrapperSiblingMap.delete(current);
 		_parentWrapperMap.delete(current);
-		const widgetMeta = widgetMetaMap.get(current.owningId);
-		if (widgetMeta && current.node.properties.key) {
-			widgetMeta.nodeMap.delete(current.node.properties.key);
+		if (current.node.properties.key) {
+			const widgetMeta = widgetMetaMap.get(current.owningId);
+			const parentWrapper = _idToWrapperMap.get(current.owningId);
+			if (widgetMeta) {
+				widgetMeta.nodeMap.delete(current.node.properties.key);
+			} else if (parentWrapper && parentWrapper.instance) {
+				const instanceData = widgetInstanceMap.get(parentWrapper.instance);
+				instanceData && instanceData.nodeHandler.remove(current.node.properties.key);
+			}
 		}
+
 		if (current.hasAnimations) {
 			return {
 				item: { current: current.childrenWrappers, meta: {} },

--- a/tests/core/unit/NodeHandler.ts
+++ b/tests/core/unit/NodeHandler.ts
@@ -27,6 +27,12 @@ registerSuite('NodeHandler', {
 			nodeHandler.add(element, 'foo');
 			assert.equal(nodeHandler.get('foo'), element);
 		},
+		'remove node from nodehandler map'() {
+			nodeHandler.add(element, 'foo');
+			assert.isTrue(nodeHandler.has('foo'));
+			nodeHandler.remove('foo');
+			assert.isFalse(nodeHandler.has('foo'));
+		},
 		'clear removes nodes from map'() {
 			nodeHandler.add(element, 'foo');
 			assert.isTrue(nodeHandler.has('foo'));

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -5570,11 +5570,6 @@ jsdomDescribe('vdom', () => {
 			const div = document.createElement('div');
 			r.mount({ domNode: div, sync: true });
 			assert.isTrue(meta.nodeHandlerStub.addRoot.called);
-			meta.nodeHandlerStub.addRoot.resetHistory();
-			meta.invalidate();
-
-			assert.isTrue(meta.nodeHandlerStub.addRoot.called);
-			meta.nodeHandlerStub.addRoot.resetHistory();
 		});
 
 		it('addRoot called on node handler for updated widgets with key', () => {
@@ -5582,9 +5577,6 @@ jsdomDescribe('vdom', () => {
 			const r = renderer(() => w(Widget, {}));
 			const div = document.createElement('div');
 			r.mount({ domNode: div, sync: true });
-			assert.isTrue(meta.nodeHandlerStub.addRoot.called);
-			meta.nodeHandlerStub.addRoot.resetHistory();
-			meta.invalidate();
 			assert.isTrue(meta.nodeHandlerStub.addRoot.called);
 		});
 	});

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -36,7 +36,8 @@ function getWidget(renderResult: any) {
 			private _renderResult: any | (() => any) = renderResult;
 			private _nodeHandlerStub = {
 				add: stub(),
-				addRoot: stub()
+				addRoot: stub(),
+				remove: stub()
 			};
 			private _onElementCreatedStub = stub();
 			private _onElementUpdatedStub = stub();
@@ -5540,11 +5541,6 @@ jsdomDescribe('vdom', () => {
 			r.mount({ domNode: div, sync: true });
 			assert.isTrue(meta.nodeHandlerStub.add.called);
 			assert.isTrue(meta.nodeHandlerStub.add.calledWith(div.childNodes[0] as Element, '1'));
-			meta.nodeHandlerStub.add.resetHistory();
-			meta.setRenderResult(v('div', { key: '1' }));
-
-			assert.isTrue(meta.nodeHandlerStub.add.called);
-			assert.isTrue(meta.nodeHandlerStub.add.calledWith(div.childNodes[0] as Element, '1'));
 		});
 
 		it('element added on update to node handler for nodes with a key of 0', () => {
@@ -5554,11 +5550,18 @@ jsdomDescribe('vdom', () => {
 			r.mount({ domNode: div, sync: true });
 			assert.isTrue(meta.nodeHandlerStub.add.called);
 			assert.isTrue(meta.nodeHandlerStub.add.calledWith(div.childNodes[0] as Element, '0'));
-			meta.nodeHandlerStub.add.resetHistory();
-			meta.setRenderResult(v('div', { key: 0 }));
+		});
 
+		it('element removed when dom node removed', () => {
+			const [Widget, meta] = getWidget(v('div', { key: '1' }));
+			const r = renderer(() => w(Widget, {}));
+			const div = document.createElement('div');
+			r.mount({ domNode: div, sync: true });
 			assert.isTrue(meta.nodeHandlerStub.add.called);
-			assert.isTrue(meta.nodeHandlerStub.add.calledWith(div.childNodes[0] as Element, '0'));
+			assert.isTrue(meta.nodeHandlerStub.add.calledWith(div.childNodes[0] as Element, '1'));
+			meta.setRenderResult(null);
+			assert.isTrue(meta.nodeHandlerStub.remove.called);
+			assert.isTrue(meta.nodeHandlerStub.remove.calledWith('1'));
 		});
 
 		it('addRoot called on node handler for created widgets with a zero key', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Clearing the node handler after the widget render no longer works as deferred properties are now resolved in vdom. There is no need to clear the entire node map, we can just remove the nodes from the map when the dom node is removed.