### PR TITLE
Do not queue an invalidation when an invalidate occurs during a render

### DIFF
--- a/src/routing/Outlet.ts
+++ b/src/routing/Outlet.ts
@@ -37,8 +37,8 @@ export const Outlet = factory(function Outlet({
 			if (handle) {
 				cache.set('handle', handle);
 			}
-			invalidator();
 		}
+		invalidator();
 	});
 	const router = injector.get<Router>(routerKey);
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

From realworld testing some small issue have been identified and resolved:

* Do not add a widget on the invalidation queue when the invalidate occurs whilst "rendering"
* Do not run deferred properties if the owning widget has been destroyed
* Revert change for `Outlet` that moved `invalidate` inside the property diff condition, since it always needs to re-render from the parent.
