### PR TITLE
Virtual Node Support

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1927,14 +1927,13 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			}
 		}
 		setDomNodeOnParentWrapper(next);
-		let dom: ApplicationInstruction | undefined;
-		if (!isVirtual) {
-			dom = {
-				next: next!,
-				parentDomNode: parentDomNode,
-				type: 'create'
-			};
-		}
+		const dom: ApplicationInstruction | undefined = isVirtual
+			? undefined
+			: {
+					next: next!,
+					parentDomNode: parentDomNode,
+					type: 'create'
+			  };
 		if (next.childrenWrappers) {
 			return {
 				item: {

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1885,7 +1885,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	function _createDom({ next }: CreateDomInstruction): ProcessResult {
 		let mergeNodes: Node[] = [];
 		const parentDomNode = findParentDomNode(next)!;
-		const isFragment = next.node.tag === 'fragment';
+		const isVirtual = next.node.tag === 'virtual';
 		if (!next.domNode) {
 			if ((next.node as any).domNode) {
 				next.domNode = (next.node as any).domNode;
@@ -1893,7 +1893,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				if (next.node.tag === 'svg') {
 					next.namespace = NAMESPACE_SVG;
 				}
-				if (next.node.tag && !isFragment) {
+				if (next.node.tag && !isVirtual) {
 					if (next.namespace) {
 						next.domNode = global.document.createElementNS(next.namespace, next.node.tag);
 					} else {
@@ -1921,14 +1921,14 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				_allMergedNodes = [..._allMergedNodes, ...mergeNodes];
 			}
 		}
-		if (next.domNode || isFragment) {
+		if (next.domNode || isVirtual) {
 			if (next.node.children && next.node.children.length) {
 				next.childrenWrappers = renderedToWrapper(next.node.children, next, null);
 			}
 		}
 		setDomNodeOnParentWrapper(next);
 		let dom: ApplicationInstruction | undefined;
-		if (!isFragment) {
+		if (!isVirtual) {
 			dom = {
 				next: next!,
 				parentDomNode: parentDomNode,
@@ -1971,7 +1971,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	}
 
 	function _removeDom({ current }: RemoveDomInstruction): ProcessResult {
-		const isFragment = current.node.tag === 'fragment';
+		const isVirtual = current.node.tag === 'virtual';
 		_wrapperSiblingMap.delete(current);
 		_parentWrapperMap.delete(current);
 		if (current.node.properties.key) {
@@ -1984,10 +1984,10 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				instanceData && instanceData.nodeHandler.remove(current.node.properties.key);
 			}
 		}
-		if (current.hasAnimations || isFragment) {
+		if (current.hasAnimations || isVirtual) {
 			return {
 				item: { current: current.childrenWrappers, meta: {} },
-				dom: isFragment ? undefined : { type: 'delete', current }
+				dom: isVirtual ? undefined : { type: 'delete', current }
 			};
 		}
 

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1885,6 +1885,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	function _createDom({ next }: CreateDomInstruction): ProcessResult {
 		let mergeNodes: Node[] = [];
 		const parentDomNode = findParentDomNode(next)!;
+		const isFragment = next.node.tag === 'fragment';
 		if (!next.domNode) {
 			if ((next.node as any).domNode) {
 				next.domNode = (next.node as any).domNode;
@@ -1892,7 +1893,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				if (next.node.tag === 'svg') {
 					next.namespace = NAMESPACE_SVG;
 				}
-				if (next.node.tag) {
+				if (next.node.tag && !isFragment) {
 					if (next.namespace) {
 						next.domNode = global.document.createElementNS(next.namespace, next.node.tag);
 					} else {
@@ -1920,17 +1921,20 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				_allMergedNodes = [..._allMergedNodes, ...mergeNodes];
 			}
 		}
-		if (next.domNode) {
-			if (next.node.children) {
+		if (next.domNode || isFragment) {
+			if (next.node.children && next.node.children.length) {
 				next.childrenWrappers = renderedToWrapper(next.node.children, next, null);
 			}
 		}
 		setDomNodeOnParentWrapper(next);
-		const dom: ApplicationInstruction = {
-			next: next!,
-			parentDomNode: parentDomNode,
-			type: 'create'
-		};
+		let dom: ApplicationInstruction | undefined;
+		if (!isFragment) {
+			dom = {
+				next: next!,
+				parentDomNode: parentDomNode,
+				type: 'create'
+			};
+		}
 		if (next.childrenWrappers) {
 			return {
 				item: {
@@ -1967,6 +1971,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	}
 
 	function _removeDom({ current }: RemoveDomInstruction): ProcessResult {
+		const isFragment = current.node.tag === 'fragment';
 		_wrapperSiblingMap.delete(current);
 		_parentWrapperMap.delete(current);
 		if (current.node.properties.key) {
@@ -1979,11 +1984,10 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				instanceData && instanceData.nodeHandler.remove(current.node.properties.key);
 			}
 		}
-
-		if (current.hasAnimations) {
+		if (current.hasAnimations || isFragment) {
 			return {
 				item: { current: current.childrenWrappers, meta: {} },
-				dom: { type: 'delete', current }
+				dom: isFragment ? undefined : { type: 'delete', current }
 			};
 		}
 

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3598,39 +3598,39 @@ jsdomDescribe('vdom', () => {
 		});
 	});
 
-	describe('fragment', () => {
-		it('can use a fragment', () => {
-			const [Widget, meta] = getWidget(v('fragment', [v('div', ['one', 'two', v('div', ['three'])])]));
+	describe('virtual node', () => {
+		it('can use a virtual node', () => {
+			const [Widget, meta] = getWidget(v('virtual', [v('div', ['one', 'two', v('div', ['three'])])]));
 			const r = renderer(() => w(Widget, {}));
 			const div = document.createElement('div');
 			r.mount({ domNode: div });
 			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>onetwo<div>three</div></div>');
-			meta.setRenderResult(v('fragment', [v('div', ['four', 'five', v('div', ['six'])])]));
+			meta.setRenderResult(v('virtual', [v('div', ['four', 'five', v('div', ['six'])])]));
 			resolvers.resolve();
 			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>fourfive<div>six</div></div>');
 			meta.setRenderResult(v('div', ['one', 'two', v('div', ['three'])]));
 			resolvers.resolve();
 			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>onetwo<div>three</div></div>');
-			meta.setRenderResult(v('fragment', [v('div', ['four', 'five', v('div', ['six'])])]));
+			meta.setRenderResult(v('virtual', [v('div', ['four', 'five', v('div', ['six'])])]));
 			resolvers.resolve();
 			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>fourfive<div>six</div></div>');
 		});
 
-		it('can use a fragment with widgets', () => {
+		it('can use a virtual node with widgets', () => {
 			class Foo extends WidgetBase<any> {
 				render() {
 					return v('div', [this.properties.text]);
 				}
 			}
 			const [Widget, meta] = getWidget(
-				v('fragment', [w(Foo, { text: 'one' }), w(Foo, { text: 'two' }), w(Foo, { text: 'three' })])
+				v('virtual', [w(Foo, { text: 'one' }), w(Foo, { text: 'two' }), w(Foo, { text: 'three' })])
 			);
 			const r = renderer(() => w(Widget, {}));
 			const div = document.createElement('div');
 			r.mount({ domNode: div });
 			assert.strictEqual(div.outerHTML, '<div><div>one</div><div>two</div><div>three</div></div>');
 			meta.setRenderResult(
-				v('fragment', [w(Foo, { text: 'four' }), w(Foo, { text: 'five' }), w(Foo, { text: 'six' })])
+				v('virtual', [w(Foo, { text: 'four' }), w(Foo, { text: 'five' }), w(Foo, { text: 'six' })])
 			);
 			resolvers.resolve();
 			assert.strictEqual(div.outerHTML, '<div><div>four</div><div>five</div><div>six</div></div>');
@@ -3638,7 +3638,7 @@ jsdomDescribe('vdom', () => {
 			resolvers.resolve();
 			assert.strictEqual(div.outerHTML, '<div><div>one</div><div>two</div><div>three</div></div>');
 			meta.setRenderResult(
-				v('fragment', [w(Foo, { text: 'four' }), w(Foo, { text: 'five' }), w(Foo, { text: 'six' })])
+				v('virtual', [w(Foo, { text: 'four' }), w(Foo, { text: 'five' }), w(Foo, { text: 'six' })])
 			);
 			resolvers.resolve();
 			assert.strictEqual(div.outerHTML, '<div><div>four</div><div>five</div><div>six</div></div>');

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3598,6 +3598,53 @@ jsdomDescribe('vdom', () => {
 		});
 	});
 
+	describe('fragment', () => {
+		it('can use a fragment', () => {
+			const [Widget, meta] = getWidget(v('fragment', [v('div', ['one', 'two', v('div', ['three'])])]));
+			const r = renderer(() => w(Widget, {}));
+			const div = document.createElement('div');
+			r.mount({ domNode: div });
+			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>onetwo<div>three</div></div>');
+			meta.setRenderResult(v('fragment', [v('div', ['four', 'five', v('div', ['six'])])]));
+			resolvers.resolve();
+			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>fourfive<div>six</div></div>');
+			meta.setRenderResult(v('div', ['one', 'two', v('div', ['three'])]));
+			resolvers.resolve();
+			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>onetwo<div>three</div></div>');
+			meta.setRenderResult(v('fragment', [v('div', ['four', 'five', v('div', ['six'])])]));
+			resolvers.resolve();
+			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>fourfive<div>six</div></div>');
+		});
+
+		it('can use a fragment with widgets', () => {
+			class Foo extends WidgetBase<any> {
+				render() {
+					return v('div', [this.properties.text]);
+				}
+			}
+			const [Widget, meta] = getWidget(
+				v('fragment', [w(Foo, { text: 'one' }), w(Foo, { text: 'two' }), w(Foo, { text: 'three' })])
+			);
+			const r = renderer(() => w(Widget, {}));
+			const div = document.createElement('div');
+			r.mount({ domNode: div });
+			assert.strictEqual(div.outerHTML, '<div><div>one</div><div>two</div><div>three</div></div>');
+			meta.setRenderResult(
+				v('fragment', [w(Foo, { text: 'four' }), w(Foo, { text: 'five' }), w(Foo, { text: 'six' })])
+			);
+			resolvers.resolve();
+			assert.strictEqual(div.outerHTML, '<div><div>four</div><div>five</div><div>six</div></div>');
+			meta.setRenderResult([w(Foo, { text: 'one' }), w(Foo, { text: 'two' }), w(Foo, { text: 'three' })]);
+			resolvers.resolve();
+			assert.strictEqual(div.outerHTML, '<div><div>one</div><div>two</div><div>three</div></div>');
+			meta.setRenderResult(
+				v('fragment', [w(Foo, { text: 'four' }), w(Foo, { text: 'five' }), w(Foo, { text: 'six' })])
+			);
+			resolvers.resolve();
+			assert.strictEqual(div.outerHTML, '<div><div>four</div><div>five</div><div>six</div></div>');
+		});
+	});
+
 	describe('properties', () => {
 		it('does not add "key" to the dom node', () => {
 			const [Widget] = getWidget(v('div', { key: '1' }));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for virtual nodes in the rendering engine. This enables nicely returning arrays when using TSX.

```tsx
render() {
    return (
        <virtual><div/><div/></virtual>
    );
}
```

Resolves #424 
