### PR TITLE
Inline MAX_SAFE_INTEGER value so number is included in every app build

### DIFF
--- a/src/shim/array.ts
+++ b/src/shim/array.ts
@@ -1,6 +1,5 @@
 `!has('es6-iterator')`;
 import { isArrayLike, isIterable, Iterable } from './iterator';
-import { MAX_SAFE_INTEGER } from './number';
 import has from '../core/has';
 import { wrapNative } from './support/util';
 
@@ -121,6 +120,8 @@ let toInteger: any;
 let normalizeOffset: any;
 
 if (!has('es6-array') || !has('es6-array-fill') || !has('es7-array')) {
+	const MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
+
 	/**
 	 * Ensures a non-negative, non-infinite, safe integer.
 	 *


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

`MAX_SAFE_INTEGER` is used by array which means that all of `number.ts` is included in application bundles. Duplicating and inlining one variable to ensure that superfluous code isn't included in built application is a good deal.