### PR TITLE
Always set rendering back to false

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1813,11 +1813,11 @@ export function renderer(renderer: () => RenderResult): Renderer {
 						children: next.node.children,
 						middleware: widgetMeta.middleware
 					});
-					widgetMeta.rendering = false;
 					if (widgetMeta.deferRefs > 0) {
 						rendered = null;
 					}
 				}
+				widgetMeta.rendering = false;
 			}
 		} else {
 			const instanceData = widgetInstanceMap.get(instance!)!;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Always set rendering back to false even if the widget is not dirty.