### PR TITLE
Mock Store Middleware

### DIFF
--- a/src/testing/mocks/middleware/store.ts
+++ b/src/testing/mocks/middleware/store.ts
@@ -1,0 +1,74 @@
+import { create, destroy, invalidator } from '../../../core/vdom';
+import injector from '../../../core/middleware/injector';
+import { createStoreMiddleware } from '../../../core/middleware/store';
+import Store, { StatePaths } from '../../../stores/Store';
+import { MiddlewareResult } from '../../../core/interfaces';
+import { PatchOperation } from '../../../stores/state/Patch';
+import { Process } from '../../../stores/process';
+
+const factory = create({ destroy, invalidator, injector });
+
+export function createMockStoreMiddleware<T = any>() {
+	const store = createStoreMiddleware();
+	const calledProcesses = new Map();
+	const storeMock = new Store<T>();
+	const injectorStub = {
+		get: (): any => {
+			return storeMock;
+		},
+		subscribe: (): any => {}
+	};
+	const mockStoreMiddleware = factory(({ properties, middleware: { destroy, invalidator }, children, id }) => {
+		const { callback } = store();
+		const mock = callback({
+			id,
+			middleware: { destroy, invalidator, injector: injectorStub },
+			properties,
+			children
+		});
+		return {
+			get: mock.get.bind(mock),
+			path: mock.path.bind(mock),
+			executor: <T extends Process<any, any>>(process: T): ReturnType<T> => {
+				const executorMock = (...args: any[]) => {
+					const callArgs = calledProcesses.get(process) || [];
+					callArgs.push(...args);
+					calledProcesses.set(process, callArgs);
+				};
+				return executorMock as any;
+			},
+			at: mock.at.bind(mock)
+		};
+	});
+
+	function mockStore(): MiddlewareResult<any, any, any>;
+	function mockStore(operations: (path: StatePaths<T>) => PatchOperation[]): void;
+	function mockStore(operations?: (path: any) => PatchOperation[]): void | MiddlewareResult<any, any, any> {
+		if (operations) {
+			storeMock.apply(operations(storeMock.path), true);
+		} else {
+			return mockStoreMiddleware();
+		}
+	}
+
+	// I think we should expose a way of asserting against processes that are called
+	// not sure whether we should return things for the consumer to assert or assert
+	// internally.
+
+	mockStore.getProcessCall = (process: any, call: number) => {
+		const calls = calledProcesses.get(process);
+		if (calls && calls[call]) {
+			return calls[call];
+		}
+		return null;
+	};
+
+	mockStore.processCallCount = (process: any) => {
+		const calls = calledProcesses.get(process) || [];
+		return calls.length;
+	};
+
+	return mockStore;
+}
+
+export default createMockStoreMiddleware;

--- a/src/testing/mocks/middleware/store.ts
+++ b/src/testing/mocks/middleware/store.ts
@@ -32,7 +32,7 @@ export function createMockStoreMiddleware<T = any>() {
 			executor: <T extends Process<any, any>>(process: T): ReturnType<T> => {
 				const executorMock = (...args: any[]) => {
 					const callArgs = calledProcesses.get(process) || [];
-					callArgs.push(...args);
+					callArgs.push(args);
 					calledProcesses.set(process, callArgs);
 				};
 				return executorMock as any;

--- a/tests/testing/unit/mocks/middleware/all.ts
+++ b/tests/testing/unit/mocks/middleware/all.ts
@@ -1,3 +1,4 @@
 import './intersection';
 import './node';
 import './resize';
+import './store';

--- a/tests/testing/unit/mocks/middleware/store.tsx
+++ b/tests/testing/unit/mocks/middleware/store.tsx
@@ -1,0 +1,87 @@
+const { it, describe } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import createStoreMock from '../../../../../src/testing/mocks/middleware/store';
+import { createStoreMiddleware } from '../../../../../src/core/middleware/store';
+import { tsx, create } from '../../../../../src/core/vdom';
+import harness from '../../../../../src/testing/harness';
+import { createProcess } from '../../../../../src/stores/process';
+import { stub } from 'sinon';
+import { replace } from '../../../../../src/stores/state/operations';
+
+interface State {
+	foo: string;
+	bar: {
+		qux: number;
+	};
+}
+
+const store = createStoreMiddleware<State>();
+
+const myProcess = createProcess('test', [() => {}]);
+const otherProcess = createProcess('other', [() => {}]);
+
+describe('store mock', () => {
+	it('should mock store middleware', () => {
+		const processStub = stub();
+		const storeMock = createStoreMock<State>([[myProcess, processStub]]);
+		const factory = create({ store });
+		const App = factory(({ middleware: { store } }) => {
+			const { get, path, executor } = store;
+			const foo = get(path('foo'));
+			const qux = get(path('bar', 'qux'));
+			return (
+				<div>
+					<button
+						key="button"
+						onclick={() => {
+							executor(myProcess)({ id: 'test' });
+						}}
+					/>
+					<button
+						key="other"
+						onclick={() => {
+							executor(otherProcess)({ id: 'test' });
+						}}
+					/>
+					<span>{foo}</span>
+					{qux && <span>{`${qux}`}</span>}
+				</div>
+			);
+		});
+		const h = harness(() => <App key="app" />, { middleware: [[store, storeMock]] });
+		h.expect(() => {
+			return (
+				<div>
+					<button key="button" onclick={() => {}} />
+					<button key="other" onclick={() => {}} />
+					<span />
+				</div>
+			);
+		});
+		assert.isTrue(processStub.notCalled);
+		h.trigger('@button', 'onclick');
+		h.trigger('@other', 'onclick');
+		assert.isTrue(processStub.calledOnce);
+		storeMock((path) => [replace(path('foo'), 'foo')]);
+		h.expect(() => {
+			return (
+				<div>
+					<button key="button" onclick={() => {}} />
+					<button key="other" onclick={() => {}} />
+					<span>foo</span>
+				</div>
+			);
+		});
+		storeMock((path) => [replace(path('bar'), { qux: 1 })]);
+		h.expect(() => {
+			return (
+				<div>
+					<button key="button" onclick={() => {}} />
+					<button key="other" onclick={() => {}} />
+					<span>foo</span>
+					<span>1</span>
+				</div>
+			);
+		});
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

A mock store middleware testing widgets that use the `store` middleware. Automatically injects an empty store for testing, providing an API for running operations against the store.

```tsx
// Widget
import { create, tsx } from '@dojo/framework/core/vdom'
import createStoreMiddleware from '@dojo/framework/core/middleware/store';

import { myProcess } from './processes';
import MyState from './interfaces';
// application store middleware typed with the state interface
// Example: `const store = createStoreMiddleware<MyState>();`
import store from './store';

const factory = create({ store }).properties<{ id: string }>();

export default factory(function MyWidget({ properties: { id }, middleware: store }) {
    const { path, get, executor } = store; 
    const details = get(path('details');
    let isLoading = get(path('isLoading'));

    if ((!details || details.id !== id) && !isLoading) {
        executor(myProcess)({ id });
        isLoading = true;
    }

    if (isLoading) {
        return <Loading />;
    }

    return <ShowDetails {...details} />;
});

// Test
import createMockStoreMiddleware from '@dojo/framework/testing/mocks/middleware/store';
import harness from '@dojo/framework/testing/harness';

import { myProcess } from './processes';
import MyWidget from './MyWidget';
import MyState from './interfaces';
import store from './store';

// import a stub/mock lib, doesn't have to sinon
import { stub } from 'sinon';

describe('MyWidget', () => {
     it('test', () => {
          const properties = {
               id: 'id'
          };
         const myProcessStub = stub();
         // type safe mock store middleware
         // pass through an array of tuples `[originalProcess, stub]` for mocked processes
         // calls to processes not stubbed/mocked will just be ignored
         const mockStore = createMockStoreMiddleware<MyState>([[myProcess, myProcessStub]]);
         const h = harness(() => <MyWidget {...properties} />, { 
             middleware: [store, mockStore]
         });
         h.expect(/* assertion template for `Loading`*/);

         // would be useful to assert the calls to processes effectively stubbed
         // at the moment there are two APIs from `mockStore` that just return details
         // that need to be asserted in user land
         expect(myProcessStub.calledWith({ id: 'id' })).toBeTruthy();

         mockStore((path) => [replace(path('isLoading', true)]); 
         h.expect(/* assertion template for `Loading`*/);
         expect(myProcessStub.calledOnce()).toBeTruthy();

         // use the mock store to apply operations to the store
         mockStore((path) => [replace(path('details', { id: 'id' })]); 
         mockStore((path) => [replace(path('isLoading', true)]); 

         h.expect(/* assertion template for `ShowDetails`*/);

         properties.id = 'other';
         h.expect(/* assertion template for `Loading`*/);
         expect(myProcessStub.calledTwice()).toBeTruthy();
         expect(myProcessStub.secondCall.calledWith({ id: 'other' })).toBeTruthy();
         mockStore((path) => [replace(path('details', { id: 'other' })]);
         h.expect(/* assertion template for `ShowDetails`*/);
     });
});
```
