### PR TITLE
Defer to, and provide a shim for, globalThis

### DIFF
--- a/src/core/has.ts
+++ b/src/core/has.ts
@@ -476,3 +476,5 @@ add('dom-pointer-events', () => has('host-browser') && global.onpointerdown !== 
 add('build-elide', false);
 
 add('test', false);
+
+add('global-this', () => typeof global.globalThis !== 'undefined');

--- a/src/shim/global.ts
+++ b/src/shim/global.ts
@@ -2,6 +2,9 @@ const globalObject: any = (function(): any {
 	// the only reliable means to get the global object is
 	// `Function('return this')()`
 	// However, this causes CSP violations in Chrome apps.
+	if (typeof globalThis !== 'undefined') {
+		return globalThis;
+	}
 	if (typeof self !== 'undefined') {
 		return self;
 	}

--- a/src/shim/globalThis.ts
+++ b/src/shim/globalThis.ts
@@ -1,0 +1,6 @@
+import global from './global';
+import has from '../core/has';
+
+if (!has('global-this')) {
+	global.globalThis = global;
+}

--- a/tests/shim/unit/all.ts
+++ b/tests/shim/unit/all.ts
@@ -7,6 +7,7 @@ import './util/wrapper';
 import './AbortController';
 import './array';
 import './global';
+import './globalThis';
 import './iterator';
 import './main';
 import './Map';

--- a/tests/shim/unit/globalThis.ts
+++ b/tests/shim/unit/globalThis.ts
@@ -6,7 +6,6 @@ const { assert } = intern.getPlugin('chai');
 
 registerSuite('globalThis', {
 	'ensures that the global object is available as `globalThis`'() {
-		// If tests are running under CSP, unsafe eval will be denied and this test will fail
 		assert.strictEqual(globalObj, globalThis);
 	}
 });

--- a/tests/shim/unit/globalThis.ts
+++ b/tests/shim/unit/globalThis.ts
@@ -1,0 +1,12 @@
+import globalObj from '../../../src/shim/global';
+import '../../../src/shim/globalThis';
+
+const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
+
+registerSuite('globalThis', {
+	'ensures that the global object is available as `globalThis`'() {
+		// If tests are running under CSP, unsafe eval will be denied and this test will fail
+		assert.strictEqual(globalObj, globalThis);
+	}
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Modifies `global.ts` to defer to `globalThis`, and adds a has check and shim for it.
Related to #222 
