### PR TITLE
Fix the order logic dealing with node insertion when using a virtual node

### DIFF
--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3789,25 +3789,25 @@ jsdomDescribe('vdom', () => {
 			r.mount({ domNode: div });
 			assert.strictEqual(
 				div.outerHTML,
-				'<div><div><h2>List</h2><span>Yay 0</span><button>Add</button></div></div>'
+				'<div><div><h2>List</h2><span>Yay 0</span><button>toggle</button></div></div>'
 			);
 			buttonClick();
 			resolvers.resolve();
 			assert.strictEqual(
 				div.outerHTML,
-				'<div><div><h2>List</h2><span>Yay 0</span><div>Toggled</div><span>Yay 1</span><div>Toggled</div><button>Add</button></div></div>'
+				'<div><div><h2>List</h2><span>Yay 0</span><div>Toggled</div><span>Yay 1</span><div>Toggled</div><button>toggle</button></div></div>'
 			);
 			buttonClick();
 			resolvers.resolve();
 			assert.strictEqual(
 				div.outerHTML,
-				'<div><div><h2>List</h2><span>Yay 0</span><span>Yay 1</span><span>Yay 2</span><button>Add</button></div></div>'
+				'<div><div><h2>List</h2><span>Yay 0</span><span>Yay 1</span><span>Yay 2</span><button>toggle</button></div></div>'
 			);
 			buttonClick();
 			resolvers.resolve();
 			assert.strictEqual(
 				div.outerHTML,
-				'<div><div><h2>List</h2><span>Yay 0</span><div>Toggled</div><span>Yay 1</span><div>Toggled</div><span>Yay 2</span><div>Toggled</div><span>Yay 3</span><div>Toggled</div><button>Add</button></div></div>'
+				'<div><div><h2>List</h2><span>Yay 0</span><div>Toggled</div><span>Yay 1</span><div>Toggled</div><span>Yay 2</span><div>Toggled</div><span>Yay 3</span><div>Toggled</div><button>toggle</button></div></div>'
 			);
 		});
 	});

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3760,6 +3760,56 @@ jsdomDescribe('vdom', () => {
 			resolvers.resolve();
 			assert.strictEqual(div.outerHTML, '<div><div>four</div><div>five</div><div>six</div></div>');
 		});
+
+		it('can use virtual node in maps', () => {
+			let buttonClick: any;
+			class App extends WidgetBase {
+				private _items = [0];
+				private _toggled = false;
+
+				constructor() {
+					super();
+					buttonClick = () => {
+						this._toggled = !this._toggled;
+						this._items.push(this._items.length);
+						this.invalidate();
+					};
+				}
+				protected render() {
+					const nodes = this._items.map((item) => {
+						return v('virtual', [v('span', [`Yay ${item}`]), this._toggled && v('div', ['Toggled'])]);
+					});
+
+					return v('div', [v('h2', ['List']), ...nodes, v('button', ['toggle'])]);
+				}
+			}
+			const r = renderer(() => w(App, {}));
+			const div = document.createElement('div');
+			document.body.appendChild(div);
+			r.mount({ domNode: div });
+			assert.strictEqual(
+				div.outerHTML,
+				'<div><div><h2>List</h2><span>Yay 0</span><button>Add</button></div></div>'
+			);
+			buttonClick();
+			resolvers.resolve();
+			assert.strictEqual(
+				div.outerHTML,
+				'<div><div><h2>List</h2><span>Yay 0</span><div>Toggled</div><span>Yay 1</span><div>Toggled</div><button>Add</button></div></div>'
+			);
+			buttonClick();
+			resolvers.resolve();
+			assert.strictEqual(
+				div.outerHTML,
+				'<div><div><h2>List</h2><span>Yay 0</span><span>Yay 1</span><span>Yay 2</span><button>Add</button></div></div>'
+			);
+			buttonClick();
+			resolvers.resolve();
+			assert.strictEqual(
+				div.outerHTML,
+				'<div><div><h2>List</h2><span>Yay 0</span><div>Toggled</div><span>Yay 1</span><div>Toggled</div><span>Yay 2</span><div>Toggled</div><span>Yay 3</span><div>Toggled</div><button>Add</button></div></div>'
+			);
+		});
 	});
 
 	describe('properties', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fixes the logic for node ordering when using a "virtual" node.

Resolves #438 
