### PR TITLE
Node replacement utility

### DIFF
--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -373,12 +373,17 @@ export function decorate(
 		shouldDrain = true;
 	}
 
+	function modifyNode(modifier: Modifier<DNode>, node: DNode) {
+		const modifiedNode = modifier(node, breaker);
+		return modifiedNode === undefined ? node : modifiedNode;
+	}
+
 	let nodes = Array.isArray(dNodes) ? [...dNodes] : [dNodes];
 	for (let i = 0; i < nodes.length; i++) {
 		const node = nodes[i];
 		if (node && node !== true) {
 			if (!predicate || predicate(node)) {
-				nodes[i] = modifier(node, breaker) || node;
+				nodes[i] = modifyNode(modifier, node);
 			}
 		}
 		if (shouldDrain) {
@@ -396,7 +401,7 @@ export function decorate(
 					const child = node.children[i];
 					if (child && child !== true) {
 						if (!predicate || predicate(child)) {
-							node.children[i] = modifier(child, breaker) || child;
+							node.children[i] = modifyNode(modifier, child);
 						}
 					}
 					nodes.push(node.children[i]);

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -1,12 +1,12 @@
 import { Handle } from './Destroyable';
-import { DNode, RenderResult } from './interfaces';
+import { DNode, RenderResult, VNode, WNode } from './interfaces';
 import { isWNode, isVNode } from './vdom';
 
 const slice = Array.prototype.slice;
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 export interface Modifier<T extends DNode> {
-	(dNode: T, breaker: () => void): void | DNode;
+	(dNode: T, breaker: () => void): void | VNode | WNode | null | string | boolean;
 }
 
 export interface Predicate<T extends DNode> {

--- a/tests/core/unit/d.ts
+++ b/tests/core/unit/d.ts
@@ -413,14 +413,19 @@ registerSuite('d', {
 			const nodeOne = w(WidgetBase, {}, [childOne]);
 			const nodeTwo = 'text node';
 			const childTwo = v('div');
-			const nodeThree = v('div', {}, [childTwo]);
+			const nodeThree = v('div', { id: 'node-three' }, [childTwo]);
 			const nodeFour = v('div', { id: 'node-four' });
 			const nodes = [nodeOne, nodeTwo, nodeThree, nodeFour];
 			const newGrandChild = v('div', { id: 'grand-child' });
 			const newChildOne = w(WidgetBase, {}, [newGrandChild]);
-			const newNodeFour = v('div', { id: 'new-node-four' });
+			const newChildFour = v('div', { id: 'new-child-four' });
+			const newNodeFour = v('div', { id: 'new-node-four' }, [newChildFour]);
 			const newNodes = decorate(nodes, {
 				modifier: (node: DNode) => {
+					if (node === 'text node') {
+						return 'new text node';
+					}
+
 					if (isVNode(node) || isWNode(node)) {
 						if (node.properties.id === 'child-one') {
 							return newChildOne;
@@ -433,14 +438,20 @@ registerSuite('d', {
 						if (node.properties.id === 'node-four') {
 							return newNodeFour;
 						}
+
+						if (node.properties.id === 'node-three' || node.properties.id === 'new-child-four') {
+							return false;
+						}
 					}
 				}
 			});
+			assert.strictEqual(newNodes.length, 4);
 			assert.strictEqual(nodeOne.children[0], newChildOne);
 			assert.strictEqual(newGrandChild.properties.id, 'new-grand-child-id');
-			assert.strictEqual(nodeTwo, 'text node');
-			assert.strictEqual(newNodes.length, 4);
+			assert.strictEqual(newNodes[1], 'new text node');
+			assert.isFalse(newNodes[2]);
 			assert.strictEqual(newNodes[3], newNodeFour);
+			assert.isFalse(newNodeFour.children![0]);
 		}
 	},
 	'isVNode and isWNode': {

--- a/tests/core/unit/d.ts
+++ b/tests/core/unit/d.ts
@@ -407,6 +407,40 @@ registerSuite('d', {
 				assert.strictEqual(children[4], 'my text');
 				assert.isNull(children[5]);
 			}
+		},
+		'returning a new node replaces the node, and new children will be checked'() {
+			const childOne = v('div', { id: 'child-one' });
+			const nodeOne = w(WidgetBase, {}, [childOne]);
+			const nodeTwo = 'text node';
+			const childTwo = v('div');
+			const nodeThree = v('div', {}, [childTwo]);
+			const nodeFour = v('div', { id: 'node-four' });
+			const nodes = [nodeOne, nodeTwo, nodeThree, nodeFour];
+			const newGrandChild = v('div', { id: 'grand-child' });
+			const newChildOne = w(WidgetBase, {}, [newGrandChild]);
+			const newNodeFour = v('div', { id: 'new-node-four' });
+			const newNodes = decorate(nodes, {
+				modifier: (node: DNode) => {
+					if (isVNode(node) || isWNode(node)) {
+						if (node.properties.id === 'child-one') {
+							return newChildOne;
+						}
+
+						if (node.properties.id === 'grand-child') {
+							node.properties = { id: 'new-grand-child-id' };
+						}
+
+						if (node.properties.id === 'node-four') {
+							return newNodeFour;
+						}
+					}
+				}
+			});
+			assert.strictEqual(nodeOne.children[0], newChildOne);
+			assert.strictEqual(newGrandChild.properties.id, 'new-grand-child-id');
+			assert.strictEqual(nodeTwo, 'text node');
+			assert.strictEqual(newNodes.length, 4);
+			assert.strictEqual(newNodes[3], newNodeFour);
 		}
 	},
 	'isVNode and isWNode': {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Provides a `replace` utility that functions similarly to `decorate` but instead replaces the node with the returned value.
Resolves #410 