### PR TITLE
Ensure that SVG nodes can be merged

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1272,8 +1272,8 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			meta: { mergeNodes: arrayFrom(domNode.childNodes) }
 		});
 		_runProcessQueue();
-		_cleanUpMergedNodes();
 		_runDomInstructionQueue();
+		_cleanUpMergedNodes();
 		_insertBeforeMap = undefined;
 		_runCallbacks();
 	}
@@ -1355,8 +1355,8 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				}
 			}
 		}
-		_cleanUpMergedNodes();
 		_runDomInstructionQueue();
+		_cleanUpMergedNodes();
 		_runCallbacks();
 	}
 
@@ -1480,7 +1480,8 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				} = next;
 				for (let i = 0; i < mergeNodes.length; i++) {
 					const domElement = mergeNodes[i] as Element;
-					if (tag.toUpperCase() === (domElement.tagName || '')) {
+					const tagName = domElement.tagName || '';
+					if (tag.toUpperCase() === tagName.toUpperCase()) {
 						const mergeNodeIndex = _allMergedNodes.indexOf(domElement);
 						if (mergeNodeIndex !== -1) {
 							_allMergedNodes.splice(mergeNodeIndex, 1);

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -5596,6 +5596,38 @@ jsdomDescribe('vdom', () => {
 			assert.isTrue(onclickListener.called, 'onclickListener should have been called');
 			document.body.removeChild(iframe);
 		});
+		it('supports merging svg nodes', () => {
+			const iframe = document.createElement('iframe');
+			document.body.appendChild(iframe);
+			iframe.contentDocument!.write(`<div><svg></svg></div>`);
+			iframe.contentDocument!.close();
+			const root = iframe.contentDocument!.body.firstChild as HTMLElement;
+			const svg = root.childNodes[0];
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', [v('svg')]);
+				}
+			}
+			const r = renderer(() => w(Foo, {}));
+			r.mount({ domNode: iframe.contentDocument!.body });
+			assert.strictEqual(root.childNodes[0], svg);
+		});
+		it('supports inserting before nodes that are not merged', () => {
+			const iframe = document.createElement('iframe');
+			document.body.appendChild(iframe);
+			iframe.contentDocument!.write(`<div><div></div></div>`);
+			iframe.contentDocument!.close();
+			const root = iframe.contentDocument!.body.firstChild as HTMLElement;
+			const span = root.childNodes[0];
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', [v('span')]);
+				}
+			}
+			const r = renderer(() => w(Foo, {}));
+			r.mount({ domNode: iframe.contentDocument!.body });
+			assert.notStrictEqual(root.childNodes[0], span);
+		});
 		it('Removes unknown nodes when merging', () => {
 			const iframe = document.createElement('iframe');
 			document.body.appendChild(iframe);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

SVG elements can have a lowercase `tagName` which meant they were never matched when processing merge nodes. This changes to upper case both tags before comparison.

Includes a change to move the orphaned node clean up to after the dom instructions are completed, as the failing unit test for the SVG failed first as it tried to insert before a node that has already been removed from the DOM.