### PR TITLE
Fix block function argument typings and update API

### DIFF
--- a/src/core/middleware/block.ts
+++ b/src/core/middleware/block.ts
@@ -6,22 +6,20 @@ const blockFactory = create({ defer, cache, icache });
 
 export const block = blockFactory(({ middleware: { cache, icache, defer } }) => {
 	let id = 1;
-	return {
-		run<T extends (...args: any[]) => any>(module: T) {
-			return (...args: any[]): (ReturnType<T> extends Promise<infer U> ? U : ReturnType<T>) | null => {
-				const argsString = JSON.stringify(args);
-				const moduleId = cache.get(module) || id++;
-				cache.set(module, moduleId);
-				const cachedValue = icache.getOrSet(`${moduleId}-${argsString}`, async () => {
-					const run = module(...args);
-					defer.pause();
-					const result = await run;
-					defer.resume();
-					return result;
-				});
-				return cachedValue || null;
-			};
-		}
+	return <T extends (...args: any[]) => any>(module: T) => {
+		return (...args: Parameters<T>): (ReturnType<T> extends Promise<infer U> ? U : ReturnType<T>) | null => {
+			const argsString = JSON.stringify(args);
+			const moduleId = cache.get(module) || id++;
+			cache.set(module, moduleId);
+			const cachedValue = icache.getOrSet(`${moduleId}-${argsString}`, async () => {
+				const run = module(...args);
+				defer.pause();
+				const result = await run;
+				defer.resume();
+				return result;
+			});
+			return cachedValue || null;
+		};
 	};
 });
 

--- a/tests/core/unit/middleware/block.ts
+++ b/tests/core/unit/middleware/block.ts
@@ -69,11 +69,11 @@ describe('block middleware', () => {
 
 		const waiter = waitForCall(3, invalidatorStub);
 
-		const resultOne = block.run(testModule)('test');
+		const resultOne = block(testModule)('test');
 		assert.isTrue(deferStub.pause.calledOnce);
-		const resultTwo = block.run(testModuleOther)('test');
+		const resultTwo = block(testModuleOther)('test');
 		assert.isTrue(deferStub.pause.calledTwice);
-		const resultThree = block.run(testModule)('other');
+		const resultThree = block(testModule)('other');
 		assert.isTrue(deferStub.pause.calledThrice);
 		assert.isNull(resultOne);
 		assert.isNull(resultTwo);
@@ -86,11 +86,11 @@ describe('block middleware', () => {
 		return waiter.then(() => {
 			assert.isTrue(deferStub.resume.calledThrice);
 			assert.isTrue(invalidatorStub.calledThrice);
-			const resultOne = block.run(testModule)('test');
+			const resultOne = block(testModule)('test');
 			assert.strictEqual(resultOne, 'resultOne');
-			const resultTwo = block.run(testModuleOther)('test');
+			const resultTwo = block(testModuleOther)('test');
 			assert.strictEqual(resultTwo, 'resultTwo');
-			const resultThree = block.run(testModule)('other');
+			const resultThree = block(testModule)('other');
 			assert.strictEqual(resultThree, 'resultThree');
 			assert.isTrue(deferStub.pause.calledThrice);
 		});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changes the API for `block` from `block.run(myBlock)()` to `block(myBlock)()` and fixes the typings for inferring the block function parameters.
