### PR TITLE
Support rendering nodes to the document body

### DIFF
--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3736,21 +3736,30 @@ jsdomDescribe('vdom', () => {
 							invalidator();
 						}
 					}),
-					v('body', [show ? v('div', { id: 'my-body-node' }, ['My Body Div']) : null])
+					v('body', [show ? v('div', { id: 'my-body-node-1' }, ['My Body Div 1']) : null]),
+					v('body', [show ? v('div', { id: 'my-body-node-2' }, ['My Body Div 2']) : null])
 				]);
 			});
 			const r = renderer(() => w(App, {}));
 			r.mount({ domNode: root });
-			let bodyNode = document.getElementById('my-body-node')!;
-			assert.isOk(bodyNode);
-			assert.strictEqual(bodyNode.outerHTML, '<div id="my-body-node">My Body Div</div>');
-			assert.strictEqual(bodyNode.parentNode, document.body);
-			assert.isNull(root.querySelector('#my-body-node'));
+			let bodyNodeOne = document.getElementById('my-body-node-1')!;
+			assert.isOk(bodyNodeOne);
+			assert.strictEqual(bodyNodeOne.outerHTML, '<div id="my-body-node-1">My Body Div 1</div>');
+			assert.strictEqual(bodyNodeOne.parentNode, document.body);
+			assert.isNull(root.querySelector('#my-body-node-1'));
+			let bodyNodeTwo = document.getElementById('my-body-node-2')!;
+			assert.isOk(bodyNodeTwo);
+			assert.strictEqual(bodyNodeTwo.outerHTML, '<div id="my-body-node-2">My Body Div 2</div>');
+			assert.strictEqual(bodyNodeTwo.parentNode, document.body);
+			assert.isNull(root.querySelector('#my-body-node-2'));
 			sendEvent(root.childNodes[0].childNodes[0] as Element, 'click');
 			resolvers.resolve();
-			bodyNode = document.getElementById('my-body-node')!;
-			assert.isNull(bodyNode);
-			assert.isNull(root.querySelector('#my-body-node'));
+			bodyNodeOne = document.getElementById('my-body-node-1')!;
+			assert.isNull(bodyNodeOne);
+			assert.isNull(root.querySelector('#my-body-node-1'));
+			bodyNodeTwo = document.getElementById('my-body-node-2')!;
+			assert.isNull(bodyNodeTwo);
+			assert.isNull(root.querySelector('#my-body-node-2'));
 		});
 	});
 

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -5,8 +5,6 @@ import { spy, stub, SinonSpy, SinonStub } from 'sinon';
 import { add } from '../../../src/core/has';
 import { createResolvers } from './../support/util';
 import sendEvent from '../support/sendEvent';
-
-import global from '../../../src/shim/global';
 import {
 	create,
 	renderer,
@@ -3720,11 +3718,11 @@ jsdomDescribe('vdom', () => {
 		let root = document.createElement('div');
 		beforeEach(() => {
 			root = document.createElement('div');
-			global.document.body.appendChild(root);
+			document.body.appendChild(root);
 		});
 
 		afterEach(() => {
-			global.document.body.removeChild(root);
+			document.body.removeChild(root);
 		});
 
 		it('can attach a node to the body', () => {
@@ -3743,14 +3741,14 @@ jsdomDescribe('vdom', () => {
 			});
 			const r = renderer(() => w(App, {}));
 			r.mount({ domNode: root });
-			let bodyNode = global.document.getElementById('my-body-node');
+			let bodyNode = document.getElementById('my-body-node')!;
 			assert.isOk(bodyNode);
 			assert.strictEqual(bodyNode.outerHTML, '<div id="my-body-node">My Body Div</div>');
-			assert.strictEqual(bodyNode.parentNode, global.document.body);
+			assert.strictEqual(bodyNode.parentNode, document.body);
 			assert.isNull(root.querySelector('#my-body-node'));
 			sendEvent(root.childNodes[0].childNodes[0] as Element, 'click');
 			resolvers.resolve();
-			bodyNode = global.document.getElementById('my-body-node');
+			bodyNode = document.getElementById('my-body-node')!;
 			assert.isNull(bodyNode);
 			assert.isNull(root.querySelector('#my-body-node'));
 		});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for a special `vnode` tag, `body` that will render its children directly to the `document.body`.

```tsx
import { create, tsx } from '@dojo/framework/core/vdom';

const factory = create();

const MyWidget = factory(function MyWidget() {
    return (
        <div>
            <body><div>Body Node</div></body>
            <div>Normal Node</div>
        </div>
    );
});
```

Resolves #447 
