### PR TITLE
Change `properties` and `children` API to functions

### DIFF
--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -298,7 +298,8 @@ import store from './store';
 
 const factory = create({ store }).properties<{ id: string }>();
 
-export default factory(function MyWidget({ properties: { id }, middleware: store }) {
+export default factory(function MyWidget({ properties, middleware: store }) {
+	const { id } = properties();
     const { path, get, executor } = store;
     const details = get(path('details');
     let isLoading = get(path('isLoading'));

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -355,7 +355,12 @@ export type MiddlewareApiMap<U extends MiddlewareMap<any>> = { [P in keyof U]: R
 
 export interface Callback<Props, Middleware, ReturnValue> {
 	(
-		options: { id: string; middleware: MiddlewareApiMap<Middleware>; properties: Props; children?: DNode[] }
+		options: {
+			id: string;
+			middleware: MiddlewareApiMap<Middleware>;
+			properties: () => Props;
+			children: () => DNode[];
+		}
 	): ReturnValue;
 }
 

--- a/src/core/middleware/i18n.ts
+++ b/src/core/middleware/i18n.ts
@@ -8,8 +8,7 @@ import { I18nProperties, LocaleData, LocalizedMessages, INJECTOR_KEY, registerI1
 
 const factory = create({ invalidator, injector, getRegistry }).properties<I18nProperties>();
 
-export const i18n = factory((options) => {
-	const { invalidator, injector, getRegistry } = options.middleware;
+export const i18n = factory(({ properties, middleware: { invalidator, injector, getRegistry } }) => {
 	const i18nInjector = injector.get(INJECTOR_KEY);
 	if (!i18nInjector) {
 		const registry = getRegistry();
@@ -20,8 +19,7 @@ export const i18n = factory((options) => {
 	injector.subscribe(INJECTOR_KEY);
 
 	function getLocaleMessages(bundle: Bundle<Messages>): Messages | void {
-		const { properties } = options;
-		let locale = properties.locale;
+		let { locale } = properties();
 		if (!locale) {
 			const injectedLocale = injector.get<Injector<LocaleData>>(INJECTOR_KEY);
 			if (injectedLocale) {
@@ -41,8 +39,7 @@ export const i18n = factory((options) => {
 	}
 
 	function resolveBundle<T extends Messages>(bundle: Bundle<T>): Bundle<T> {
-		const { properties } = options;
-		let { i18nBundle } = properties;
+		let { i18nBundle } = properties();
 		if (i18nBundle) {
 			if (i18nBundle instanceof Map) {
 				i18nBundle = i18nBundle.get(bundle);
@@ -67,11 +64,10 @@ export const i18n = factory((options) => {
 
 	return {
 		localize<T extends Messages>(bundle: Bundle<T>, useDefaults = false): LocalizedMessages<T> {
-			const { properties } = options;
+			let { locale } = properties();
 			bundle = resolveBundle(bundle);
 			const messages = getLocaleMessages(bundle);
 			const isPlaceholder = !messages;
-			let locale = properties.locale;
 			if (!locale) {
 				const injectedLocale = injector.get<Injector<LocaleData>>(INJECTOR_KEY);
 				if (injectedLocale) {

--- a/src/core/middleware/i18n.ts
+++ b/src/core/middleware/i18n.ts
@@ -8,7 +8,8 @@ import { I18nProperties, LocaleData, LocalizedMessages, INJECTOR_KEY, registerI1
 
 const factory = create({ invalidator, injector, getRegistry }).properties<I18nProperties>();
 
-export const i18n = factory(({ middleware: { invalidator, injector, getRegistry }, properties }) => {
+export const i18n = factory((options) => {
+	const { invalidator, injector, getRegistry } = options.middleware;
 	const i18nInjector = injector.get(INJECTOR_KEY);
 	if (!i18nInjector) {
 		const registry = getRegistry();
@@ -19,6 +20,7 @@ export const i18n = factory(({ middleware: { invalidator, injector, getRegistry 
 	injector.subscribe(INJECTOR_KEY);
 
 	function getLocaleMessages(bundle: Bundle<Messages>): Messages | void {
+		const { properties } = options;
 		let locale = properties.locale;
 		if (!locale) {
 			const injectedLocale = injector.get<Injector<LocaleData>>(INJECTOR_KEY);
@@ -39,6 +41,7 @@ export const i18n = factory(({ middleware: { invalidator, injector, getRegistry 
 	}
 
 	function resolveBundle<T extends Messages>(bundle: Bundle<T>): Bundle<T> {
+		const { properties } = options;
 		let { i18nBundle } = properties;
 		if (i18nBundle) {
 			if (i18nBundle instanceof Map) {
@@ -64,6 +67,7 @@ export const i18n = factory(({ middleware: { invalidator, injector, getRegistry 
 
 	return {
 		localize<T extends Messages>(bundle: Bundle<T>, useDefaults = false): LocalizedMessages<T> {
+			const { properties } = options;
 			bundle = resolveBundle(bundle);
 			const messages = getLocaleMessages(bundle);
 			const isPlaceholder = !messages;

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -13,89 +13,89 @@ export interface ThemedProperties {
 
 const factory = create({ invalidator, cache, diffProperty, injector, getRegistry }).properties<ThemedProperties>();
 
-export const theme = factory((options) => {
-	const { invalidator, cache, diffProperty, injector, getRegistry } = options.middleware;
-	let themeKeys = new Set();
-	diffProperty('theme', (current: ThemedProperties, next: ThemedProperties) => {
-		if (current.theme !== next.theme) {
-			cache.clear();
-			invalidator();
-		}
-	});
-	diffProperty('classes', (current: ThemedProperties, next: ThemedProperties) => {
-		let result = false;
-		if ((current.classes && !next.classes) || (!current.classes && next.classes)) {
-			result = true;
-		} else if (current.classes && next.classes) {
-			const keys = [...themeKeys.values()];
-			for (let i = 0; i < keys.length; i++) {
-				let key = keys[i];
-				result = shallow(current.classes[key], next.classes[key], 1).changed;
-				if (result) {
-					break;
-				}
+export const theme = factory(
+	({ middleware: { invalidator, cache, diffProperty, injector, getRegistry }, properties }) => {
+		let themeKeys = new Set();
+		diffProperty('theme', (current: ThemedProperties, next: ThemedProperties) => {
+			if (current.theme !== next.theme) {
+				cache.clear();
+				invalidator();
 			}
-		}
-		if (result) {
-			cache.clear();
-			invalidator();
-		}
-	});
-
-	const themeInjector = injector.get(INJECTED_THEME_KEY);
-	if (!themeInjector) {
-		const registry = getRegistry();
-		if (registry) {
-			registerThemeInjector(undefined, registry.base);
-		}
-	}
-	injector.subscribe(INJECTED_THEME_KEY, () => {
-		cache.clear();
-		invalidator();
-	});
-	return {
-		classes<T extends ClassNames>(css: T): T {
-			let theme = cache.get(css);
-			const properties = options.properties;
-			if (theme) {
-				return theme;
-			}
-			const { [THEME_KEY]: key, ...classes } = css;
-			themeKeys.add(key);
-			theme = classes as T;
-			let currentTheme = properties.theme;
-			if (!currentTheme) {
-				const injectedTheme = injector.get<Injector<Theme>>(INJECTED_THEME_KEY);
-				currentTheme = injectedTheme ? injectedTheme.get() : undefined;
-			}
-			if (currentTheme && currentTheme[key]) {
-				theme = { ...theme, ...currentTheme[key] };
-			}
-			if (properties.classes && properties.classes[key]) {
-				const classKeys = Object.keys(properties.classes[key]);
-				for (let i = 0; i < classKeys.length; i++) {
-					const classKey = classKeys[i];
-					if (theme[classKey]) {
-						theme[classKey] = `${theme[classKey]} ${properties.classes[key][classKey].join(' ')}`;
+		});
+		diffProperty('classes', (current: ThemedProperties, next: ThemedProperties) => {
+			let result = false;
+			if ((current.classes && !next.classes) || (!current.classes && next.classes)) {
+				result = true;
+			} else if (current.classes && next.classes) {
+				const keys = [...themeKeys.values()];
+				for (let i = 0; i < keys.length; i++) {
+					let key = keys[i];
+					result = shallow(current.classes[key], next.classes[key], 1).changed;
+					if (result) {
+						break;
 					}
 				}
 			}
-			cache.set(css, theme);
-			return theme;
-		},
-		set(css: Theme): void {
-			const currentTheme = injector.get<Injector<Theme | undefined>>(INJECTED_THEME_KEY);
-			if (currentTheme) {
-				currentTheme.set(css);
+			if (result) {
+				cache.clear();
+				invalidator();
 			}
-		},
-		get(): Theme | undefined {
-			const currentTheme = injector.get<Injector<Theme | undefined>>(INJECTED_THEME_KEY);
-			if (currentTheme) {
-				return currentTheme.get();
+		});
+
+		const themeInjector = injector.get(INJECTED_THEME_KEY);
+		if (!themeInjector) {
+			const registry = getRegistry();
+			if (registry) {
+				registerThemeInjector(undefined, registry.base);
 			}
 		}
-	};
-});
+		injector.subscribe(INJECTED_THEME_KEY, () => {
+			cache.clear();
+			invalidator();
+		});
+		return {
+			classes<T extends ClassNames>(css: T): T {
+				let theme = cache.get(css);
+				if (theme) {
+					return theme;
+				}
+				const { [THEME_KEY]: key, ...classes } = css;
+				themeKeys.add(key);
+				theme = classes as T;
+				let { theme: currentTheme, classes: currentClasses } = properties();
+				if (!currentTheme) {
+					const injectedTheme = injector.get<Injector<Theme>>(INJECTED_THEME_KEY);
+					currentTheme = injectedTheme ? injectedTheme.get() : undefined;
+				}
+				if (currentTheme && currentTheme[key]) {
+					theme = { ...theme, ...currentTheme[key] };
+				}
+				if (currentClasses && currentClasses[key]) {
+					const classKeys = Object.keys(currentClasses[key]);
+					for (let i = 0; i < classKeys.length; i++) {
+						const classKey = classKeys[i];
+						if (theme[classKey]) {
+							theme[classKey] = `${theme[classKey]} ${currentClasses[key][classKey].join(' ')}`;
+						}
+					}
+				}
+				cache.set(css, theme);
+				return theme;
+			},
+			set(css: Theme): void {
+				const currentTheme = injector.get<Injector<Theme | undefined>>(INJECTED_THEME_KEY);
+				if (currentTheme) {
+					currentTheme.set(css);
+				}
+			},
+			get(): Theme | undefined {
+				const currentTheme = injector.get<Injector<Theme | undefined>>(INJECTED_THEME_KEY);
+				if (currentTheme) {
+					return currentTheme.get();
+				}
+			}
+		};
+	}
+);
 
 export default theme;

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -13,89 +13,89 @@ export interface ThemedProperties {
 
 const factory = create({ invalidator, cache, diffProperty, injector, getRegistry }).properties<ThemedProperties>();
 
-export const theme = factory(
-	({ middleware: { invalidator, cache, diffProperty, injector, getRegistry }, properties }) => {
-		let themeKeys = new Set();
-		diffProperty('theme', (current: ThemedProperties, next: ThemedProperties) => {
-			if (current.theme !== next.theme) {
-				cache.clear();
-				invalidator();
-			}
-		});
-		diffProperty('classes', (current: ThemedProperties, next: ThemedProperties) => {
-			let result = false;
-			if ((current.classes && !next.classes) || (!current.classes && next.classes)) {
-				result = true;
-			} else if (current.classes && next.classes) {
-				const keys = [...themeKeys.values()];
-				for (let i = 0; i < keys.length; i++) {
-					let key = keys[i];
-					result = shallow(current.classes[key], next.classes[key], 1).changed;
-					if (result) {
-						break;
-					}
-				}
-			}
-			if (result) {
-				cache.clear();
-				invalidator();
-			}
-		});
-
-		const themeInjector = injector.get(INJECTED_THEME_KEY);
-		if (!themeInjector) {
-			const registry = getRegistry();
-			if (registry) {
-				registerThemeInjector(undefined, registry.base);
-			}
-		}
-		injector.subscribe(INJECTED_THEME_KEY, () => {
+export const theme = factory((options) => {
+	const { invalidator, cache, diffProperty, injector, getRegistry } = options.middleware;
+	let themeKeys = new Set();
+	diffProperty('theme', (current: ThemedProperties, next: ThemedProperties) => {
+		if (current.theme !== next.theme) {
 			cache.clear();
 			invalidator();
-		});
-		return {
-			classes<T extends ClassNames>(css: T): T {
-				let theme = cache.get<T>(css);
-				if (theme) {
-					return theme;
-				}
-				const { [THEME_KEY]: key, ...classes } = css;
-				themeKeys.add(key);
-				theme = classes as T;
-				let currentTheme = properties.theme;
-				if (!currentTheme) {
-					const injectedTheme = injector.get<Injector<Theme>>(INJECTED_THEME_KEY);
-					currentTheme = injectedTheme ? injectedTheme.get() : undefined;
-				}
-				if (currentTheme && currentTheme[key]) {
-					theme = { ...theme, ...currentTheme[key] };
-				}
-				if (properties.classes && properties.classes[key]) {
-					const classKeys = Object.keys(properties.classes[key]);
-					for (let i = 0; i < classKeys.length; i++) {
-						const classKey = classKeys[i];
-						if (theme[classKey]) {
-							theme[classKey] = `${theme[classKey]} ${properties.classes[key][classKey].join(' ')}`;
-						}
-					}
-				}
-				cache.set(css, theme);
-				return theme;
-			},
-			set(css: Theme): void {
-				const currentTheme = injector.get<Injector<Theme | undefined>>(INJECTED_THEME_KEY);
-				if (currentTheme) {
-					currentTheme.set(css);
-				}
-			},
-			get(): Theme | undefined {
-				const currentTheme = injector.get<Injector<Theme | undefined>>(INJECTED_THEME_KEY);
-				if (currentTheme) {
-					return currentTheme.get();
+		}
+	});
+	diffProperty('classes', (current: ThemedProperties, next: ThemedProperties) => {
+		let result = false;
+		if ((current.classes && !next.classes) || (!current.classes && next.classes)) {
+			result = true;
+		} else if (current.classes && next.classes) {
+			const keys = [...themeKeys.values()];
+			for (let i = 0; i < keys.length; i++) {
+				let key = keys[i];
+				result = shallow(current.classes[key], next.classes[key], 1).changed;
+				if (result) {
+					break;
 				}
 			}
-		};
+		}
+		if (result) {
+			cache.clear();
+			invalidator();
+		}
+	});
+
+	const themeInjector = injector.get(INJECTED_THEME_KEY);
+	if (!themeInjector) {
+		const registry = getRegistry();
+		if (registry) {
+			registerThemeInjector(undefined, registry.base);
+		}
 	}
-);
+	injector.subscribe(INJECTED_THEME_KEY, () => {
+		cache.clear();
+		invalidator();
+	});
+	return {
+		classes<T extends ClassNames>(css: T): T {
+			let theme = cache.get(css);
+			const properties = options.properties;
+			if (theme) {
+				return theme;
+			}
+			const { [THEME_KEY]: key, ...classes } = css;
+			themeKeys.add(key);
+			theme = classes as T;
+			let currentTheme = properties.theme;
+			if (!currentTheme) {
+				const injectedTheme = injector.get<Injector<Theme>>(INJECTED_THEME_KEY);
+				currentTheme = injectedTheme ? injectedTheme.get() : undefined;
+			}
+			if (currentTheme && currentTheme[key]) {
+				theme = { ...theme, ...currentTheme[key] };
+			}
+			if (properties.classes && properties.classes[key]) {
+				const classKeys = Object.keys(properties.classes[key]);
+				for (let i = 0; i < classKeys.length; i++) {
+					const classKey = classKeys[i];
+					if (theme[classKey]) {
+						theme[classKey] = `${theme[classKey]} ${properties.classes[key][classKey].join(' ')}`;
+					}
+				}
+			}
+			cache.set(css, theme);
+			return theme;
+		},
+		set(css: Theme): void {
+			const currentTheme = injector.get<Injector<Theme | undefined>>(INJECTED_THEME_KEY);
+			if (currentTheme) {
+				currentTheme.set(css);
+			}
+		},
+		get(): Theme | undefined {
+			const currentTheme = injector.get<Injector<Theme | undefined>>(INJECTED_THEME_KEY);
+			if (currentTheme) {
+				return currentTheme.get();
+			}
+		}
+	};
+});
 
 export default theme;

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1646,28 +1646,22 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		for (let i = 0; i < keys.length; i++) {
 			const middleware = middlewares[keys[i]]();
 			const payload: any = {
-				id: uniqueId
-			};
-			Object.defineProperty(payload, 'properties', {
-				get() {
+				id: uniqueId,
+				properties: () => {
 					const widgetMeta = widgetMetaMap.get(id);
 					if (widgetMeta) {
 						return { ...widgetMeta.properties };
 					}
+					return {};
 				},
-				enumerable: true,
-				configurable: true
-			});
-			Object.defineProperty(payload, 'children', {
-				get() {
+				children: () => {
 					const widgetMeta = widgetMetaMap.get(id);
 					if (widgetMeta) {
 						return widgetMeta.children;
 					}
-				},
-				enumerable: true,
-				configurable: true
-			});
+					return [];
+				}
+			};
 			if (middleware.middlewares) {
 				const resolvedMiddleware = resolveMiddleware(middleware.middlewares, id);
 				payload.middleware = resolvedMiddleware;
@@ -1736,8 +1730,8 @@ export function renderer(renderer: () => RenderResult): Renderer {
 
 			rendered = Constructor({
 				id: next.id,
-				properties: next.node.properties,
-				children: next.node.children,
+				properties: () => next.node.properties,
+				children: () => next.node.children,
 				middleware: widgetMeta.middleware
 			});
 			widgetMeta.rendering = false;
@@ -1836,8 +1830,8 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					widgetMeta.dirty = false;
 					rendered = Constructor({
 						id: next.id,
-						properties: next.node.properties,
-						children: next.node.children,
+						properties: () => next.node.properties,
+						children: () => next.node.children,
 						middleware: widgetMeta.middleware
 					});
 					if (widgetMeta.deferRefs > 0) {

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1722,7 +1722,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					properties: next.node.properties,
 					children: next.node.children,
 					deferRefs: 0,
-					rendering: false,
+					rendering: true,
 					registry: _mountOptions.registry
 				};
 
@@ -1740,6 +1740,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				children: next.node.children,
 				middleware: widgetMeta.middleware
 			});
+			widgetMeta.rendering = false;
 			if (widgetMeta.deferRefs > 0) {
 				return false;
 			}

--- a/src/routing/ActiveLink.ts
+++ b/src/routing/ActiveLink.ts
@@ -21,8 +21,8 @@ export const ActiveLink = factory(function ActiveLink({
 	properties,
 	children
 }) {
-	const { to, routerKey = 'router', params } = properties;
-	let { activeClasses, classes = [], ...props } = properties;
+	const { to, routerKey = 'router', params } = properties();
+	let { activeClasses, classes = [], ...props } = properties();
 
 	diffProperty('to', (current: ActiveLinkProperties, next: ActiveLinkProperties) => {
 		if (current.to !== next.to) {
@@ -62,7 +62,7 @@ export const ActiveLink = factory(function ActiveLink({
 		}
 		props = { ...props, classes };
 	}
-	return w(Link, props, children);
+	return w(Link, props, children());
 });
 
 export default ActiveLink;

--- a/src/routing/Link.ts
+++ b/src/routing/Link.ts
@@ -16,7 +16,7 @@ export interface LinkProperties extends VNodeProperties {
 const factory = create({ injector }).properties<LinkProperties>();
 
 export const Link = factory(function Link({ middleware: { injector }, properties, children }) {
-	let { routerKey = 'router', to, isOutlet = true, target, params = {}, onClick, ...props } = properties;
+	let { routerKey = 'router', to, isOutlet = true, target, params = {}, onClick, ...props } = properties();
 	const router = injector.get<Router>(routerKey);
 	let href: string | undefined = to;
 
@@ -37,7 +37,7 @@ export const Link = factory(function Link({ middleware: { injector }, properties
 	} else {
 		linkProps = { ...props, href };
 	}
-	return v('a', linkProps, children);
+	return v('a', linkProps, children());
 });
 
 export default Link;

--- a/src/routing/Outlet.ts
+++ b/src/routing/Outlet.ts
@@ -17,7 +17,7 @@ export const Outlet = factory(function Outlet({
 	middleware: { cache, injector, diffProperty, invalidator },
 	properties
 }) {
-	const { renderer, id, routerKey = 'router' } = properties;
+	const { renderer, id, routerKey = 'router' } = properties();
 	const currentHandle = cache.get<Function>('handle');
 	if (!currentHandle) {
 		const handle = injector.subscribe(routerKey);

--- a/src/testing/harness.ts
+++ b/src/testing/harness.ts
@@ -96,22 +96,14 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 					isMock = true;
 				}
 				const payload: any = {
-					id: uniqueId
-				};
-				Object.defineProperty(payload, 'properties', {
-					get() {
+					id: uniqueId,
+					properties: () => {
 						return { ...properties };
 					},
-					enumerable: true,
-					configurable: true
-				});
-				Object.defineProperty(payload, 'children', {
-					get() {
+					children: () => {
 						return children;
-					},
-					enumerable: true,
-					configurable: true
-				});
+					}
+				};
 				if (middleware.middlewares) {
 					const resolvedMiddleware = resolveMiddleware(middleware.middlewares, mocks);
 					payload.middleware = resolvedMiddleware;
@@ -199,7 +191,7 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 			properties = { ...wNode.properties };
 			children = wNode.children;
 			if (invalidated) {
-				render = widget({ id: 'test', middleware, properties, children });
+				render = widget({ id: 'test', middleware, properties: () => properties, children: () => children });
 			}
 		} else {
 			widget.__setProperties__(wNode.properties);

--- a/tests/core/unit/middleware/block.ts
+++ b/tests/core/unit/middleware/block.ts
@@ -22,11 +22,17 @@ function waitForCall(calls = 1, stub: SinonStub) {
 
 describe('block middleware', () => {
 	beforeEach(() => {
-		cache = cacheMiddleware().callback({ id: 'cache-test', middleware: { destroy: sb.stub() }, properties: {} });
+		cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: sb.stub() },
+			properties: () => ({}),
+			children: () => []
+		});
 		icache = icacheMiddleware().callback({
 			id: 'cache-test',
 			middleware: { cache, invalidator: invalidatorStub },
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 	});
 	afterEach(() => {
@@ -41,7 +47,8 @@ describe('block middleware', () => {
 				icache,
 				defer: deferStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		let resolverOne: any;

--- a/tests/core/unit/middleware/breakpoint.ts
+++ b/tests/core/unit/middleware/breakpoint.ts
@@ -32,7 +32,8 @@ describe('breakpoint middleware', () => {
 			middleware: {
 				resize: resizeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		assert.isNull(breakpoint.get('root'));
 	});
@@ -44,7 +45,8 @@ describe('breakpoint middleware', () => {
 			middleware: {
 				resize: resizeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		resizeStub.get
@@ -81,7 +83,8 @@ describe('breakpoint middleware', () => {
 			middleware: {
 				resize: resizeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		resizeStub.get
@@ -122,7 +125,8 @@ describe('breakpoint middleware', () => {
 			middleware: {
 				resize: resizeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		resizeStub.get

--- a/tests/core/unit/middleware/cache.ts
+++ b/tests/core/unit/middleware/cache.ts
@@ -18,7 +18,8 @@ describe('cache middleware', () => {
 			middleware: {
 				destroy: destroyStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		assert.isUndefined(cache.get('test'));
 		cache.set('test', 'value');
@@ -32,7 +33,8 @@ describe('cache middleware', () => {
 			middleware: {
 				destroy: destroyStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		cache.set('test', 'value');
 		assert.isTrue(destroyStub.calledOnce);
@@ -47,7 +49,8 @@ describe('cache middleware', () => {
 			middleware: {
 				destroy: destroyStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		assert.isUndefined(cache.get('test'));
 		cache.set('test', 'value');

--- a/tests/core/unit/middleware/dimensions.ts
+++ b/tests/core/unit/middleware/dimensions.ts
@@ -24,7 +24,8 @@ describe('dimensions middleware', () => {
 			middleware: {
 				node: nodeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const client = { clientLeft: 1, clientTop: 2, clientWidth: 3, clientHeight: 4 };
 		const offset = { offsetHeight: 10, offsetLeft: 10, offsetTop: 10, offsetWidth: 10 };
@@ -68,7 +69,8 @@ describe('dimensions middleware', () => {
 			middleware: {
 				node: nodeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		let defaultDims = dimensions.get('div');
 		assert.deepEqual(defaultDims, {

--- a/tests/core/unit/middleware/focus.ts
+++ b/tests/core/unit/middleware/focus.ts
@@ -17,13 +17,19 @@ const nodeStub = {
 const invalidatorStub = sb.stub();
 
 function cacheFactory() {
-	return cacheMiddleware().callback({ id: 'test-cache', properties: {}, middleware: { destroy: sb.stub() } });
+	return cacheMiddleware().callback({
+		id: 'test-cache',
+		properties: () => ({}),
+		children: () => [],
+		middleware: { destroy: sb.stub() }
+	});
 }
 
 function icacheFactory() {
 	return icacheMiddleware().callback({
 		id: 'test-cache',
-		properties: {},
+		properties: () => ({}),
+		children: () => [],
 		middleware: { cache: cacheFactory(), invalidator: sb.stub() }
 	});
 }
@@ -45,7 +51,8 @@ describe('focus middleware', () => {
 				node: nodeStub,
 				invalidator: invalidatorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		assert.isFalse(focus.shouldFocus());
 		focus.focus();
@@ -64,7 +71,8 @@ describe('focus middleware', () => {
 				node: nodeStub,
 				invalidator: invalidatorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		diffPropertyStub.getCall(0).callArgWith(1, {}, { focus: () => true });
 		assert.isTrue(focus.shouldFocus());
@@ -82,7 +90,8 @@ describe('focus middleware', () => {
 				node: nodeStub,
 				invalidator: invalidatorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		diffPropertyStub.getCall(0).callArgWith(1, {}, { focus: () => false });
 		assert.isFalse(focus.shouldFocus());
@@ -100,7 +109,8 @@ describe('focus middleware', () => {
 				node: nodeStub,
 				invalidator: invalidatorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		assert.isFalse(focus.isFocused('root'));
 	});
@@ -117,7 +127,8 @@ describe('focus middleware', () => {
 				node: nodeStub,
 				invalidator: invalidatorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const div = global.document.createElement('div');
 		const buttonOne = global.document.createElement('button');

--- a/tests/core/unit/middleware/i18n.ts
+++ b/tests/core/unit/middleware/i18n.ts
@@ -320,6 +320,7 @@ describe('i18n middleware', () => {
 				}
 				passLocale = () => {
 					shouldPassLocale = true;
+					invalidator();
 				};
 
 				return v('div', [shouldPassLocale ? w(I18nWidget, { locale: 'es' }) : w(I18nWidget, {})]);
@@ -334,7 +335,7 @@ describe('i18n middleware', () => {
 			passLocale();
 			assert.strictEqual(
 				root.outerHTML,
-				'<div><div>{"hello":"Hola","goodbye":"Adiós","welcome":"Bienvenido, {name}!"}</div></div>'
+				'<div><div>{"hello":"Hola","goodbye":"Adiós","welcome":"Bienvenido, {name}"}</div></div>'
 			);
 		});
 	});

--- a/tests/core/unit/middleware/i18n.ts
+++ b/tests/core/unit/middleware/i18n.ts
@@ -58,7 +58,8 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const { format, isPlaceholder, messages } = i18n.localize(bundle);
 
@@ -78,7 +79,8 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const { format, isPlaceholder, messages } = i18n.localize(bundle, true);
 
@@ -98,7 +100,8 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const { isPlaceholder, messages } = i18n.localize({
 			messages: {
@@ -121,9 +124,10 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {
+			properties: () => ({
 				locale: 'fr'
-			}
+			}),
+			children: () => []
 		});
 		await coreI18n(bundle, 'fr');
 		const { isPlaceholder, messages } = i18n.localize(bundle);
@@ -142,7 +146,8 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		await coreI18n(bundle, 'fr');
 		const { isPlaceholder, messages } = i18n.localize(bundle);
@@ -161,7 +166,8 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		await coreI18n(bundle, 'fr');
 		const { format } = i18n.localize(bundle);
@@ -178,9 +184,10 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {
+			properties: () => ({
 				i18nBundle: overrideBundle
-			}
+			}),
+			children: () => []
 		});
 		await coreI18n(bundle, 'es');
 		await coreI18n(overrideBundle, 'es');
@@ -202,9 +209,10 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {
+			properties: () => ({
 				i18nBundle: i18nBundleMap
-			}
+			}),
+			children: () => []
 		});
 		await coreI18n(bundle, 'es');
 		await coreI18n(overrideBundle, 'es');
@@ -225,9 +233,10 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {
+			properties: () => ({
 				i18nBundle: i18nBundleMap
-			}
+			}),
+			children: () => []
 		});
 		await coreI18n(bundle, 'es');
 		await coreI18n(overrideBundle, 'es');
@@ -248,7 +257,8 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		await coreI18n(bundle, 'fr');
 		const { isPlaceholder, messages } = i18n.localize(bundle);
@@ -268,9 +278,10 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {
+			properties: () => ({
 				locale: 'fr'
-			}
+			}),
+			children: () => []
 		});
 		await coreI18n(bundle, 'fr');
 		const { isPlaceholder, messages } = i18n.localize(bundle);
@@ -291,7 +302,8 @@ describe('i18n middleware', () => {
 				invalidator: invalidatorStub,
 				getRegistry: getRegistryStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		assert.isTrue(defineInjector.calledOnce);
 		await coreI18n(bundle, 'fr');

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -18,7 +18,8 @@ describe('icache middleware', () => {
 		const cache = cacheMiddleware().callback({
 			id: 'cache-test',
 			middleware: { destroy: sb.stub() },
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const icache = callback({
 			id: 'test',
@@ -26,7 +27,8 @@ describe('icache middleware', () => {
 				cache,
 				invalidator: invalidatorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		assert.isUndefined(icache.get('test'));
 		assert.strictEqual('test', icache.getOrSet('test', 'test'));
@@ -39,7 +41,8 @@ describe('icache middleware', () => {
 		const cache = cacheMiddleware().callback({
 			id: 'cache-test',
 			middleware: { destroy: sb.stub() },
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const icache = callback({
 			id: 'test',
@@ -47,7 +50,8 @@ describe('icache middleware', () => {
 				cache,
 				invalidator: invalidatorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		let resolverOne: any;
 		let resolverTwo: any;
@@ -74,7 +78,8 @@ describe('icache middleware', () => {
 		const cache = cacheMiddleware().callback({
 			id: 'cache-test',
 			middleware: { destroy: sb.stub() },
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const icache = callback({
 			id: 'test',
@@ -82,7 +87,8 @@ describe('icache middleware', () => {
 				cache,
 				invalidator: invalidatorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		let resolverOne: any;
 		let resolverTwo: any;
@@ -111,7 +117,8 @@ describe('icache middleware', () => {
 		const cache = cacheMiddleware().callback({
 			id: 'cache-test',
 			middleware: { destroy: sb.stub() },
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const icache = callback({
 			id: 'test',
@@ -119,7 +126,8 @@ describe('icache middleware', () => {
 				cache,
 				invalidator: invalidatorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		assert.isUndefined(icache.get('test'));
 		icache.set('test', 'value');

--- a/tests/core/unit/middleware/injector.ts
+++ b/tests/core/unit/middleware/injector.ts
@@ -38,7 +38,8 @@ describe('injector middleware', () => {
 					invalidator,
 					destroy
 				},
-				properties: {}
+				properties: () => ({}),
+				children: () => []
 			});
 			const injectorItem = injector.get<string>('test');
 			assert.strictEqual(injectorItem, 'Test Injector');
@@ -54,7 +55,8 @@ describe('injector middleware', () => {
 					invalidator,
 					destroy
 				},
-				properties: {}
+				properties: () => ({}),
+				children: () => []
 			});
 			const injectorItem = injector.get<string>('test');
 			assert.isNull(injectorItem);
@@ -70,7 +72,8 @@ describe('injector middleware', () => {
 					invalidator,
 					destroy
 				},
-				properties: {}
+				properties: () => ({}),
+				children: () => []
 			});
 			const injectorItem = injector.get<string>('test');
 			assert.isNull(injectorItem);
@@ -91,7 +94,8 @@ describe('injector middleware', () => {
 					invalidator,
 					destroy
 				},
-				properties: {}
+				properties: () => ({}),
+				children: () => []
 			});
 			injector.subscribe('test');
 			assert.isTrue(eventStub.calledOnce);
@@ -113,7 +117,8 @@ describe('injector middleware', () => {
 					invalidator,
 					destroy
 				},
-				properties: {}
+				properties: () => ({}),
+				children: () => []
 			});
 			const customCallback = sb.stub();
 			injector.subscribe('test', customCallback);
@@ -132,7 +137,8 @@ describe('injector middleware', () => {
 					invalidator,
 					destroy
 				},
-				properties: {}
+				properties: () => ({}),
+				children: () => []
 			});
 			injector.subscribe('test');
 			assert.isTrue(eventStub.notCalled);
@@ -153,7 +159,8 @@ describe('injector middleware', () => {
 					invalidator,
 					destroy
 				},
-				properties: {}
+				properties: () => ({}),
+				children: () => []
 			});
 			injector.subscribe('test');
 			assert.isTrue(eventStub.notCalled);
@@ -176,7 +183,8 @@ describe('injector middleware', () => {
 					invalidator,
 					destroy
 				},
-				properties: {}
+				properties: () => ({}),
+				children: () => []
 			});
 			const customCallback = sb.stub();
 			const injectorHandle = injector.subscribe('test', customCallback);

--- a/tests/core/unit/middleware/intersection.ts
+++ b/tests/core/unit/middleware/intersection.ts
@@ -52,7 +52,8 @@ describe('intersection middleware', () => {
 
 	it('no intersection', () => {
 		const cache = cacheMiddleware().callback({
-			properties: {},
+			properties: () => ({}),
+			children: () => [],
 			id: 'test-cache',
 			middleware: { destroy: destroyStub }
 		});
@@ -64,7 +65,8 @@ describe('intersection middleware', () => {
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		const info = intersection.get('root');
@@ -76,7 +78,8 @@ describe('intersection middleware', () => {
 
 	it('no intersection with options', () => {
 		const cache = cacheMiddleware().callback({
-			properties: {},
+			properties: () => ({}),
+			children: () => [],
 			id: 'test-cache',
 			middleware: { destroy: destroyStub }
 		});
@@ -88,7 +91,8 @@ describe('intersection middleware', () => {
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		const info = intersection.get('root', { root: 'root' });
@@ -100,7 +104,8 @@ describe('intersection middleware', () => {
 
 	it('Should return the registered intersection', () => {
 		const cache = cacheMiddleware().callback({
-			properties: {},
+			properties: () => ({}),
+			children: () => [],
 			id: 'test-cache',
 			middleware: { destroy: destroyStub }
 		});
@@ -112,7 +117,8 @@ describe('intersection middleware', () => {
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		const mockNode = sb.stub();
@@ -142,7 +148,8 @@ describe('intersection middleware', () => {
 
 	it('intersections calls waits for root node before invalidating', () => {
 		const cache = cacheMiddleware().callback({
-			properties: {},
+			properties: () => ({}),
+			children: () => [],
 			id: 'test-cache',
 			middleware: { destroy: destroyStub }
 		});
@@ -154,7 +161,8 @@ describe('intersection middleware', () => {
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		let info = intersection.get('foo', { root: 'root' });
@@ -205,7 +213,8 @@ describe('intersection middleware', () => {
 
 	it('Should register disconnect with destroy', () => {
 		const cache = cacheMiddleware().callback({
-			properties: {},
+			properties: () => ({}),
+			children: () => [],
 			id: 'test-cache',
 			middleware: { destroy: sb.stub() }
 		});
@@ -217,7 +226,8 @@ describe('intersection middleware', () => {
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		const mockNode = sb.stub();

--- a/tests/core/unit/middleware/resize.ts
+++ b/tests/core/unit/middleware/resize.ts
@@ -51,12 +51,14 @@ describe('resize middleware', () => {
 
 	it('Should observe node with with resize and invalidate when the resize callback is called ', () => {
 		const cache = cacheMiddleware().callback({
-			properties: {},
+			properties: () => ({}),
+			children: () => [],
 			id: 'test-cache',
 			middleware: { destroy: destroyStub }
 		});
 		const icache = icacheMiddleware().callback({
-			properties: {},
+			properties: () => ({}),
+			children: () => [],
 			id: 'test-cache',
 			middleware: { invalidator: invalidatorStub, cache }
 		});
@@ -68,7 +70,8 @@ describe('resize middleware', () => {
 				icache,
 				node: nodeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		assert.isNull(resize.get('key'));
 		const mockNode = sb.stub();
@@ -94,12 +97,14 @@ describe('resize middleware', () => {
 
 	it('Should register disconnect with destroy', () => {
 		const cache = cacheMiddleware().callback({
-			properties: {},
+			properties: () => ({}),
+			children: () => [],
 			id: 'test-cache',
 			middleware: { destroy: sb.stub() }
 		});
 		const icache = icacheMiddleware().callback({
-			properties: {},
+			properties: () => ({}),
+			children: () => [],
 			id: 'test-cache',
 			middleware: { invalidator: invalidatorStub, cache }
 		});
@@ -111,7 +116,8 @@ describe('resize middleware', () => {
 				icache,
 				node: nodeStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		const mockNode = sb.stub();

--- a/tests/core/unit/middleware/store.ts
+++ b/tests/core/unit/middleware/store.ts
@@ -34,7 +34,8 @@ describe('store middleware', () => {
 				invalidator: invalidatorStub,
 				injector: injectorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		let result = store.get(store.path('my-state'));
 		assert.isUndefined(result);
@@ -58,7 +59,8 @@ describe('store middleware', () => {
 				invalidator: invalidatorStub,
 				injector: injectorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		let result = store.get(store.path('my-state'));
 		assert.isUndefined(result);
@@ -91,7 +93,8 @@ describe('store middleware', () => {
 				invalidator: invalidatorStub,
 				injector: injectorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		let result = store.get(store.path('my-state'));
 		assert.isUndefined(result);
@@ -133,7 +136,8 @@ describe('store middleware', () => {
 				invalidator: invalidatorStub,
 				injector: injectorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const result = store.get(store.path('my', 'nested', 'state'));
 		assert.strictEqual(result, 'existing-data');
@@ -144,7 +148,8 @@ describe('store middleware', () => {
 				invalidator: invalidatorStub,
 				injector: injectorStub
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 		const resultTwo = otherStore.get(store.path('my', 'nested', 'state'));
 		assert.strictEqual(resultTwo, 'existing-data');

--- a/tests/core/unit/middleware/theme.ts
+++ b/tests/core/unit/middleware/theme.ts
@@ -28,7 +28,12 @@ describe('theme middleware', () => {
 	});
 
 	it('Should register injector and allow theme to be set', () => {
-		const cache = cacheMiddleware().callback({ middleware: { destroy: sb.stub() }, properties: {}, id: 'blah' });
+		const cache = cacheMiddleware().callback({
+			middleware: { destroy: sb.stub() },
+			properties: () => ({}),
+			children: () => [],
+			id: 'blah'
+		});
 		const { callback } = themeMiddleware();
 		defineInjector.callsFake((...args: any[]) => {
 			injector.get.withArgs(args[0]).returns(new Injector('blah'));
@@ -42,7 +47,8 @@ describe('theme middleware', () => {
 				injector,
 				getRegistry
 			},
-			properties: {}
+			properties: () => ({}),
+			children: () => []
 		});
 
 		assert.isTrue(diffProperty.calledTwice);
@@ -75,7 +81,12 @@ describe('theme middleware', () => {
 	});
 
 	it('Should give precedence to theme from properties over an injected theme', () => {
-		const cache = cacheMiddleware().callback({ middleware: { destroy: sb.stub() }, properties: {}, id: 'blah' });
+		const cache = cacheMiddleware().callback({
+			middleware: { destroy: sb.stub() },
+			properties: () => ({}),
+			children: () => [],
+			id: 'blah'
+		});
 		const { callback } = themeMiddleware();
 		defineInjector.callsFake((...args: any[]) => {
 			injector.get.withArgs(args[0]).returns(new Injector('blah'));
@@ -94,9 +105,10 @@ describe('theme middleware', () => {
 				injector,
 				getRegistry
 			},
-			properties: {
+			properties: () => ({
 				theme: propertyTheme
-			}
+			}),
+			children: () => []
 		});
 
 		assert.isTrue(diffProperty.calledTwice);
@@ -127,7 +139,12 @@ describe('theme middleware', () => {
 	});
 
 	it('Should support classes property for adding additional classes', () => {
-		const cache = cacheMiddleware().callback({ middleware: { destroy: sb.stub() }, properties: {}, id: 'blah' });
+		const cache = cacheMiddleware().callback({
+			middleware: { destroy: sb.stub() },
+			properties: () => ({}),
+			children: () => [],
+			id: 'blah'
+		});
 		const { callback } = themeMiddleware();
 		defineInjector.callsFake((...args: any[]) => {
 			injector.get.withArgs(args[0]).returns(new Injector('blah'));
@@ -141,7 +158,7 @@ describe('theme middleware', () => {
 				injector,
 				getRegistry
 			},
-			properties: {
+			properties: () => ({
 				classes: {
 					other: {
 						bar: ['extra-extra-extra']
@@ -151,7 +168,8 @@ describe('theme middleware', () => {
 						other: ['extra-extra-extra']
 					}
 				}
-			}
+			}),
+			children: () => []
 		});
 
 		assert.isTrue(diffProperty.calledTwice);

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3065,7 +3065,7 @@ jsdomDescribe('vdom', () => {
 				let text = 'first';
 				let updateText: any;
 
-				const Foo = createWidget(({ children }) => children);
+				const Foo = createWidget(({ children }) => children());
 				const App = createWidget(({ middleware }) => {
 					updateText = () => {
 						text = 'second';
@@ -3117,7 +3117,7 @@ jsdomDescribe('vdom', () => {
 				let label = 'default';
 				const createWidget = create({ invalidator });
 				const Foo = createWidget.properties<{ label: string; other: boolean }>()(
-					({ properties }) => properties.label
+					({ properties }) => properties().label
 				);
 				const App = createWidget.properties()(({ middleware }) => {
 					const setLabel = () => {
@@ -3142,8 +3142,12 @@ jsdomDescribe('vdom', () => {
 			it('supports widget registry items', () => {
 				const registry = new Registry();
 				const createWidget = create();
-				const Foo = createWidget.properties<{ text: string }>()(({ properties }) => v('h1', [properties.text]));
-				const Bar = createWidget.properties<{ text: string }>()(({ properties }) => v('h1', [properties.text]));
+				const Foo = createWidget.properties<{ text: string }>()(({ properties }) =>
+					v('h1', [properties().text])
+				);
+				const Bar = createWidget.properties<{ text: string }>()(({ properties }) =>
+					v('h1', [properties().text])
+				);
 
 				registry.define('foo', Foo);
 				registry.define('bar', Bar);
@@ -3282,8 +3286,8 @@ jsdomDescribe('vdom', () => {
 				let visible = true;
 				let swap: any;
 
-				const Foo = createWidget.properties<{ text: string }>()(({ properties }) => properties.text);
-				const Bar = createWidget.properties<{ text: string }>()(({ properties }) => properties.text);
+				const Foo = createWidget.properties<{ text: string }>()(({ properties }) => properties().text);
+				const Bar = createWidget.properties<{ text: string }>()(({ properties }) => properties().text);
 				const App = createWidget(({ middleware }) => {
 					swap = () => {
 						visible = !visible;
@@ -3580,7 +3584,7 @@ jsdomDescribe('vdom', () => {
 						const createWidget = create({ diffProperty, invalidator }).properties<any>();
 						const Foo = createWidget(({ middleware, properties }) => {
 							middleware.diffProperty('text', (current: any, properties: any) => {});
-							return v('div', [properties.text]);
+							return v('div', [properties().text]);
 						});
 						let text = 'first';
 						const App = createWidget(({ middleware }) => {

--- a/tests/testing/unit/harness.tsx
+++ b/tests/testing/unit/harness.tsx
@@ -653,7 +653,7 @@ describe('harness', () => {
 				});
 				return (
 					<div>
-						<button key="click-me">{`${properties.key} ${id}`}</button>
+						<button key="click-me">{`${properties().key} ${id}`}</button>
 					</div>
 				);
 			});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The `properties` and `children` are injected one time into both middleware and widgets. With middleware it is easy to destructure the properties outside of the middleware API meaning that when it is used in subsequent renders it will be the stale properties from the first render.

This changes the `properties` and `children` to be functions which is clearer to users that it needs to be called on demand to get the latest properties/children.

Related to #349 
