### PR TITLE
Prefer wrapper ids over references

### DIFF
--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3079,7 +3079,6 @@ jsdomDescribe('vdom', () => {
 				resolvers.resolve();
 				assert.strictEqual(div.outerHTML, '<div><div>first</div></div>');
 				updateText();
-				debugger;
 				resolvers.resolve();
 				assert.strictEqual(div.outerHTML, '<div><div>second</div></div>');
 			});
@@ -3774,7 +3773,6 @@ jsdomDescribe('vdom', () => {
 			const r = renderer(() => w(Widget, {}));
 			const div = document.createElement('div');
 			r.mount({ domNode: div });
-			debugger;
 			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>onetwo<div>three</div></div>');
 			meta.setRenderResult(v('virtual', [v('div', ['four', 'five', v('div', ['six'])])]));
 			resolvers.resolve();

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3079,6 +3079,7 @@ jsdomDescribe('vdom', () => {
 				resolvers.resolve();
 				assert.strictEqual(div.outerHTML, '<div><div>first</div></div>');
 				updateText();
+				debugger;
 				resolvers.resolve();
 				assert.strictEqual(div.outerHTML, '<div><div>second</div></div>');
 			});
@@ -3773,6 +3774,7 @@ jsdomDescribe('vdom', () => {
 			const r = renderer(() => w(Widget, {}));
 			const div = document.createElement('div');
 			r.mount({ domNode: div });
+			debugger;
 			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>onetwo<div>three</div></div>');
 			meta.setRenderResult(v('virtual', [v('div', ['four', 'five', v('div', ['six'])])]));
 			resolvers.resolve();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Change how children and parents are referenced by other wrappers, preferring using the wrapper id over storing the wrapper object itself. This should reduce the references that are held in memory and help the memory footprint generally.