### PR TITLE
Prefer wrapper ids over references for tracking nodes

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1913,10 +1913,13 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	}
 
 	function _createDom({ next }: CreateDomInstruction): ProcessResult {
-		let mergeNodes: Node[] = [];
-		const parentDomNode = findParentDomNode(next)!;
+		const parentDomNode = findParentDomNode(next);
+		if (!parentDomNode) {
+			return {};
+		}
 		const isVirtual = isVirtualWrapper(next);
 		const isBody = isBodyWrapper(next);
+		let mergeNodes: Node[] = [];
 		next.id = `${wrapperId++}`;
 		_idToWrapperMap.set(next.id, next);
 		if (!next.domNode) {
@@ -1987,6 +1990,9 @@ export function renderer(renderer: () => RenderResult): Renderer {
 
 	function _updateDom({ current, next }: UpdateDomInstruction): ProcessResult {
 		const parentDomNode = findParentDomNode(current);
+		if (!parentDomNode) {
+			return {};
+		}
 		next.domNode = current.domNode;
 		next.namespace = current.namespace;
 		next.id = current.id;

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -55,6 +55,8 @@ export interface BaseNodeWrapper {
 	hasParentWNode?: boolean;
 	namespace?: string;
 	hasAnimations?: boolean;
+	parentId: string;
+	childDomWrapperId?: string;
 }
 
 export interface WNodeWrapper extends BaseNodeWrapper {
@@ -817,13 +819,12 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	let _applicationQueue: ApplicationInstruction[] = [];
 	let _eventMap = new WeakMap<Function, EventListener>();
 	let _idToWrapperMap = new Map<string, DNodeWrapper>();
-	let _parentWrapperMap = new WeakMap<DNodeWrapper, DNodeWrapper>();
 	let _wrapperSiblingMap = new WeakMap<DNodeWrapper, DNodeWrapper>();
+	let _idToChildrenWrappers = new Map<string, DNodeWrapper[]>();
 	let _insertBeforeMap: undefined | WeakMap<DNodeWrapper, Node> = new WeakMap<DNodeWrapper, Node>();
 	let _nodeToWrapperMap = new WeakMap<VNode | WNode<any>, WNodeWrapper>();
 	let _renderScheduled: number | undefined;
 	let _idleCallbacks: Function[] = [];
-	let _idToChildrenWrappers = new Map<string, DNodeWrapper[]>();
 	let _deferredRenderCallbacks: Function[] = [];
 	let parentInvalidate: () => void;
 	let _allMergedNodes: Node[] = [];
@@ -985,6 +986,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				node: renderedItem,
 				depth: depth + 1,
 				order: i,
+				parentId: parent.id,
 				requiresInsertBefore: insertBefore,
 				hasParentWNode,
 				namespace: namespace
@@ -995,13 +997,13 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				}
 				if (renderedItem.properties.exitAnimation) {
 					parent.hasAnimations = true;
-					let nextParent = _parentWrapperMap.get(parent);
+					let nextParent = _idToWrapperMap.get(parent.parentId);
 					while (nextParent) {
 						if (nextParent.hasAnimations) {
 							break;
 						}
 						nextParent.hasAnimations = true;
-						nextParent = _parentWrapperMap.get(nextParent);
+						nextParent = _idToWrapperMap.get(nextParent.parentId);
 					}
 				}
 			}
@@ -1011,8 +1013,6 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			if (isWNode(renderedItem)) {
 				resolveRegistryItem(wrapper as WNodeWrapper, (parent as any).instance, (parent as any).id);
 			}
-
-			_parentWrapperMap.set(wrapper, parent);
 			if (previousItem) {
 				_wrapperSiblingMap.set(previousItem, wrapper);
 			}
@@ -1024,7 +1024,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 
 	function findParentDomNode(currentNode: DNodeWrapper): Node | undefined {
 		let parentDomNode: Node | undefined;
-		let parentWrapper = _parentWrapperMap.get(currentNode);
+		let parentWrapper = _idToWrapperMap.get(currentNode.parentId);
 
 		while (!parentDomNode && parentWrapper) {
 			if (
@@ -1035,7 +1035,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			) {
 				parentDomNode = parentWrapper.domNode;
 			}
-			parentWrapper = _parentWrapperMap.get(parentWrapper);
+			parentWrapper = _idToWrapperMap.get(parentWrapper.parentId);
 		}
 		return parentDomNode;
 	}
@@ -1062,22 +1062,21 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		while (!insertBefore) {
 			const nextSibling = _wrapperSiblingMap.get(searchNode);
 			if (nextSibling) {
-				if (isVNodeWrapper(nextSibling)) {
-					if (nextSibling.domNode && nextSibling.domNode.parentNode) {
-						insertBefore = nextSibling.domNode;
-						break;
+				let domNode = nextSibling.domNode;
+				if ((isWNodeWrapper(nextSibling) || isVirtualWrapper(nextSibling)) && nextSibling.childDomWrapperId) {
+					const childWrapper = _idToWrapperMap.get(nextSibling.childDomWrapperId);
+					if (childWrapper) {
+						domNode = childWrapper.domNode;
 					}
-					searchNode = nextSibling;
-					continue;
 				}
-				if (nextSibling.domNode && nextSibling.domNode.parentNode) {
-					insertBefore = nextSibling.domNode;
+				if (domNode && domNode.parentNode) {
+					insertBefore = domNode;
 					break;
 				}
 				searchNode = nextSibling;
 				continue;
 			}
-			searchNode = _parentWrapperMap.get(searchNode);
+			searchNode = searchNode && _idToWrapperMap.get(searchNode.parentId);
 			if (!searchNode || (isVNodeWrapper(searchNode) && !isVirtualWrapper(searchNode))) {
 				break;
 			}
@@ -1260,15 +1259,18 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			order: 0,
 			depth: 1,
 			owningId: '-1',
+			parentId: '-1',
+			siblingId: '-1',
 			properties: {}
 		};
-		_parentWrapperMap.set(nextWrapper, {
+		_idToWrapperMap.set('-1', {
 			id: `-1`,
 			depth: 0,
 			order: 0,
 			owningId: '',
 			domNode,
-			node: v('fake')
+			node: v('fake'),
+			parentId: '-1'
 		});
 		_processQueue.push({
 			current: [],
@@ -1331,7 +1333,6 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			if (previouslyRendered.indexOf(id) === -1 && _idToWrapperMap.has(id!)) {
 				previouslyRendered.push(id);
 				const current = getWNodeWrapper(id)!;
-				const parent = _parentWrapperMap.get(current);
 				const sibling = _wrapperSiblingMap.get(current);
 				const next = {
 					node: {
@@ -1346,10 +1347,10 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					depth: current.depth,
 					order: current.order,
 					owningId: current.owningId,
+					parentId: current.parentId,
 					registryItem: current.registryItem
 				};
 
-				parent && _parentWrapperMap.set(next, parent);
 				sibling && _wrapperSiblingMap.set(next, sibling);
 				const result = _updateWidget({ current, next });
 				if (result && result.item) {
@@ -1447,7 +1448,6 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					_mountOptions.transition.exit(current.domNode as HTMLElement, exitAnimation, exitAnimationActive);
 				} else {
 					current.domNode!.parentNode!.removeChild(current.domNode!);
-					current.domNode = undefined;
 				}
 			} else if (item.type === 'attach') {
 				const { instance, attached } = item;
@@ -1461,7 +1461,6 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					const instanceData = widgetInstanceMap.get(item.current.instance);
 					instanceData && instanceData.onDetach();
 				}
-				item.current.domNode = undefined;
 				item.current.instance = undefined;
 			}
 		}
@@ -1692,19 +1691,16 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		next.properties = next.node.properties;
 		next.id = next.id || `${wrapperId++}`;
 		_idToWrapperMap.set(next.id, next);
+		const { id, depth, order } = next;
 		if (!isWidgetBaseConstructor(Constructor)) {
-			let widgetMeta = widgetMetaMap.get(next.id);
+			let widgetMeta = widgetMetaMap.get(id);
 			if (!widgetMeta) {
 				invalidate = () => {
-					const widgetMeta = widgetMetaMap.get(next.id);
+					const widgetMeta = widgetMetaMap.get(id);
 					if (widgetMeta) {
 						widgetMeta.dirty = true;
-						if (!widgetMeta.rendering && _idToWrapperMap.has(next.id)) {
-							_invalidationQueue.push({
-								id: next.id,
-								depth: next.depth,
-								order: next.order
-							});
+						if (!widgetMeta.rendering && _idToWrapperMap.has(id)) {
+							_invalidationQueue.push({ id, depth, order });
 							_schedule();
 						}
 					}
@@ -1722,14 +1718,14 @@ export function renderer(renderer: () => RenderResult): Renderer {
 
 				widgetMetaMap.set(next.id, widgetMeta);
 				widgetMeta.middleware = (Constructor as any).middlewares
-					? resolveMiddleware((Constructor as any).middlewares, next.id)
+					? resolveMiddleware((Constructor as any).middlewares, id)
 					: {};
 			} else {
 				invalidate = widgetMeta.invalidator;
 			}
 
 			rendered = Constructor({
-				id: next.id,
+				id,
 				properties: () => next.node.properties,
 				children: () => next.node.children,
 				middleware: widgetMeta.middleware
@@ -1747,12 +1743,8 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			const instanceData = widgetInstanceMap.get(instance)!;
 			invalidate = () => {
 				instanceData.dirty = true;
-				if (!instanceData.rendering && _idToWrapperMap.has(next.id)) {
-					_invalidationQueue.push({
-						id: next.id,
-						depth: next.depth,
-						order: next.order
-					});
+				if (!instanceData.rendering && _idToWrapperMap.has(id)) {
+					_invalidationQueue.push({ id, depth, order });
 					_schedule();
 				}
 			};
@@ -1769,7 +1761,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		if (rendered) {
 			rendered = Array.isArray(rendered) ? rendered : [rendered];
 			children = renderedToWrapper(rendered, next, null);
-			_idToChildrenWrappers.set(next.id, children);
+			_idToChildrenWrappers.set(id, children);
 		}
 
 		if (!parentInvalidate && !(Constructor as any).isWNodeWrapper) {
@@ -1781,7 +1773,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				next: children,
 				meta: { mergeNodes: next.mergeNodes }
 			},
-			widget: { type: 'attach', instance: next.instance, id: next.id, attached: true }
+			widget: { type: 'attach', instance: next.instance, id, attached: true }
 		};
 	}
 
@@ -1802,7 +1794,9 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		let currentChildren = _idToChildrenWrappers.get(current.id);
 		next.hasAnimations = hasAnimations;
 		next.id = current.id;
+		next.childDomWrapperId = current.childDomWrapperId;
 		next.properties = next.node.properties;
+		_wrapperSiblingMap.delete(current);
 		if (domNode && domNode.parentNode) {
 			next.domNode = domNode;
 		}
@@ -1877,12 +1871,11 @@ export function renderer(renderer: () => RenderResult): Renderer {
 
 	function _removeWidget({ current }: RemoveWidgetInstruction): ProcessResult {
 		current = getWNodeWrapper(current.id) || current;
-		_wrapperSiblingMap.delete(current);
-		_parentWrapperMap.delete(current);
 		_idToWrapperMap.delete(current.id);
 		const meta = widgetMetaMap.get(current.id);
 		let currentChildren = _idToChildrenWrappers.get(current.id);
 		_idToChildrenWrappers.delete(current.id);
+		_wrapperSiblingMap.delete(current);
 		let processResult: ProcessResult = {
 			item: {
 				current: currentChildren,
@@ -1908,7 +1901,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			child = children.shift();
 			if (child) {
 				if (child.domNode) {
-					wrapper.domNode = child.domNode;
+					wrapper.childDomWrapperId = child.id;
 					break;
 				}
 				let nextChildren = _idToChildrenWrappers.get(child.id);
@@ -1997,6 +1990,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		next.domNode = current.domNode;
 		next.namespace = current.namespace;
 		next.id = current.id;
+		next.childDomWrapperId = current.childDomWrapperId;
 		let children: DNodeWrapper[] | undefined;
 		let currentChildren = _idToChildrenWrappers.get(next.id);
 		if (next.node.text && next.node.text !== current.node.text) {
@@ -2007,6 +2001,8 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			children = renderedToWrapper(next.node.children, next, current);
 			_idToChildrenWrappers.set(next.id, children);
 		}
+		_wrapperSiblingMap.delete(current);
+		_idToWrapperMap.set(next.id, next);
 		return {
 			item: {
 				current: currentChildren,
@@ -2020,13 +2016,10 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	function _removeDom({ current }: RemoveDomInstruction): ProcessResult {
 		const isVirtual = isVirtualWrapper(current);
 		const isBody = isBodyWrapper(current);
-		_wrapperSiblingMap.delete(current);
-		_parentWrapperMap.delete(current);
-		let children = _idToChildrenWrappers.get(current.id);
+		const children = _idToChildrenWrappers.get(current.id);
 		_idToChildrenWrappers.delete(current.id);
-		if (current.id) {
-			_idToWrapperMap.delete(current.id);
-		}
+		_idToWrapperMap.delete(current.id);
+		_wrapperSiblingMap.delete(current);
 		if (current.node.properties.key) {
 			const widgetMeta = widgetMetaMap.get(current.owningId);
 			const parentWrapper = getWNodeWrapper(current.owningId);
@@ -2070,9 +2063,6 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					}
 					_idToChildrenWrappers.delete(wrapper.id);
 					_idToWrapperMap.delete(wrapper.id);
-					_wrapperSiblingMap.delete(wrapper);
-					_parentWrapperMap.delete(wrapper);
-					wrapper.domNode = undefined;
 				}
 			});
 		}

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3079,7 +3079,6 @@ jsdomDescribe('vdom', () => {
 				resolvers.resolve();
 				assert.strictEqual(div.outerHTML, '<div><div>first</div></div>');
 				updateText();
-				debugger;
 				resolvers.resolve();
 				assert.strictEqual(div.outerHTML, '<div><div>second</div></div>');
 			});
@@ -3774,7 +3773,6 @@ jsdomDescribe('vdom', () => {
 			const r = renderer(() => w(Widget, {}));
 			const div = document.createElement('div');
 			r.mount({ domNode: div });
-			debugger;
 			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>onetwo<div>three</div></div>');
 			meta.setRenderResult(v('virtual', [v('div', ['four', 'five', v('div', ['six'])])]));
 			resolvers.resolve();

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3079,6 +3079,7 @@ jsdomDescribe('vdom', () => {
 				resolvers.resolve();
 				assert.strictEqual(div.outerHTML, '<div><div>first</div></div>');
 				updateText();
+				debugger;
 				resolvers.resolve();
 				assert.strictEqual(div.outerHTML, '<div><div>second</div></div>');
 			});
@@ -3773,6 +3774,7 @@ jsdomDescribe('vdom', () => {
 			const r = renderer(() => w(Widget, {}));
 			const div = document.createElement('div');
 			r.mount({ domNode: div });
+			debugger;
 			assert.strictEqual((div.childNodes[0] as Element).outerHTML, '<div>onetwo<div>three</div></div>');
 			meta.setRenderResult(v('virtual', [v('div', ['four', 'five', v('div', ['six'])])]));
 			resolvers.resolve();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

Change how children and parents are referenced by other wrappers, preferring using the wrapper id over storing the wrapper object itself. This should reduce the references that are held in memory and help the memory footprint generally.