### PR TITLE
Ensure that widgets are removed from the body when they are detached

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -2067,12 +2067,12 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					}
 					if (isBodyWrapper(wrapper)) {
 						bodyIds.push(wrapper.id);
-					} else if (
-						bodyIds.indexOf(wrapper.parentId) !== -1 &&
-						wrapper.domNode &&
-						wrapper.domNode.parentNode
-					) {
-						wrapper.domNode.parentNode.removeChild(wrapper.domNode);
+					} else if (bodyIds.indexOf(wrapper.parentId) !== -1) {
+						if (isWNodeWrapper(wrapper) || isVirtualWrapper(wrapper)) {
+							bodyIds.push(wrapper.id);
+						} else if (wrapper.domNode && wrapper.domNode.parentNode) {
+							wrapper.domNode.parentNode.removeChild(wrapper.domNode);
+						}
 					}
 					_idToChildrenWrappers.delete(wrapper.id);
 					_idToWrapperMap.delete(wrapper.id);

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3868,6 +3868,113 @@ jsdomDescribe('vdom', () => {
 			resolvers.resolveRAF();
 			results = document.querySelectorAll('.body-span');
 			assert.lengthOf(results, 1);
+			doShow();
+			resolvers.resolveRAF();
+			resolvers.resolveRAF();
+			results = document.querySelectorAll('.body-span');
+			assert.lengthOf(results, 0);
+		});
+
+		it('should detach widgets nested in a body tag', () => {
+			let doShow: any;
+
+			class A extends WidgetBase<any> {
+				render() {
+					return v('div', [v('body', [w(B, {})])]);
+				}
+			}
+
+			class B extends WidgetBase<any> {
+				render() {
+					return v('span', { classes: ['body-span'] }, ['and im in the body!!']);
+				}
+			}
+
+			class App extends WidgetBase {
+				private show = true;
+
+				constructor() {
+					super();
+					doShow = () => {
+						this.show = !this.show;
+						this.invalidate();
+					};
+				}
+
+				protected render() {
+					return v('div', [this.show && w(A, {})]);
+				}
+			}
+
+			const r = renderer(() => w(App, {}));
+			r.mount({ domNode: root });
+
+			let results = document.querySelectorAll('.body-span');
+			assert.lengthOf(results, 1);
+			doShow();
+			resolvers.resolveRAF();
+			resolvers.resolveRAF();
+			results = document.querySelectorAll('.body-span');
+			assert.lengthOf(results, 0);
+			doShow();
+			resolvers.resolveRAF();
+			resolvers.resolveRAF();
+			results = document.querySelectorAll('.body-span');
+			assert.lengthOf(results, 1);
+			doShow();
+			resolvers.resolveRAF();
+			resolvers.resolveRAF();
+			results = document.querySelectorAll('.body-span');
+			assert.lengthOf(results, 0);
+		});
+
+		it('should detach virtual nodes nested in a body tag', () => {
+			let doShow: any;
+
+			class A extends WidgetBase<any> {
+				render() {
+					return v('div', [
+						v('body', [v('virtual', [v('span', { classes: ['body-span'] }, ['and im in the body!!'])])])
+					]);
+				}
+			}
+
+			class App extends WidgetBase {
+				private show = true;
+
+				constructor() {
+					super();
+					doShow = () => {
+						this.show = !this.show;
+						this.invalidate();
+					};
+				}
+
+				protected render() {
+					return v('div', [this.show && w(A, {})]);
+				}
+			}
+
+			const r = renderer(() => w(App, {}));
+			r.mount({ domNode: root });
+
+			let results = document.querySelectorAll('.body-span');
+			assert.lengthOf(results, 1);
+			doShow();
+			resolvers.resolveRAF();
+			resolvers.resolveRAF();
+			results = document.querySelectorAll('.body-span');
+			assert.lengthOf(results, 0);
+			doShow();
+			resolvers.resolveRAF();
+			resolvers.resolveRAF();
+			results = document.querySelectorAll('.body-span');
+			assert.lengthOf(results, 1);
+			doShow();
+			resolvers.resolveRAF();
+			resolvers.resolveRAF();
+			results = document.querySelectorAll('.body-span');
+			assert.lengthOf(results, 0);
 		});
 	});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure nodes created by a widget are removed when wrapped in a body.

Resolves #462 
