### PR TITLE
Improve return typing on icache getOrSet

### DIFF
--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -8,57 +8,70 @@ interface CacheWrapper<T = any> {
 	value: T;
 }
 
-export const icache = factory(({ middleware: { invalidator, cache } }) => {
-	return {
-		getOrSet<T = any>(key: any, value: any): T | undefined {
-			let cachedValue = cache.get<CacheWrapper<T>>(key);
-			if (!cachedValue) {
-				this.set(key, value);
-			}
-			cachedValue = cache.get<CacheWrapper<T>>(key);
-			if (!cachedValue || cachedValue.status === 'pending') {
-				return undefined;
-			}
-			return cachedValue.value;
-		},
-		get<T = any>(key: any): T | undefined {
-			const cachedValue = cache.get<CacheWrapper<T>>(key);
-			if (!cachedValue || cachedValue.status === 'pending') {
-				return undefined;
-			}
-			return cachedValue.value;
-		},
-		set(key: any, value: any): void {
-			if (typeof value === 'function') {
-				value = value();
-				if (value && typeof value.then === 'function') {
-					cache.set(key, {
-						status: 'pending',
-						value
-					});
-					value.then((result: any) => {
-						const cachedValue = cache.get<CacheWrapper<any>>(key);
-						if (cachedValue && cachedValue.value === value) {
-							cache.set(key, {
-								status: 'resolved',
-								value: result
-							});
-							invalidator();
-						}
-					});
-					return;
-				}
-			}
-			cache.set(key, {
-				status: 'resolved',
-				value
-			});
-			invalidator();
-		},
-		clear(): void {
-			cache.clear();
-		}
+export interface IcacheResult {
+	getOrSet: {
+		<T>(key: any, value: () => Promise<T>): undefined;
+		<T>(key: any, value: () => T): T;
+		<T>(key: any, value: T): T;
 	};
-});
+	get<T = any>(key: any): T | undefined;
+	set(key: any, value: any): void;
+	clear(): void;
+}
+
+export const icache = factory(
+	({ middleware: { invalidator, cache } }): IcacheResult => {
+		return {
+			getOrSet<T = any>(key: any, value: any): T | undefined {
+				let cachedValue = cache.get<CacheWrapper<T>>(key);
+				if (!cachedValue) {
+					this.set(key, value);
+				}
+				cachedValue = cache.get<CacheWrapper<T>>(key);
+				if (!cachedValue || cachedValue.status === 'pending') {
+					return undefined;
+				}
+				return cachedValue.value;
+			},
+			get<T = any>(key: any): T | undefined {
+				const cachedValue = cache.get<CacheWrapper<T>>(key);
+				if (!cachedValue || cachedValue.status === 'pending') {
+					return undefined;
+				}
+				return cachedValue.value;
+			},
+			set(key: any, value: any): void {
+				if (typeof value === 'function') {
+					value = value();
+					if (value && typeof value.then === 'function') {
+						cache.set(key, {
+							status: 'pending',
+							value
+						});
+						value.then((result: any) => {
+							const cachedValue = cache.get<CacheWrapper<any>>(key);
+							if (cachedValue && cachedValue.value === value) {
+								cache.set(key, {
+									status: 'resolved',
+									value: result
+								});
+								invalidator();
+							}
+						});
+						return;
+					}
+				}
+				cache.set(key, {
+					status: 'resolved',
+					value
+				});
+				invalidator();
+			},
+			clear(): void {
+				cache.clear();
+			}
+		};
+	}
+);
 
 export default icache;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Improve argument and return typing on `icache` middleware's getOrSet method.

This is completely a typing change with no implementation changes.

**Before**:
```tsx
icache.getOrSet('test', 'test'); /* Type: any */
icache.getOrSet('test', () => 'test'); /* Type: any */
icache.getOrSet('test', () => Promise.resolve()); /* Type: any */
	
icache.getOrSet<string>('test', 'test'); /* Type: string | undefined */
icache.getOrSet<string>('test', 42); /* No Error, Type: string | undefined */
icache.getOrSet<string>('test', () => 'test'); /* Type: string | undefined */
icache.getOrSet<string>('test', () => Promise.resolve()); /* Type: string | undefined */
```

**After**:
```tsx
icache.getOrSet('test', 'test'); /* Type: 'test' */
icache.getOrSet('test', () => 'test'); /* Type: string */
icache.getOrSet('test', () => Promise.resolve()); /* Type: undefined */

icache.getOrSet<string>('test', 'test'); /* Type: string */
icache.getOrSet<string>('test', 42); /* Type error: '42' is not assignable to parameter of type 'string' */
icache.getOrSet<string>('test', () => 'test'); /* Type: string */
icache.getOrSet<string>('test', () => Promise.resolve()); /* Type error: '() => Promise<void>' is not assignable to parameter of type 'string' */
icache.getOrSet<string>('test', () => new Promise<string>(() => {})); /* Type: undefined */
```