### PR TITLE
Add jsdom user agent check to global shim

### DIFF
--- a/src/shim/global.ts
+++ b/src/shim/global.ts
@@ -2,7 +2,7 @@ const globalObject: any = (function(): any {
 	// the only reliable means to get the global object is
 	// `Function('return this')()`
 	// However, this causes CSP violations in Chrome apps.
-	if (typeof window !== 'undefined' && window.navigator.userAgent.includes('jsdom')) {
+	if (typeof window !== 'undefined' && window.navigator.userAgent.indexOf('jsdom') > -1) {
 		return window;
 	}
 	if (typeof globalThis !== 'undefined') {

--- a/src/shim/global.ts
+++ b/src/shim/global.ts
@@ -2,6 +2,9 @@ const globalObject: any = (function(): any {
 	// the only reliable means to get the global object is
 	// `Function('return this')()`
 	// However, this causes CSP violations in Chrome apps.
+	if (typeof window !== 'undefined' && window.navigator.userAgent.includes('jsdom')) {
+		return window;
+	}
 	if (typeof globalThis !== 'undefined') {
 		return globalThis;
 	}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Checking for `globalThis` this was breaking testing functionality that expected the jsdom window to be returned from `global.ts`. This adds an explicit check that should detect when the window has been provided by jsdom.
