### PR TITLE
Update routing guide

### DIFF
--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -137,7 +137,7 @@ export default factory(function App() {
 });
 ```
 
-If the browser is pointed to the URL path `/home/page?queryOne=modern&queryTwo=dojo`, then the query params are injected into the matching `Outlet`'s `renderer` method as a `MatchDetails` type and accessed via its `queryParams` property. Using this URL, the page would show "Hello modern-dojo". If a query parameter is not provided, then its value will be set to `undefined`.
+If the browser is pointed to the URL path `/home/page?queryOne=modern&queryTwo=dojo`, then the query parameters are injected into the matching `Outlet`'s `renderer` method as an object of type `MatchDetails` and accessed via that object's `queryParams` property. Using this URL, the page would show "Hello modern-dojo". If a query parameter is not provided, then its value will be set to `undefined`.
 
 ## Default route and parameters
 

--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -64,6 +64,9 @@ export default factory(function App() {
 });
 ```
 
+-   The URL of the route is determined by the `path` element of the route configuration. In this case, `home` was specified so the route can be accessed via the URL path `/#home`.
+    -   By default the router uses the [HashHistory](/learn/routing/history-managers#hashhistory) history manager which requires the use of the `#` before the route path. Other [history managers](/learn/routing/history-managers) are available to support other history management mechanisms.
+
 ## Path and query parameters
 
 Path parameters are placeholders in the routing configuration that will match any value for the segment. The parameters are defined using curly braces, for example: `{param}`.
@@ -98,14 +101,14 @@ export default factory(function App() {
 });
 ```
 
-Query parameters are also defined using curly braces split from the route path by a `?`. To define more than one query param, use the `&` delimiter.
+Query parameters can also be added to route URLs. As with normal query parameters, the first must be prefixed with a `?` with additional query parameters delimited by the `&` character. Note that the route configuration does not change when using query parameters.
 
 > src/routes.ts
 
 ```ts
 export default [
 	{
-		path: 'home/{page}?{queryOne}&{queryTwo}',
+		path: 'home/{page}',
 		outlet: 'home'
 	}
 ];
@@ -134,7 +137,7 @@ export default factory(function App() {
 });
 ```
 
-The query params are injected into matching `Outlet` `renderer` properties accessed from `queryParams` property.
+If the browser is pointed to the URL path `/home/page?queryOne=modern&queryTwo=dojo`, then the query params are injected into matching `Outlet` `renderer` properties accessed from `queryParams` property. Using this URL, the page would show "Hello modern-dojo". If a query parameter is not provided, then its value will be set to `undefined`.
 
 ## Default route and parameters
 

--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -137,7 +137,7 @@ export default factory(function App() {
 });
 ```
 
-If the browser is pointed to the URL path `/home/page?queryOne=modern&queryTwo=dojo`, then the query params are injected into matching `Outlet` `renderer` properties accessed from `queryParams` property. Using this URL, the page would show "Hello modern-dojo". If a query parameter is not provided, then its value will be set to `undefined`.
+If the browser is pointed to the URL path `/home/page?queryOne=modern&queryTwo=dojo`, then the query params are injected into the matching `Outlet`'s `renderer` method as a `MatchDetails` type and accessed via its `queryParams` property. Using this URL, the page would show "Hello modern-dojo". If a query parameter is not provided, then its value will be set to `undefined`.
 
 ## Default route and parameters
 

--- a/docs/en/routing/supplemental.md
+++ b/docs/en/routing/supplemental.md
@@ -183,6 +183,10 @@ const outletContext = router.getOutlet('home');
 
 For every `outlet` that is matched on a route change, `MatchDetails` are injected into the `Outlet` widget's `renderer` property. The `MatchDetails` object contains specific details for the matched outlet.
 
+Note: All examples assume that the default [HashHistory](#hashhistory) history manager is being used.
+
+## `queryParams`
+
 -   `queryParams: { [index: string]: string }`: The query params from the matched route.
 
 > src/routes.ts
@@ -190,11 +194,22 @@ For every `outlet` that is matched on a route change, `MatchDetails` are injecte
 ```ts
 export default [
 	{
-		path: 'home?{query}',
+		path: 'home',
 		outlet: 'home'
 	}
 ];
 ```
+
+-   given the URL path `/#home?foo=bar&baz=42`, the `queryParams` object will look like:
+
+```js
+{
+	foo: 'bar',
+	baz: '42'
+}
+```
+
+## `params`
 
 -   `params: { [index: string]: string }`: The path params from the matched route.
 
@@ -203,11 +218,21 @@ export default [
 ```ts
 export default [
 	{
-		path: 'home/{param}',
+		path: 'home/{page}',
 		outlet: 'home'
 	}
 ];
 ```
+
+-   given the URL path `/#home/about`, the `params` object will have look like:
+
+```js
+{
+	page: 'about';
+}
+```
+
+## `isExact()`
 
 -   `isExact(): boolean`: A function that indicates if the outlet is an exact match for the path. This can be used to conditionally render different widgets or nodes.
 
@@ -219,12 +244,49 @@ export default [
 		path: 'home',
 		outlet: 'home',
 		children: [
-			path: 'about',
-			outlet: 'about'
+			{
+				path: 'about',
+				outlet: 'about'
+			}
 		]
 	}
 ];
 ```
+
+-   given the above route definition, if the URL path is set to `/#home/about`, then `isExact()` will evaluate to `false` for the `Outlet` with the id "home" and `true` for the an `Outlet` that is a child of the home `Outlet` with the id "about" as shown in the following file:
+
+> src/App.tsx
+
+```ts
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Outlet from '@dojo/framework/routing/Outlet';
+
+const factory = create();
+
+export default factory(function App() {
+	return (
+		<div>
+			<Outlet
+				id="home"
+				renderer={(homeMatchDetails) => {
+					console.log('home', homeMatchDetails.isExact()); // home false
+					return (
+						<Outlet
+							id="about"
+							renderer={(aboutMatchDetails) => {
+								console.log('about', aboutMatchDetails.isExact()); // about true
+								return [];
+							}}
+						/>
+					);
+				}}
+			/>
+		</div>
+	);
+});
+```
+
+## `isError()`
 
 -   `isError(): boolean`: A function indicates if the outlet is an error match for the path. This indicates after this outlet was matched, no other matches were found.
 
@@ -243,7 +305,34 @@ export default [
 ];
 ```
 
+-   given this route definition, if the URL path is set to `/#home/foo` then there is no exact route match, so the `isError()` method on the home `Outlet`'s `martchDetails` object will yield `true`. Navigating to `/#home` or `/#home/about` however will cause the same method to return `false` since both routes are defined.
+
+## `type`
+
 -   `type: 'index' | 'partial' | 'error'`: The type of match for the route, either `index`, `partial` or `error`. Using `type` should not be necessary, instead favouring a combination of `isExact` and `isError`.
+
+```ts
+export default [
+	{
+		path: 'home',
+		outlet: 'home',
+		children: [
+			path: 'about',
+			outlet: 'about'
+		]
+	}
+];
+```
+
+-   given the above route definition, the following values of `type` would be provided to each outlet:
+
+| URL path       | Home outlet | About outlet |
+| -------------- | :---------: | :----------: |
+| `/#home`       |   'index'   |     N/A      |
+| `/#home/about` |  'partial'  |   'index'    |
+| `/#home/foo`   |   'error'   |     N/A      |
+
+## `router`
 
 -   `router: RouterInterface`: The router instance which can used to create links and initiate route changes. For more information see the router API.
 


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [X] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**
Added an example to the introduction page that shows what the URL path looks like when using routing and points to the History Manager section of the supplemental material to get more information. This PR also expands on the documentation for the `MatchDetails` object to provide more clarity on how different scenarios affect the values of its members.
