### PR TITLE
add regular replace test

### DIFF
--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -167,6 +167,12 @@ describe('assertionTemplate', () => {
 		h.expect(insertionAssertion);
 	});
 
+	it('can replace a node', () => {
+		const h = harness(() => w(MyWidget, { replaceChild: true }));
+		const childAssertion = baseAssertion.replace('~header', v('h2', ['replace']));
+		h.expect(childAssertion);
+	});
+
 	it('can replace a node in the root', () => {
 		const h = harness(() => w(MyWidget, { removeHeader: true, before: true }));
 		const childAssertion = baseAssertion.replace('~header', v('span', ['before']));

--- a/tests/testing/unit/assertionTemplate.tsx
+++ b/tests/testing/unit/assertionTemplate.tsx
@@ -149,12 +149,6 @@ describe('assertionTemplate', () => {
 		h.expect(propertyAssertion);
 	});
 
-	it('can replace a node', () => {
-		const h = harness(() => w(MyWidget, {}));
-		const childAssertion = baseAssertion.replace('~header', v('h2', { '~key': 'header' }, ['hello']));
-		h.expect(childAssertion);
-	});
-
 	it('can remove a node', () => {
 		const h = harness(() => w(MyWidget, { removeHeader: true }));
 		const childAssertion = baseAssertion.remove('~header');


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Improves the replace assertionTest for non-root nodes and moves it next to the other replace test.

Related to #470 [(comment)](https://github.com/dojo/framework/pull/470#discussion_r312182340)
