### PR TITLE
Update StateHistory to generate relative links and use the `app-base` has flag

### DIFF
--- a/tests/routing/unit/history/StateHistory.ts
+++ b/tests/routing/unit/history/StateHistory.ts
@@ -1,12 +1,12 @@
 const { afterEach, beforeEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
-import { stub } from 'sinon';
+import { stub, SinonStub } from 'sinon';
 
-import global from '../../../../src/shim/global';
-import { add } from '../../../../src/core/has';
 import { StateHistory } from '../../../../src/routing/history/StateHistory';
+import { add } from '../../../../src/core/has';
 
 const onChange = stub();
+let consoleWarnStub: SinonStub;
 
 describe('StateHistory', () => {
 	let sandbox: HTMLIFrameElement;
@@ -14,6 +14,7 @@ describe('StateHistory', () => {
 		sandbox = document.createElement('iframe');
 		sandbox.src = '../../tests/routing/support/sandbox.html';
 		document.body.appendChild(sandbox);
+		consoleWarnStub = stub(console, 'warn');
 		return new Promise((resolve) => {
 			sandbox.addEventListener('load', function() {
 				resolve();
@@ -25,43 +26,39 @@ describe('StateHistory', () => {
 		document.body.removeChild(sandbox);
 		sandbox = null as any;
 		onChange.reset();
-		add('public-path', undefined, true);
-		global.window.__public_path__ = undefined;
+		add('app-base', undefined, true);
+		add('dojo-debug', false, true);
+		consoleWarnStub.restore();
 	});
 
 	it('initializes current path to current location', () => {
 		sandbox.contentWindow!.history.pushState({}, '', '/foo?bar');
-		assert.equal(new StateHistory({ onChange, window: sandbox.contentWindow! }).current, '/foo?bar');
+		assert.equal(new StateHistory({ onChange, window: sandbox.contentWindow! }).current, 'foo?bar');
 	});
 
 	it('location defers to the global object', () => {
 		assert.equal(new StateHistory({ onChange }).current, window.location.pathname + window.location.search);
 	});
 
-	it('prefixes path with leading slash if necessary', () => {
+	it('prefixes sanatizes path removing / and # characters', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
-		assert.equal(history.prefix('/foo'), '/foo');
-		assert.equal(history.prefix('foo'), '/foo');
-	});
-
-	it('prefixes path removes # characters', () => {
-		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
-		assert.equal(history.prefix('#/foo'), '/foo');
-		assert.equal(history.prefix('#foo'), '/foo');
+		assert.equal(history.prefix('#/foo'), 'foo');
+		assert.equal(history.prefix('#foo'), 'foo');
+		assert.equal(history.prefix('/foo'), 'foo');
 	});
 
 	it('update path', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		history.set('/foo');
-		assert.equal(history.current, '/foo');
+		assert.equal(history.current, 'foo');
 		assert.equal(sandbox.contentWindow!.location.pathname, '/foo');
 	});
 
 	it('update path, does not update path if path is set to the current value', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		const beforeLength = sandbox.contentWindow!.history.length;
-		history.set('/bar');
-		history.set('/bar');
+		history.set('bar');
+		history.set('bar');
 		const afterLength = sandbox.contentWindow!.history.length;
 		assert.equal(afterLength - beforeLength, 1);
 	});
@@ -69,17 +66,17 @@ describe('StateHistory', () => {
 	it('update path, adds leading slash if necessary', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		history.set('foo');
-		assert.equal(history.current, '/foo');
+		assert.equal(history.current, 'foo');
 		assert.equal(sandbox.contentWindow!.location.pathname, '/foo');
 	});
 
 	it('emits change when path is updated', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		assert.deepEqual(onChange.firstCall.args, [
-			sandbox.contentWindow!.location.pathname + sandbox.contentWindow!.location.search
+			sandbox.contentWindow!.location.pathname.slice(1) + sandbox.contentWindow!.location.search
 		]);
 		history.set('/foo');
-		assert.deepEqual(onChange.secondCall.args, ['/foo']);
+		assert.deepEqual(onChange.secondCall.args, ['foo']);
 	});
 
 	it('does not emit change if path is set to the current value', () => {
@@ -91,9 +88,10 @@ describe('StateHistory', () => {
 
 	describe('with base', () => {
 		it('throws if base contains #', () => {
+			add('app-base', '/foo#bar', true);
 			assert.throws(
 				() => {
-					new StateHistory({ onChange, base: '/foo#bar', window });
+					new StateHistory({ onChange, window });
 				},
 				TypeError,
 				"base must not contain '#' or '?'"
@@ -101,9 +99,10 @@ describe('StateHistory', () => {
 		});
 
 		it('throws if base contains ?', () => {
+			add('app-base', '/foo?bar', true);
 			assert.throws(
 				() => {
-					new StateHistory({ onChange, base: '/foo?bar', window });
+					new StateHistory({ onChange, window });
 				},
 				TypeError,
 				"base must not contain '#' or '?'"
@@ -111,65 +110,69 @@ describe('StateHistory', () => {
 		});
 
 		it('initializes current path, taking out the base, with trailing slash', () => {
+			add('app-base', '/foo/', true);
 			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar?baz');
-			assert.equal(
-				new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! }).current,
-				'/bar?baz'
-			);
+			assert.equal(new StateHistory({ onChange, window: sandbox.contentWindow! }).current, 'bar?baz');
 		});
 
 		it('initializes current path, taking out the base, without trailing slash', () => {
+			add('app-base', '/foo/', true);
 			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar?baz');
-			assert.equal(
-				new StateHistory({ onChange, base: '/foo', window: sandbox.contentWindow! }).current,
-				'/bar?baz'
-			);
-		});
-
-		it("initializes current path to / if it's not a base suffix", () => {
-			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar?baz');
-			assert.equal(new StateHistory({ onChange, base: '/thud/', window: sandbox.contentWindow! }).current, '/');
-		});
-
-		it('#prefix prefixes path with the base (with trailing slash)', () => {
-			const history = new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
-			assert.equal(history.prefix('/bar'), '/foo/bar');
-			assert.equal(history.prefix('bar'), '/foo/bar');
-		});
-
-		it('#prefix prefixes path with the base (without trailing slash)', () => {
-			const history = new StateHistory({ onChange, base: '/foo', window: sandbox.contentWindow! });
-			assert.equal(history.prefix('/bar'), '/foo/bar');
-			assert.equal(history.prefix('bar'), '/foo/bar');
+			assert.equal(new StateHistory({ onChange, window: sandbox.contentWindow! }).current, 'bar?baz');
 		});
 
 		it('#set expands the path with the base when pushing state, with trailing slash', () => {
-			const history = new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
+			add('app-base', '/foo/', true);
+			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 			history.set('/foo/bar');
-			assert.equal(history.current, '/bar');
+			assert.equal(history.current, 'bar');
 			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/bar');
 
 			history.set('/foo/baz');
-			assert.equal(history.current, '/baz');
+			assert.equal(history.current, 'baz');
 			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/baz');
 		});
 
 		it('#set expands the path with the base when pushing state, without trailing slash', () => {
-			const history = new StateHistory({ onChange, base: '/foo', window: sandbox.contentWindow! });
-			history.set('/foo/bar');
-			assert.equal(history.current, '/bar');
+			add('app-base', '/foo/', true);
+			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+			history.set('bar');
+			assert.equal(history.current, 'bar');
 			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/bar');
 
-			history.set('/foo/baz');
-			assert.equal(history.current, '/baz');
+			history.set('baz');
+			assert.equal(history.current, 'baz');
 			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/baz');
 		});
 
-		it('Assumes base set in window __public_path__ variable if not explicitly set', () => {
-			add('public-path', 'base/path', true);
-			global.window.__public_path__ = 'base/path';
+		it('use app base for the base of the state history', () => {
+			add('app-base', '/foo/bar/', true);
+			sandbox.contentWindow!.history.pushState({}, '', '/');
 			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
-			assert.strictEqual(history.prefix('foo'), '/base/path/foo');
+			history.set('baz');
+			assert.strictEqual(sandbox.contentWindow!.location.pathname, '/foo/bar/baz');
+			assert.equal(history.current, 'baz');
+		});
+
+		it('add a prefix and suffix slash to base', () => {
+			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar/');
+			add('app-base', 'foo/bar', true);
+			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+			assert.strictEqual(sandbox.contentWindow!.location.pathname, '/foo/bar/');
+			history.set('baz');
+			assert.strictEqual(sandbox.contentWindow!.location.pathname, '/foo/bar/baz');
+			assert.equal(history.current, 'baz');
+		});
+
+		it('Warns in debug mode if the base option has been set on history options', () => {
+			add('dojo-debug', true, true);
+			new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
+			assert.isTrue(consoleWarnStub.calledOnce);
+		});
+
+		it('Does not warn when not in debug mode if the base option has been set on history options', () => {
+			new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
+			assert.isTrue(consoleWarnStub.notCalled);
 		});
 	});
 });

--- a/tests/routing/unit/history/StateHistory.ts
+++ b/tests/routing/unit/history/StateHistory.ts
@@ -37,7 +37,8 @@ describe('StateHistory', () => {
 	});
 
 	it('location defers to the global object', () => {
-		assert.equal(new StateHistory({ onChange }).current, window.location.pathname + window.location.search);
+		let location = window.location.pathname.slice(1);
+		assert.equal(new StateHistory({ onChange }).current, location + window.location.search);
 	});
 
 	it('prefixes sanatizes path removing / and # characters', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changes the `StateHistory` module to generate relative links, deprecates the `base` option as this is automatically detected by the `base` property in the `.dojorc` when using the dojo build pipeline.

Outside of the dojo build pipeline, the has flag `app-base` would need to be configured manually and base HTML element added to the index.html, e.g. `<base href="[the app base]" />.

Will warn when trying to use the `base` history option in development mode.
