### PR TITLE
Fix return type for getOrSet for a promise factory

### DIFF
--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -10,7 +10,7 @@ interface CacheWrapper<T = any> {
 
 export interface IcacheResult {
 	getOrSet: {
-		<T>(key: any, value: () => Promise<T>): undefined;
+		<T>(key: any, value: () => Promise<T>): undefined | T;
 		<T>(key: any, value: () => T): T;
 		<T>(key: any, value: T): T;
 	};


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fix the `getOrSet` typings for a `promise` factory to return `undefined | T`, with T being the return type of the promise or the generic passed to `getOrSet`.

**Before:**

```ts
/* Type: undefined */
icache.getOrSet<string>('test', () => Promise.resolve());
/* Type: undefined */
icache.getOrSet<string>('test', () => new Promise<string>(() => {}));
/* Type: undefined */
icache.getOrSet('test', () => new Promise<string>(() => {}));
```

**After:**

```ts
/* Type: string | undefined */
icache.getOrSet<string>('test', () => Promise.resolve());
/* Type: string | undefined */
icache.getOrSet<string>('test', () => new Promise<string>(() => {}));
/* Type: string | undefined */
icache.getOrSet('test', () => new Promise<string>(() => {}));
```
