### PR TITLE
Autodetecting custom element child type

### DIFF
--- a/src/core/decorators/customElement.ts
+++ b/src/core/decorators/customElement.ts
@@ -1,5 +1,4 @@
 import { WidgetProperties } from '../interfaces';
-import { CustomElementChildType } from '../registerCustomElement';
 import Registry from '../Registry';
 
 export type CustomElementPropertyNames<P extends object> = ((keyof P) | (keyof WidgetProperties))[];
@@ -27,8 +26,6 @@ export interface CustomElementConfig<P extends object = { [index: string]: any }
 	 * List of events to expose
 	 */
 	events?: CustomElementPropertyNames<P>;
-
-	childType?: CustomElementChildType;
 
 	registryFactory?: () => Registry;
 }

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -258,6 +258,30 @@ describe('registerCustomElement', () => {
 		assert.equal((child as any).myProp, 'can write prop to dom node');
 	});
 
+	it('custom element with child dom node and widget node', () => {
+		const BazA = createTestWidget({ childType: 'NODE' });
+		const CustomElementA = create((BazA as any).__customElementDescriptor, BazA);
+		customElements.define('baz-a', CustomElementA);
+		element = document.createElement('baz-a');
+
+		const BarB = createTestWidget({ attributes: ['myAttr'], properties: ['myProp'], events: ['onBar'] });
+		const CustomElementB = create((BarB as any).__customElementDescriptor, BarB);
+		customElements.define('bar-b', CustomElementB);
+		const barB = document.createElement('bar-b');
+
+		const div = document.createElement('div');
+		div.innerHTML = 'hello world';
+		element.appendChild(div);
+		element.appendChild(barB);
+		document.body.appendChild(element);
+		const children = element.querySelector('.children') as HTMLElement;
+		const child = children.firstChild as HTMLElement;
+		assert.equal(child.innerHTML, 'hello world');
+		assert.equal((child as any).myProp, 'can write prop to dom node');
+
+		console.error(element.innerHTML);
+	});
+
 	it('custom element with child text node', () => {
 		const QuxA = createTestWidget({ childType: 'DOJO' });
 		const CustomElementA = create((QuxA as any).__customElementDescriptor, QuxA);

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -261,13 +261,13 @@ describe('registerCustomElement', () => {
 	it('custom element with child dom node and widget node', () => {
 		const BazA = createTestWidget({ childType: 'NODE' });
 		const CustomElementA = create((BazA as any).__customElementDescriptor, BazA);
-		customElements.define('baz-a', CustomElementA);
-		element = document.createElement('baz-a');
+		customElements.define('cetest-a', CustomElementA);
+		element = document.createElement('cetest-a');
 
 		const BarB = createTestWidget({ attributes: ['myAttr'], properties: ['myProp'], events: ['onBar'] });
 		const CustomElementB = create((BarB as any).__customElementDescriptor, BarB);
-		customElements.define('bar-b', CustomElementB);
-		const barB = document.createElement('bar-b');
+		customElements.define('cetest-b', CustomElementB);
+		const barB = document.createElement('cetest-b');
 
 		const div = document.createElement('div');
 		div.innerHTML = 'hello world';

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -6,7 +6,7 @@ import WidgetBase from '../../../src/core/WidgetBase';
 import Container from '../../../src/core/Container';
 import Registry from '../../../src/core/Registry';
 import { v, w } from '../../../src/core/vdom';
-import register, { create, CustomElementChildType } from '../../../src/core/registerCustomElement';
+import register, { create } from '../../../src/core/registerCustomElement';
 import { createResolvers } from '../support/util';
 import { ThemedMixin, theme } from '../../../src/core/mixins/Themed';
 import { waitFor } from './waitFor';
@@ -42,8 +42,7 @@ class DisplayElementDefault extends WidgetBase {
 }
 
 @customElement({
-	tag: 'delayed-children-element',
-	childType: CustomElementChildType.TEXT
+	tag: 'delayed-children-element'
 })
 class DelayedChildrenWidget extends WidgetBase {
 	render() {
@@ -64,13 +63,12 @@ class DelayedChildrenWidget extends WidgetBase {
 }
 
 function createTestWidget(options: any) {
-	const { properties, attributes, events, childType = CustomElementChildType.DOJO } = options;
+	const { properties, attributes, events, childType = 'DOJO' } = options;
 	@customElement<any>({
 		tag: 'bar-element',
 		properties,
 		attributes,
-		events,
-		childType
+		events
 	})
 	@diffProperty('onExternalFunction', reference)
 	class Bar extends WidgetBase<any> {
@@ -84,7 +82,7 @@ function createTestWidget(options: any) {
 			let childProp = '';
 			if (this.children.length) {
 				const [child] = this.children;
-				if (childType === CustomElementChildType.DOJO) {
+				if (childType === 'DOJO') {
 					(child as any).properties.myAttr = 'set attribute from parent';
 					(child as any).properties.onBar = () => {
 						this._called = true;
@@ -93,7 +91,7 @@ function createTestWidget(options: any) {
 					if ((child as any).properties.myProp) {
 						childProp = (child as any).properties.myProp;
 					}
-				} else if (childType === CustomElementChildType.NODE) {
+				} else if (childType === 'NODE') {
 					childProp = (child as any).properties.myProp = 'can write prop to dom node';
 				}
 			}
@@ -246,7 +244,7 @@ describe('registerCustomElement', () => {
 	});
 
 	it('custom element with child dom node', () => {
-		const BazA = createTestWidget({ childType: CustomElementChildType.NODE });
+		const BazA = createTestWidget({ childType: 'NODE' });
 		const CustomElementA = create((BazA as any).__customElementDescriptor, BazA);
 		customElements.define('baz-a', CustomElementA);
 		element = document.createElement('baz-a');
@@ -261,7 +259,7 @@ describe('registerCustomElement', () => {
 	});
 
 	it('custom element with child text node', () => {
-		const QuxA = createTestWidget({ childType: CustomElementChildType.TEXT });
+		const QuxA = createTestWidget({ childType: 'DOJO' });
 		const CustomElementA = create((QuxA as any).__customElementDescriptor, QuxA);
 		customElements.define('qux-a', CustomElementA);
 		element = document.createElement('qux-a');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Getting rid of `childType` for custom elements and detecting it automatically. Previously, a user would have to manually specify the childType (NODE, TEXT, or DOJO) that a custom element would contain. Now, if there are any widget nodes, the child list includes DOM nodes and dojo widgets, but not text nodes. If there are no widget nodes, the child list includes text nodes and DOM nodes.

**Note: This is a breaking change from the current behavior!**

Resolves #304 
