### PR TITLE
Fixing focus

### DIFF
--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -39,7 +39,10 @@ export function DomToWidgetWrapper(domNode: HTMLElement): any {
 }
 
 const propertyMap: any = {
-	focus: 'hasFocus'
+	focus: 'doFocus',
+	blur: 'doBlur',
+	scrollIntoView: 'doScrollIntoView',
+	click: 'doClick'
 };
 
 export function create(descriptor: any, WidgetConstructor: any): any {

--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -38,6 +38,10 @@ export function DomToWidgetWrapper(domNode: HTMLElement): any {
 	return DomToWidgetWrapper;
 }
 
+const propertyMap: any = {
+	focus: 'hasFocus'
+};
+
 export function create(descriptor: any, WidgetConstructor: any): any {
 	const {
 		attributes = [],
@@ -47,8 +51,9 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 	const attributeMap: any = {};
 
 	attributes.forEach((propertyName: string) => {
-		const attributeName = propertyName.toLowerCase();
-		attributeMap[attributeName] = propertyName;
+		const mappedPropertyName = propertyMap[propertyName] || propertyName;
+		const attributeName = mappedPropertyName.toLowerCase();
+		attributeMap[attributeName] = mappedPropertyName;
 	});
 
 	return class extends HTMLElement {
@@ -101,20 +106,21 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 			this._properties = { ...this._properties, ...this._attributesToProperties(attributes) };
 
 			[...attributes, ...properties].forEach((propertyName: string) => {
-				const value = (this as any)[propertyName];
-				const filteredPropertyName = propertyName.replace(/^on/, '__');
+				const mappedPropertyName = propertyMap[propertyName] || propertyName;
+				const value = (this as any)[mappedPropertyName];
+				const filteredPropertyName = mappedPropertyName.replace(/^on/, '__');
 				if (value !== undefined) {
 					this._properties[propertyName] = value;
 				}
 
 				if (filteredPropertyName !== propertyName) {
 					domProperties[filteredPropertyName] = {
-						get: () => this._getProperty(propertyName),
-						set: (value: any) => this._setProperty(propertyName, value)
+						get: () => this._getProperty(mappedPropertyName),
+						set: (value: any) => this._setProperty(mappedPropertyName, value)
 					};
 				}
 
-				domProperties[propertyName] = {
+				domProperties[mappedPropertyName] = {
 					get: () => this._getProperty(propertyName),
 					set: (value: any) => this._setProperty(propertyName, value)
 				};

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -107,7 +107,8 @@ function createTestWidget(options: any) {
 				v('div', { classes: ['attr'] }, [`${myAttr}`]),
 				v('div', { classes: ['handler'] }, [`${this._called}`]),
 				v('div', { classes: ['childProp'] }, [`${childProp}`]),
-				v('div', { classes: ['children'] }, this.children)
+				v('div', { classes: ['children'] }, this.children),
+				v('div', { classes: ['focus'] }, [this.properties.hasFocus ? 'yes' : 'no'])
 			]);
 		}
 	}
@@ -431,5 +432,18 @@ describe('registerCustomElement', () => {
 				}
 			});
 		});
+	});
+
+	it('uses the property map to create change the name of the focus property', () => {
+		const BarA = createTestWidget({ attributes: ['focus'] });
+		const CustomElement = create((BarA as any).__customElementDescriptor, BarA);
+
+		customElements.define('ce-test-focus', CustomElement);
+		element = document.createElement('ce-test-focus');
+		document.body.appendChild(element);
+
+		element.setAttribute('hasfocus', 'true');
+		resolvers.resolve();
+		assert.equal(element.getElementsByClassName('focus')[0].innerHTML, 'yes');
 	});
 });

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -108,7 +108,7 @@ function createTestWidget(options: any) {
 				v('div', { classes: ['handler'] }, [`${this._called}`]),
 				v('div', { classes: ['childProp'] }, [`${childProp}`]),
 				v('div', { classes: ['children'] }, this.children),
-				v('div', { classes: ['focus'] }, [this.properties.hasFocus ? 'yes' : 'no'])
+				v('div', { classes: ['focus'] }, [this.properties.doFocus ? 'yes' : 'no'])
 			]);
 		}
 	}
@@ -442,7 +442,7 @@ describe('registerCustomElement', () => {
 		element = document.createElement('ce-test-focus');
 		document.body.appendChild(element);
 
-		element.setAttribute('hasfocus', 'true');
+		element.setAttribute('dofocus', 'true');
 		resolvers.resolve();
 		assert.equal(element.getElementsByClassName('focus')[0].innerHTML, 'yes');
 	});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

You currently cannot have an attribute named `focus` as this conflicts with the existing `focus` function. To solve this, we map special names like this (currently _just_ `focus`) into new names, `hasfocus` that will come through in the properties in their place.
