### PR TITLE
Infer target type for vnode event handlers

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -37,6 +37,37 @@ export interface MouseEventHandler {
 	(event?: MouseEvent): EventHandlerResult;
 }
 
+/**
+* Cannot extend the global due to TS error: `All declarations of 'target' must have identical modifiers.`
+*/
+export interface DojoEvent<T extends EventTarget = EventTarget> extends Event {
+	target: T;
+}
+
+declare global {
+	interface MouseEvent<T extends EventTarget = EventTarget> {
+		target: T;
+	}
+	interface PointerEvent<T extends EventTarget = EventTarget> {
+		target: T;
+	}
+	interface TouchEvent<T extends EventTarget = EventTarget> {
+		target: T;
+	}
+	interface KeyboardEvent<T extends EventTarget = EventTarget> {
+		target: T;
+	}
+	interface FocusEvent<T extends EventTarget = EventTarget> {
+		target: T;
+	}
+	interface UIEvent<T extends EventTarget = EventTarget> {
+		target: T;
+	}
+	interface WheelEvent<T extends EventTarget = EventTarget> {
+		target: T;
+	}
+}
+
 export type BlurEventHandler = FocusEventHandler;
 export type ChangeEventHandler = EventHandler;
 export type ClickEventHandler = MouseEventHandler;
@@ -108,7 +139,7 @@ export interface VDomOptions {
 	on?: On;
 }
 
-export interface VNodeProperties {
+export interface VNodeProperties<T extends EventTarget = EventTarget> {
 	enterAnimation?: SupportedClassName;
 
 	exitAnimation?: SupportedClassName;
@@ -133,21 +164,21 @@ export interface VNodeProperties {
 	readonly styles?: Partial<CSSStyleDeclaration>;
 
 	// Pointer Events
-	onpointermove?(ev?: PointerEvent): boolean | void;
-	onpointerdown?(ev?: PointerEvent): boolean | void;
-	onpointerup?(ev?: PointerEvent): boolean | void;
-	onpointerover?(ev?: PointerEvent): boolean | void;
-	onpointerout?(ev?: PointerEvent): boolean | void;
-	onpointerenter?(ev?: PointerEvent): boolean | void;
-	onpointerleave?(ev?: PointerEvent): boolean | void;
-	onpointercancel?(ev?: PointerEvent): boolean | void;
+	onpointermove?(ev: PointerEvent<T>): boolean | void;
+	onpointerdown?(ev: PointerEvent<T>): boolean | void;
+	onpointerup?(ev: PointerEvent<T>): boolean | void;
+	onpointerover?(ev: PointerEvent<T>): boolean | void;
+	onpointerout?(ev: PointerEvent<T>): boolean | void;
+	onpointerenter?(ev: PointerEvent<T>): boolean | void;
+	onpointerleave?(ev: PointerEvent<T>): boolean | void;
+	onpointercancel?(ev: PointerEvent<T>): boolean | void;
 	// For Pointer Event Polyfill see: https://github.com/jquery/PEP
 	readonly 'touch-action'?: string;
 	// From Element
-	ontouchcancel?(ev?: TouchEvent): boolean | void;
-	ontouchend?(ev?: TouchEvent): boolean | void;
-	ontouchmove?(ev?: TouchEvent): boolean | void;
-	ontouchstart?(ev?: TouchEvent): boolean | void;
+	ontouchcancel?(ev: TouchEvent<T>): boolean | void;
+	ontouchend?(ev: TouchEvent<T>): boolean | void;
+	ontouchmove?(ev: TouchEvent<T>): boolean | void;
+	ontouchstart?(ev: TouchEvent<T>): boolean | void;
 	// From HTMLFormElement
 	readonly action?: string;
 	readonly encoding?: string;
@@ -156,26 +187,26 @@ export interface VNodeProperties {
 	readonly name?: string;
 	readonly target?: string;
 	// From HTMLElement
-	onblur?(ev?: FocusEvent): boolean | void;
-	onchange?(ev?: Event): boolean | void;
-	onclick?(ev?: MouseEvent): boolean | void;
-	ondblclick?(ev?: MouseEvent): boolean | void;
-	onfocus?(ev?: FocusEvent): boolean | void;
-	oninput?(ev?: Event): boolean | void;
-	onkeydown?(ev?: KeyboardEvent): boolean | void;
-	onkeypress?(ev?: KeyboardEvent): boolean | void;
-	onkeyup?(ev?: KeyboardEvent): boolean | void;
-	onload?(ev?: Event): boolean | void;
-	onmousedown?(ev?: MouseEvent): boolean | void;
-	onmouseenter?(ev?: MouseEvent): boolean | void;
-	onmouseleave?(ev?: MouseEvent): boolean | void;
-	onmousemove?(ev?: MouseEvent): boolean | void;
-	onmouseout?(ev?: MouseEvent): boolean | void;
-	onmouseover?(ev?: MouseEvent): boolean | void;
-	onmouseup?(ev?: MouseEvent): boolean | void;
-	onmousewheel?(ev?: WheelEvent | MouseWheelEvent): boolean | void;
-	onscroll?(ev?: UIEvent): boolean | void;
-	onsubmit?(ev?: Event): boolean | void;
+	onblur?(ev: FocusEvent<T>): boolean | void;
+	onchange?(ev: DojoEvent<T>): boolean | void;
+	onclick?(ev: MouseEvent<T>): boolean | void;
+	ondblclick?(ev: MouseEvent<T>): boolean | void;
+	onfocus?(ev: FocusEvent<T>): boolean | void;
+	oninput?(ev: DojoEvent<T>): boolean | void;
+	onkeydown?(ev: KeyboardEvent<T>): boolean | void;
+	onkeypress?(ev: KeyboardEvent<T>): boolean | void;
+	onkeyup?(ev: KeyboardEvent<T>): boolean | void;
+	onload?(ev: DojoEvent<T>): boolean | void;
+	onmousedown?(ev: MouseEvent<T>): boolean | void;
+	onmouseenter?(ev: MouseEvent<T>): boolean | void;
+	onmouseleave?(ev: MouseEvent<T>): boolean | void;
+	onmousemove?(ev: MouseEvent<T>): boolean | void;
+	onmouseout?(ev: MouseEvent<T>): boolean | void;
+	onmouseover?(ev: MouseEvent<T>): boolean | void;
+	onmouseup?(ev: MouseEvent<T>): boolean | void;
+	onmousewheel?(ev: WheelEvent<T>): boolean | void;
+	onscroll?(ev: UIEvent<T>): boolean | void;
+	onsubmit?(ev: DojoEvent<T>): boolean | void;
 	readonly spellcheck?: boolean;
 	readonly tabIndex?: number;
 	readonly disabled?: boolean;
@@ -347,7 +378,7 @@ export type LazyDefine<W extends WidgetBaseTypes = DefaultWidgetBaseInterface> =
 
 export interface MiddlewareMap<
 	Middleware extends () => { api: {}; properties: {} } = () => { api: {}; properties: {} }
-> {
+	> {
 	[index: string]: Middleware;
 }
 
@@ -436,7 +467,7 @@ export type WidgetBaseConstructor<P extends WidgetProperties = WidgetProperties,
 	WidgetBaseInterface<P, C>
 >;
 
-export interface DefaultWidgetBaseInterface extends WidgetBaseInterface<WidgetProperties, DNode> {}
+export interface DefaultWidgetBaseInterface extends WidgetBaseInterface<WidgetProperties, DNode> { }
 
 export interface WidgetBaseTypes<P = any, C extends DNode = DNode> {
 	/**
@@ -478,7 +509,7 @@ export interface WidgetBaseInterface<P = WidgetProperties, C extends DNode = DNo
 /**
  * Meta Base type
  */
-export interface MetaBase extends Destroyable {}
+export interface MetaBase extends Destroyable { }
 
 /**
  * Meta Base type
@@ -492,7 +523,7 @@ export interface WidgetMetaBase extends MetaBase {
  * Meta Base constructor type
  */
 export interface WidgetMetaConstructor<T extends MetaBase> {
-	new (properties: WidgetMetaProperties): T;
+	new(properties: WidgetMetaProperties): T;
 }
 
 export interface NodeHandlerInterface extends Evented {

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -38,8 +38,8 @@ export interface MouseEventHandler {
 }
 
 /**
-* Cannot extend the global due to TS error: `All declarations of 'target' must have identical modifiers.`
-*/
+ * Cannot extend the global due to TS error: `All declarations of 'target' must have identical modifiers.`
+ */
 export interface DojoEvent<T extends EventTarget = EventTarget> extends Event {
 	target: T;
 }
@@ -378,7 +378,7 @@ export type LazyDefine<W extends WidgetBaseTypes = DefaultWidgetBaseInterface> =
 
 export interface MiddlewareMap<
 	Middleware extends () => { api: {}; properties: {} } = () => { api: {}; properties: {} }
-	> {
+> {
 	[index: string]: Middleware;
 }
 
@@ -467,7 +467,7 @@ export type WidgetBaseConstructor<P extends WidgetProperties = WidgetProperties,
 	WidgetBaseInterface<P, C>
 >;
 
-export interface DefaultWidgetBaseInterface extends WidgetBaseInterface<WidgetProperties, DNode> { }
+export interface DefaultWidgetBaseInterface extends WidgetBaseInterface<WidgetProperties, DNode> {}
 
 export interface WidgetBaseTypes<P = any, C extends DNode = DNode> {
 	/**
@@ -509,7 +509,7 @@ export interface WidgetBaseInterface<P = WidgetProperties, C extends DNode = DNo
 /**
  * Meta Base type
  */
-export interface MetaBase extends Destroyable { }
+export interface MetaBase extends Destroyable {}
 
 /**
  * Meta Base type
@@ -523,7 +523,7 @@ export interface WidgetMetaBase extends MetaBase {
  * Meta Base constructor type
  */
 export interface WidgetMetaConstructor<T extends MetaBase> {
-	new(properties: WidgetMetaProperties): T;
+	new (properties: WidgetMetaProperties): T;
 }
 
 export interface NodeHandlerInterface extends Evented {

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -347,6 +347,7 @@ export function w<W extends WidgetBaseTypes>(
 export function v(node: VNode, properties: VNodeProperties, children: undefined | DNode[]): VNode;
 export function v(node: VNode, properties: VNodeProperties): VNode;
 export function v(tag: string, children: undefined | DNode[]): VNode;
+export function v<K extends keyof HTMLElementTagNameMap>(tag: K, properties: DeferredVirtualProperties | VNodeProperties<HTMLElementTagNameMap[K]>, children?: DNode[]): VNode;
 export function v(tag: string, properties: DeferredVirtualProperties | VNodeProperties, children?: DNode[]): VNode;
 export function v(tag: string): VNode;
 export function v(

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -347,7 +347,11 @@ export function w<W extends WidgetBaseTypes>(
 export function v(node: VNode, properties: VNodeProperties, children: undefined | DNode[]): VNode;
 export function v(node: VNode, properties: VNodeProperties): VNode;
 export function v(tag: string, children: undefined | DNode[]): VNode;
-export function v<K extends keyof HTMLElementTagNameMap>(tag: K, properties: DeferredVirtualProperties | VNodeProperties<HTMLElementTagNameMap[K]>, children?: DNode[]): VNode;
+export function v<K extends keyof HTMLElementTagNameMap>(
+	tag: K,
+	properties: DeferredVirtualProperties | VNodeProperties<HTMLElementTagNameMap[K]>,
+	children?: DNode[]
+): VNode;
 export function v(tag: string, properties: DeferredVirtualProperties | VNodeProperties, children?: DNode[]): VNode;
 export function v(tag: string): VNode;
 export function v(

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -4365,6 +4365,9 @@ jsdomDescribe('vdom', () => {
 					value: typedKeys,
 					oninput: (evt) => {
 						typedKeys = evt.target.value;
+					},
+					onclick: (evt) => {
+						typedKeys = evt.target.value;
 					}
 				});
 

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -4360,9 +4360,13 @@ jsdomDescribe('vdom', () => {
 		it('does not clear a value that was set by a testing tool which manipulates input.value directly', () => {
 			let typedKeys = '';
 
-			const renderFunction = () => v('input', { value: typedKeys, oninput: (evt) => {
-				typedKeys = evt.target.value;
-			} });
+			const renderFunction = () =>
+				v('input', {
+					value: typedKeys,
+					oninput: (evt) => {
+						typedKeys = evt.target.value;
+					}
+				});
 
 			const [Widget, meta] = getWidget(renderFunction());
 			const r = renderer(() => w(Widget, {}));

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -4359,11 +4359,10 @@ jsdomDescribe('vdom', () => {
 
 		it('does not clear a value that was set by a testing tool which manipulates input.value directly', () => {
 			let typedKeys = '';
-			const handleInput = (evt: Event) => {
-				typedKeys = (evt.target as HTMLInputElement).value;
-			};
 
-			const renderFunction = () => v('input', { value: typedKeys, oninput: handleInput });
+			const renderFunction = () => v('input', { value: typedKeys, oninput: (evt) => {
+				typedKeys = evt.target.value;
+			} });
 
 			const [Widget, meta] = getWidget(renderFunction());
 			const r = renderer(() => w(Widget, {}));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support to `v()` so that the `target` on the `event` argument of event handers, such as `onclick` etc are correct typed to the appropriate DOM element type based on the tag.

Resolves #496 
