### PR TITLE
Deal with reserved property names

### DIFF
--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -95,7 +95,8 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 
 			[...attributes, ...properties].forEach((propertyName: string) => {
 				const isReservedProp = RESERVED_PROPS.indexOf(propertyName) !== -1;
-				const value = this._propertiesMap[propertyName] || !isReservedProp ? (this as any)[propertyName] : undefined;
+				const value =
+					this._propertiesMap[propertyName] || !isReservedProp ? (this as any)[propertyName] : undefined;
 				let filteredPropertyName = propertyName.replace(/^on/, '__');
 				if (isReservedProp) {
 					filteredPropertyName = `__${propertyName}`;

--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -6,6 +6,8 @@ import global from '../shim/global';
 import { registerThemeInjector } from './mixins/Themed';
 import { alwaysRender } from './decorators/alwaysRender';
 
+const RESERVED_PROPS = ['focus'];
+
 export function DomToWidgetWrapper(domNode: HTMLElement): any {
 	@alwaysRender()
 	class DomToWidgetWrapper extends WidgetBase<any> {
@@ -13,7 +15,7 @@ export function DomToWidgetWrapper(domNode: HTMLElement): any {
 			const properties = Object.keys(this.properties).reduce(
 				(props, key: string) => {
 					const value = this.properties[key];
-					if (key.indexOf('on') === 0) {
+					if (key.indexOf('on') === 0 || RESERVED_PROPS.indexOf(key) !== -1) {
 						key = `__${key}`;
 					}
 					props[key] = value;
@@ -46,6 +48,7 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 		private _properties: any = {};
 		private _children: any[] = [];
 		private _eventProperties: any = {};
+		private _propertiesMap: any = {};
 		private _initialised = false;
 
 		public connectedCallback() {
@@ -91,8 +94,12 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 			this._properties = { ...this._properties, ...this._attributesToProperties(attributes) };
 
 			[...attributes, ...properties].forEach((propertyName: string) => {
-				const value = (this as any)[propertyName];
-				const filteredPropertyName = propertyName.replace(/^on/, '__');
+				const isReservedProp = RESERVED_PROPS.indexOf(propertyName) !== -1;
+				const value = this._propertiesMap[propertyName] || !isReservedProp ? (this as any)[propertyName] : undefined;
+				let filteredPropertyName = propertyName.replace(/^on/, '__');
+				if (isReservedProp) {
+					filteredPropertyName = `__${propertyName}`;
+				}
 				if (value !== undefined) {
 					this._properties[propertyName] = value;
 				}
@@ -104,10 +111,12 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 					};
 				}
 
-				domProperties[propertyName] = {
-					get: () => this._getProperty(propertyName),
-					set: (value: any) => this._setProperty(propertyName, value)
-				};
+				if (!isReservedProp) {
+					domProperties[propertyName] = {
+						get: () => this._getProperty(propertyName),
+						set: (value: any) => this._setProperty(propertyName, value)
+					};
+				}
 			});
 
 			events.forEach((propertyName: string) => {
@@ -261,6 +270,13 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 
 		public get isWidget() {
 			return true;
+		}
+
+		public set(key: string, value: any) {
+			this._propertiesMap[key] = value;
+			if (this._renderer) {
+				this._setProperty(key, value);
+			}
 		}
 	};
 }

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -158,7 +158,6 @@ describe('registerCustomElement', () => {
 	it('custom element', () => {
 		register(Foo);
 		element = document.createElement('foo-element');
-		(element as any).set();
 		document.body.appendChild(element);
 		assert.equal(element.outerHTML, '<foo-element style="display: block;"><div>hello world</div></foo-element>');
 	});

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -463,7 +463,7 @@ describe('registerCustomElement', () => {
 		class WidgetA extends WidgetBase<any> {
 			render() {
 				console.log('A', this.properties, this.children);
-				return v('div', {}, [ this.properties.focus, ...this.children ]);
+				return v('div', {}, [this.properties.focus, ...this.children]);
 			}
 		}
 		@customElement({
@@ -490,11 +490,17 @@ describe('registerCustomElement', () => {
 		resolvers.resolve();
 		(childElement as any).set('focus', 'child focus property');
 		resolvers.resolve();
-		assert.strictEqual('<ce-test-focus style="display: block;"><div>parent focus property<ce-test-focus-child style="display: block;"><div>child focus property</div></ce-test-focus-child></div></ce-test-focus>', element.outerHTML);
+		assert.strictEqual(
+			'<ce-test-focus style="display: block;"><div>parent focus property<ce-test-focus-child style="display: block;"><div>child focus property</div></ce-test-focus-child></div></ce-test-focus>',
+			element.outerHTML
+		);
 		(childElement as any).set('focus', 'second child focus property');
 		console.log(element.outerHTML);
 		resolvers.resolve();
-		assert.strictEqual('<ce-test-focus style="display: block;"><div>parent focus property<ce-test-focus-child style="display: block;"><div>second child focus property</div></ce-test-focus-child></div></ce-test-focus>', element.outerHTML);
+		assert.strictEqual(
+			'<ce-test-focus style="display: block;"><div>parent focus property<ce-test-focus-child style="display: block;"><div>second child focus property</div></ce-test-focus-child></div></ce-test-focus>',
+			element.outerHTML
+		);
 		console.log(element.outerHTML);
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Currently there is no way to deal with "reserved" property names when working with custom elements. This change introduces a new API `.set(key, value)` for reserved properties.

Currently only `focus` is included in as a reserved property that can be expanded on in the future.

Resolves #498 
