### PR TITLE
Auto detect custom element child type

### DIFF
--- a/src/core/decorators/customElement.ts
+++ b/src/core/decorators/customElement.ts
@@ -1,4 +1,5 @@
 import { WidgetProperties } from '../interfaces';
+import { CustomElementChildType } from '../registerCustomElement';
 import Registry from '../Registry';
 
 export type CustomElementPropertyNames<P extends object> = ((keyof P) | (keyof WidgetProperties))[];
@@ -26,6 +27,8 @@ export interface CustomElementConfig<P extends object = { [index: string]: any }
 	 * List of events to expose
 	 */
 	events?: CustomElementPropertyNames<P>;
+
+	childType?: CustomElementChildType;
 
 	registryFactory?: () => Registry;
 }

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -225,7 +225,7 @@ const WNODE = '__WNODE_TYPE';
 const VNODE = '__VNODE_TYPE';
 const DOMVNODE = '__DOMVNODE_TYPE';
 
-function isTextNode(item: any): item is Text {
+export function isTextNode(item: any): item is Text {
 	return item && item.nodeType === 3;
 }
 

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -6,7 +6,7 @@ import WidgetBase from '../../../src/core/WidgetBase';
 import Container from '../../../src/core/Container';
 import Registry from '../../../src/core/Registry';
 import { v, w } from '../../../src/core/vdom';
-import register, { create } from '../../../src/core/registerCustomElement';
+import register, { create, CustomElementChildType } from '../../../src/core/registerCustomElement';
 import { createResolvers } from '../support/util';
 import { ThemedMixin, theme } from '../../../src/core/mixins/Themed';
 import { waitFor } from './waitFor';
@@ -42,7 +42,8 @@ class DisplayElementDefault extends WidgetBase {
 }
 
 @customElement({
-	tag: 'delayed-children-element'
+	tag: 'delayed-children-element',
+	childType: CustomElementChildType.TEXT
 })
 class DelayedChildrenWidget extends WidgetBase {
 	render() {
@@ -63,12 +64,13 @@ class DelayedChildrenWidget extends WidgetBase {
 }
 
 function createTestWidget(options: any) {
-	const { properties, attributes, events, childType = 'DOJO' } = options;
+	const { properties, attributes, events, childType = CustomElementChildType.DOJO } = options;
 	@customElement<any>({
 		tag: 'bar-element',
 		properties,
 		attributes,
-		events
+		events,
+		childType
 	})
 	@diffProperty('onExternalFunction', reference)
 	class Bar extends WidgetBase<any> {
@@ -82,7 +84,7 @@ function createTestWidget(options: any) {
 			let childProp = '';
 			if (this.children.length) {
 				const [child] = this.children;
-				if (childType === 'DOJO') {
+				if (childType === CustomElementChildType.DOJO) {
 					(child as any).properties.myAttr = 'set attribute from parent';
 					(child as any).properties.onBar = () => {
 						this._called = true;
@@ -91,7 +93,7 @@ function createTestWidget(options: any) {
 					if ((child as any).properties.myProp) {
 						childProp = (child as any).properties.myProp;
 					}
-				} else if (childType === 'NODE') {
+				} else if (childType === CustomElementChildType.NODE) {
 					childProp = (child as any).properties.myProp = 'can write prop to dom node';
 				}
 			}
@@ -244,7 +246,7 @@ describe('registerCustomElement', () => {
 	});
 
 	it('custom element with child dom node', () => {
-		const BazA = createTestWidget({ childType: 'NODE' });
+		const BazA = createTestWidget({ childType: CustomElementChildType.NODE });
 		const CustomElementA = create((BazA as any).__customElementDescriptor, BazA);
 		customElements.define('baz-a', CustomElementA);
 		element = document.createElement('baz-a');
@@ -258,30 +260,8 @@ describe('registerCustomElement', () => {
 		assert.equal((child as any).myProp, 'can write prop to dom node');
 	});
 
-	it('custom element with child dom node and widget node', () => {
-		const BazA = createTestWidget({ childType: 'NODE' });
-		const CustomElementA = create((BazA as any).__customElementDescriptor, BazA);
-		customElements.define('cetest-a', CustomElementA);
-		element = document.createElement('cetest-a');
-
-		const BarB = createTestWidget({ attributes: ['myAttr'], properties: ['myProp'], events: ['onBar'] });
-		const CustomElementB = create((BarB as any).__customElementDescriptor, BarB);
-		customElements.define('cetest-b', CustomElementB);
-		const barB = document.createElement('cetest-b');
-
-		const div = document.createElement('div');
-		div.innerHTML = 'hello world';
-		element.appendChild(div);
-		element.appendChild(barB);
-		document.body.appendChild(element);
-		const children = element.querySelector('.children') as HTMLElement;
-		const child = children.firstChild as HTMLElement;
-		assert.equal(child.innerHTML, 'hello world');
-		assert.equal((child as any).myProp, 'can write prop to dom node');
-	});
-
 	it('custom element with child text node', () => {
-		const QuxA = createTestWidget({ childType: 'DOJO' });
+		const QuxA = createTestWidget({ childType: CustomElementChildType.TEXT });
 		const CustomElementA = create((QuxA as any).__customElementDescriptor, QuxA);
 		customElements.define('qux-a', CustomElementA);
 		element = document.createElement('qux-a');

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -64,13 +64,13 @@ class DelayedChildrenWidget extends WidgetBase {
 }
 
 function createTestWidget(options: any) {
-	const { properties, attributes, events, childType = CustomElementChildType.DOJO } = options;
+	const { properties, attributes, events, childType = CustomElementChildType.DOJO, auto = false } = options;
 	@customElement<any>({
 		tag: 'bar-element',
 		properties,
 		attributes,
 		events,
-		childType
+		childType: auto ? undefined : childType
 	})
 	@diffProperty('onExternalFunction', reference)
 	class Bar extends WidgetBase<any> {
@@ -128,7 +128,7 @@ describe('registerCustomElement', () => {
 
 	before((suite) => {
 		try {
-			const Test = createTestWidget({});
+			const Test = createTestWidget({ childType: CustomElementChildType.DOJO });
 			const CustomElement = create((Test as any).__customElementDescriptor, Test);
 			customElements.define('supports-custom-elements', CustomElement);
 			document.createElement('supports-custom-elements');
@@ -165,7 +165,7 @@ describe('registerCustomElement', () => {
 	});
 
 	it('custom element with property', () => {
-		const Bar = createTestWidget({ properties: ['myProp'] });
+		const Bar = createTestWidget({ properties: ['myProp'], childType: CustomElementChildType.DOJO });
 		const CustomElement = create((Bar as any).__customElementDescriptor, Bar);
 		customElements.define('bar-element-1', CustomElement);
 		element = document.createElement('bar-element-1');
@@ -176,7 +176,7 @@ describe('registerCustomElement', () => {
 	});
 
 	it('custom element with attribute', () => {
-		const Bar = createTestWidget({ attributes: ['myAttr'] });
+		const Bar = createTestWidget({ attributes: ['myAttr'], childType: CustomElementChildType.DOJO });
 		const CustomElement = create((Bar as any).__customElementDescriptor, Bar);
 		customElements.define('bar-element-2', CustomElement);
 		element = document.createElement('bar-element-2');
@@ -188,7 +188,7 @@ describe('registerCustomElement', () => {
 
 	it('custom element with event', () => {
 		let called = false;
-		const Bar = createTestWidget({ events: ['onBar'] });
+		const Bar = createTestWidget({ events: ['onBar'], childType: CustomElementChildType.DOJO });
 		const CustomElement = create((Bar as any).__customElementDescriptor, Bar);
 		customElements.define('bar-element-3', CustomElement);
 		element = document.createElement('bar-element-3');
@@ -202,10 +202,15 @@ describe('registerCustomElement', () => {
 	});
 
 	it('custom element with child dojo element', () => {
-		const BarA = createTestWidget({});
+		const BarA = createTestWidget({ childType: CustomElementChildType.DOJO, auto: true });
 		const CustomElementA = create((BarA as any).__customElementDescriptor, BarA);
 		customElements.define('bar-a', CustomElementA);
-		const BarB = createTestWidget({ attributes: ['myAttr'], properties: ['myProp'], events: ['onBar'] });
+		const BarB = createTestWidget({
+			attributes: ['myAttr'],
+			properties: ['myProp'],
+			events: ['onBar'],
+			childType: CustomElementChildType.DOJO
+		});
 		const CustomElementB = create((BarB as any).__customElementDescriptor, BarB);
 		customElements.define('bar-b', CustomElementB);
 		element = document.createElement('bar-a');
@@ -265,6 +270,85 @@ describe('registerCustomElement', () => {
 		const CustomElementA = create((QuxA as any).__customElementDescriptor, QuxA);
 		customElements.define('qux-a', CustomElementA);
 		element = document.createElement('qux-a');
+		const textNode = document.createTextNode('text node');
+		element.appendChild(textNode);
+		document.body.appendChild(element);
+		const children = element.querySelector('.children') as HTMLElement;
+		const child = children.firstChild as HTMLElement;
+		assert.equal(child.nodeType, Node.TEXT_NODE);
+		assert.equal(child.textContent, 'text node');
+	});
+
+	it('custom element with auto detection of child dojo element', () => {
+		const BarA = createTestWidget({ auto: true });
+		const CustomElementA = create((BarA as any).__customElementDescriptor, BarA);
+		customElements.define('auto-bar-a', CustomElementA);
+		const BarB = createTestWidget({
+			attributes: ['myAttr'],
+			properties: ['myProp'],
+			events: ['onBar'],
+			childType: CustomElementChildType.DOJO,
+			auto: true 
+		});
+		const CustomElementB = create((BarB as any).__customElementDescriptor, BarB);
+		customElements.define('auto-bar-b', CustomElementB);
+		element = document.createElement('auto-bar-a');
+		const barB = document.createElement('auto-bar-b');
+		let childRenderCounter = 0;
+		element.addEventListener('dojo-ce-render', () => {
+			childRenderCounter++;
+		});
+		element.appendChild(barB);
+		document.body.appendChild(element);
+		(barB as any).set('myProp', 'set property on child');
+		resolvers.resolve();
+
+		assert.strictEqual(3, childRenderCounter);
+
+		const container = element.querySelector('.children');
+		const children = (container as any).children;
+		let called = false;
+		children[0].addEventListener('bar', () => {
+			called = true;
+		});
+		const event = children[0].querySelector('.event') as HTMLElement;
+		event.click();
+
+		const childProp = element.querySelector('.childProp') as HTMLElement;
+
+		assert.equal(children[0].tagName, 'AUTO-BAR-B');
+		const attr = children[0].querySelector('.attr');
+		const prop = children[0].querySelector('.prop');
+		assert.equal(attr.innerHTML, 'set attribute from parent');
+		assert.equal(prop.innerHTML, 'set property on child');
+		assert.equal(childProp.innerHTML, 'set property on child');
+		assert.isTrue(called);
+
+		resolvers.resolve();
+		const handler = element.querySelector('.handler') as HTMLElement;
+		assert.equal(handler.innerHTML, 'true');
+	});
+
+	it('custom element with auto detected node child type', () => {
+		const BazA = createTestWidget({ auto: true, childType: CustomElementChildType.NODE });
+		const CustomElementA = create((BazA as any).__customElementDescriptor, BazA);
+		customElements.define('auto-baz-a', CustomElementA);
+		element = document.createElement('auto-baz-a');
+		const div = document.createElement('div');
+		div.innerHTML = 'hello world';
+		element.appendChild(div);
+		document.body.appendChild(element);
+		const children = element.querySelector('.children') as HTMLElement;
+		const child = children.firstChild as HTMLElement;
+		assert.equal(child.innerHTML, 'hello world');
+		assert.equal((child as any).myProp, 'can write prop to dom node');
+	});
+
+	it('custom element with auto detected text child type', () => {
+		const QuxA = createTestWidget({ auto: true, childType: CustomElementChildType.TEXT });
+		const CustomElementA = create((QuxA as any).__customElementDescriptor, QuxA);
+		customElements.define('auto-qux-a', CustomElementA);
+		element = document.createElement('auto-qux-a');
 		const textNode = document.createTextNode('text node');
 		element.appendChild(textNode);
 		document.body.appendChild(element);

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -288,7 +288,7 @@ describe('registerCustomElement', () => {
 			properties: ['myProp'],
 			events: ['onBar'],
 			childType: CustomElementChildType.DOJO,
-			auto: true 
+			auto: true
 		});
 		const CustomElementB = create((BarB as any).__customElementDescriptor, BarB);
 		customElements.define('auto-bar-b', CustomElementB);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The previous attempt to auto detect childType only worked when the CE javascript was loaded before the element was created. If the CE javascript was loaded after the custom element is created then it caused issues with hydration (as dojo didn't know what was a Dojo CE and what wasn't).

The current behaviour only supports a single specified child type per widget and this auto detection mirrors that. It is assumed that if there are any children with a `-` character that the childType is `DOJO` otherwise it's `NODE/TEXT`. 

If a widget is specifically for non Dojo CE children then the existing configuration can be used.

**Note:** Additionally empty text nodes are filtered out from the childNodes

Supersedes #494 
Resolves #304 
