### PR TITLE
doc: fix path typo in store doc

### DIFF
--- a/docs/en/stores/introduction.md
+++ b/docs/en/stores/introduction.md
@@ -27,7 +27,7 @@ The store holds the global, atomic state for the entire application. The store s
 > main.ts
 
 ```ts
-import { registerStoreInjector } from '@dojo/framework/store/StoreInjector';
+import { registerStoreInjector } from '@dojo/framework/stores/StoreInjector';
 import Store from '@dojo/framework/stores/Store';
 import { State } from './interfaces';
 


### PR DESCRIPTION
**Type:** doc typo

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

There is a small typo in the store doc

`import { registerStoreInjector } from '@dojo/framework/store/StoreInjector';`
should be
`import { registerStoreInjector } from '@dojo/framework/stores/StoreInjector';`

Got me in a quick copy/paste walkthrough
