### PR TITLE
Add 'isExact' option to active link

### DIFF
--- a/src/routing/ActiveLink.ts
+++ b/src/routing/ActiveLink.ts
@@ -8,6 +8,7 @@ import Router from './Router';
 
 export interface ActiveLinkProperties extends LinkProperties {
 	activeClasses: SupportedClassName[];
+	isExact?: boolean;
 }
 
 function paramsEqual(linkParams: any = {}, contextParams: any = {}) {
@@ -22,7 +23,7 @@ export const ActiveLink = factory(function ActiveLink({
 	children
 }) {
 	const { to, routerKey = 'router', params } = properties();
-	let { activeClasses, classes = [], ...props } = properties();
+	let { activeClasses, isExact, classes = [], ...props } = properties();
 
 	diffProperty('to', (current: ActiveLinkProperties, next: ActiveLinkProperties) => {
 		if (current.to !== next.to) {
@@ -55,9 +56,10 @@ export const ActiveLink = factory(function ActiveLink({
 		}
 		const context = router.getOutlet(to);
 		const isActive = context && paramsEqual(params, context.params);
+		const contextIsExact = context && context.isExact();
 
 		classes = Array.isArray(classes) ? classes : [classes];
-		if (isActive) {
+		if (isActive && (!isExact || contextIsExact)) {
 			classes = [...classes, ...activeClasses];
 		}
 		props = { ...props, classes };

--- a/src/routing/README.md
+++ b/src/routing/README.md
@@ -338,7 +338,7 @@ import { ActiveLink } from '@dojo/framework/routing/ActiveLink';
 
 render() {
 	return v('div', [
-		w(ActiveLink, { to: 'foo', params: { foo: 'bar' }, activeClasses: [ 'link-active' ]}, [ 'Link Text' ])
+		w(ActiveLink, { to: 'foo', params: { foo: 'bar' }, isExact: false, activeClasses: [ 'link-active' ]}, [ 'Link Text' ])
 	]);
 }
 ```

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -106,7 +106,7 @@ describe('ActiveLink', () => {
 		h.expect(() => w(Link, { to: 'other', classes: ['foo'] }));
 	});
 
-	it('should look at route params when determining active', () => {
+	it('Should look at route params when determining active', () => {
 		router.setPath('/param/one');
 		const h1 = harness(
 			() =>
@@ -137,5 +137,18 @@ describe('ActiveLink', () => {
 			}
 		);
 		h2.expect(() => w(Link, { to: 'suffixed-param', classes: [], params: { suffix: 'two' } }));
+	});
+
+	it('Should be able to check for an exact match', () => {
+		router.setPath('/param/suffix');
+		let h = harness(() => w(ActiveLink, { to: 'param', activeClasses: ['foo'] }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
+		h.expect(() => w(Link, { classes: ['foo'], to: 'param' }));
+
+		h = harness(() => w(ActiveLink, { to: 'param', activeClasses: ['foo'], isExact: true }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
+		h.expect(() => w(Link, { classes: [], to: 'param' }));
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds an `isExact` option to the `ActiveLink` properties that if true will only add active classes if the matched outlet's `isExact` function returns `true`.
Resolves #492
