### PR TITLE
Skip autobind for getters on class-based widgets

### DIFF
--- a/src/core/WidgetBase.ts
+++ b/src/core/WidgetBase.ts
@@ -50,13 +50,15 @@ function autoBind(instance: any) {
 	} else {
 		while (prototype) {
 			const ownKeys = Object.getOwnPropertyNames(prototype);
-
 			if (prototype.constructor.hasOwnProperty('_type')) {
 				break;
 			}
+			const descriptors = Object.getOwnPropertyDescriptors(prototype);
+			const descriptorKeys = Object.keys(descriptors);
+			const getterKeys = descriptorKeys.filter((key) => descriptors[key].get || descriptors[key].set);
+			const filteredKeys = ownKeys.filter((key) => getterKeys.indexOf(key) === -1);
 
-			keys = [...keys, ...ownKeys];
-
+			keys = [...keys, ...filteredKeys];
 			prototype = Object.getPrototypeOf(prototype);
 		}
 

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -2750,6 +2750,22 @@ jsdomDescribe('vdom', () => {
 			);
 		});
 
+		it('Should skip binding getters', () => {
+			const root = document.createElement('div');
+			class MyWidget extends WidgetBase<any> {
+				get bar() {
+					return this.properties.foo.length;
+				}
+				render() {
+					return 'hello';
+				}
+			}
+			const r = renderer(() => w(MyWidget, { foo: 'hello' }));
+			r.mount({ domNode: root });
+			resolvers.resolve();
+			assert.strictEqual(root.innerHTML, 'hello');
+		});
+
 		describe('supports merging with a widget returned a the top level', () => {
 			it('Supports merging DNodes onto existing HTML', () => {
 				const iframe = document.createElement('iframe');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Skip autobind for getter propertoes on class-based widgets.

Resolves #521 
