### PR TITLE
Ensure middleware gets destroyed from deepest to shallowest

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -73,6 +73,7 @@ export interface WidgetMeta {
 	dirty: boolean;
 	invalidator: () => void;
 	middleware?: any;
+	middlewareIds: string[];
 	registryHandler?: RegistryHandler;
 	registry: Registry;
 	properties: any;
@@ -698,8 +699,11 @@ function addNodeToMap(id: string, key: string | number, node: HTMLElement) {
 	}
 }
 
-function destroyHandles(destroyMap: Map<string, () => void>) {
-	destroyMap.forEach((destroy) => destroy());
+function destroyHandles(destroyMap: Map<string, () => void>, middlewareIds: string[]) {
+	for (let i = 0; i < middlewareIds.length; i++) {
+		const destroy = destroyMap.get(middlewareIds[i]);
+		destroy && destroy();
+	}
 	destroyMap.clear();
 }
 
@@ -1648,7 +1652,11 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		return {};
 	}
 
-	function resolveMiddleware(middlewares: any, id: string): any {
+	function resolveMiddleware(
+		middlewares: any,
+		id: string,
+		middlewareIds: string[] = []
+	): { middlewares: any; ids: string[] } {
 		const keys = Object.keys(middlewares);
 		const results: any = {};
 		const uniqueId = `${id}-${metaId++}`;
@@ -1672,14 +1680,19 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				}
 			};
 			if (middleware.middlewares) {
-				const resolvedMiddleware = resolveMiddleware(middleware.middlewares, id);
+				const { middlewares: resolvedMiddleware } = resolveMiddleware(
+					middleware.middlewares,
+					id,
+					middlewareIds
+				);
 				payload.middleware = resolvedMiddleware;
 				results[keys[i]] = middleware.callback(payload);
 			} else {
 				results[keys[i]] = middleware.callback(payload);
 			}
 		}
-		return results;
+		middlewareIds.push(uniqueId);
+		return { middlewares: results, ids: middlewareIds };
 	}
 
 	function _createWidget({ next }: CreateWidgetInstruction): ProcessResult | false {
@@ -1724,13 +1737,17 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					children: next.node.children,
 					deferRefs: 0,
 					rendering: true,
+					middleware: {},
+					middlewareIds: [],
 					registry: _mountOptions.registry
 				};
 
 				widgetMetaMap.set(next.id, widgetMeta);
-				widgetMeta.middleware = (Constructor as any).middlewares
-					? resolveMiddleware((Constructor as any).middlewares, id)
-					: {};
+				if ((Constructor as any).middlewares) {
+					const { middlewares, ids } = resolveMiddleware((Constructor as any).middlewares, id);
+					widgetMeta.middleware = middlewares;
+					widgetMeta.middlewareIds = ids;
+				}
 			} else {
 				invalidate = widgetMeta.invalidator;
 			}
@@ -1895,7 +1912,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		};
 		if (meta) {
 			meta.registryHandler && meta.registryHandler.destroy();
-			meta.destroyMap && destroyHandles(meta.destroyMap);
+			meta.destroyMap && destroyHandles(meta.destroyMap, meta.middlewareIds);
 			widgetMetaMap.delete(current.id);
 		} else {
 			processResult.widget = { type: 'detach', current, instance: current.instance };
@@ -2061,7 +2078,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 							const meta = widgetMetaMap.get(wrapper.id);
 							if (meta) {
 								meta.registryHandler && meta.registryHandler.destroy();
-								meta.destroyMap && destroyHandles(meta.destroyMap);
+								meta.destroyMap && destroyHandles(meta.destroyMap, meta.middlewareIds);
 								widgetMetaMap.delete(wrapper.id);
 							}
 						}

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -699,10 +699,19 @@ function addNodeToMap(id: string, key: string | number, node: HTMLElement) {
 	}
 }
 
-function destroyHandles(destroyMap: Map<string, () => void>, middlewareIds: string[]) {
+function destroyHandles(meta: WidgetMeta) {
+	const { destroyMap, middlewareIds } = meta;
+	if (!destroyMap) {
+		return;
+	}
 	for (let i = 0; i < middlewareIds.length; i++) {
-		const destroy = destroyMap.get(middlewareIds[i]);
+		const id = middlewareIds[i];
+		const destroy = destroyMap.get(id);
 		destroy && destroy();
+		destroyMap.delete(id);
+		if (destroyMap.size === 0) {
+			break;
+		}
 	}
 	destroyMap.clear();
 }
@@ -1912,7 +1921,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		};
 		if (meta) {
 			meta.registryHandler && meta.registryHandler.destroy();
-			meta.destroyMap && destroyHandles(meta.destroyMap, meta.middlewareIds);
+			destroyHandles(meta);
 			widgetMetaMap.delete(current.id);
 		} else {
 			processResult.widget = { type: 'detach', current, instance: current.instance };
@@ -2078,7 +2087,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 							const meta = widgetMetaMap.get(wrapper.id);
 							if (meta) {
 								meta.registryHandler && meta.registryHandler.destroy();
-								meta.destroyMap && destroyHandles(meta.destroyMap, meta.middlewareIds);
+								destroyHandles(meta);
 								widgetMetaMap.delete(wrapper.id);
 							}
 						}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The destroy middleware is useful for ensuring widgets can deal with any references when they are removed from the tree. However currently, destroy is called in the order that the middleware dependencies of a widget call destroy. This is generally top down as `destroy` is usually called at the point of a middlewares initialisation, but this is not a guarantee meaning that not only is it generally called in the wrong order but also is not deterministic.

This change records the dependency order of all middleware for a widget and when there have been destroy functions registered ensures that they called in the right order from the deepest to shallowest (first in, last out).

Resolves #518 
