### PR TITLE
Always autostarts due to incorrect logic

### DIFF
--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -50,7 +50,8 @@ export class Router extends Evented<{ nav: NavEvent; outlet: OutletEvent }> impl
 		super();
 		this._options = options;
 		this._register(config);
-		if (options.autostart || true) {
+		const autostart = options.autostart === undefined ? true : options.autostart;
+		if (autostart) {
 			this.start();
 		}
 	}

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -517,7 +517,14 @@ describe('Router', () => {
 
 	it('The router will not start automatically if autostart is set to false', () => {
 		let initialNavEvent = false;
-		const router = new Router(routeConfigDefaultRoute, { HistoryManager, autostart: false });
+		let historyManagerCount = 0;
+		class TestHistoryManager extends HistoryManager {
+			constructor(args: any) {
+				super(args);
+				historyManagerCount++;
+			}
+		}
+		const router = new Router(routeConfigDefaultRoute, { HistoryManager: TestHistoryManager, autostart: false });
 		let navCount = 0;
 		router.on('nav', (event) => {
 			navCount++;
@@ -533,6 +540,7 @@ describe('Router', () => {
 			}
 		});
 		router.start();
+		assert.strictEqual(historyManagerCount, 1);
 		assert.isTrue(initialNavEvent);
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The logic for autostart is incorrect which causes registering multiple history managers when it is set to `autoStart: false`.