### PR TITLE
Fix the typing of icache

### DIFF
--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -9,32 +9,32 @@ interface CacheWrapper {
 	value: any;
 }
 
-export interface ICacheResult<S = null> {
+export interface ICacheResult<S = void> {
 	getOrSet: {
-		<T extends null extends S ? any : keyof S>(
-			key: null extends S ? any : T,
-			value: null extends S ? () => Promise<T> : () => Promise<S[T]>
-		): null extends S ? undefined | T : undefined | S[T];
-		<T extends null extends S ? any : keyof S>(
-			key: null extends S ? any : T,
-			value: null extends S ? () => T : () => S[T]
-		): null extends S ? T : S[T];
-		<T extends null extends S ? any : keyof S>(
-			key: null extends S ? any : T,
-			value: null extends S ? T : S[T]
-		): null extends S ? T : S[T];
+		<T extends void extends S ? any : keyof S>(
+			key: void extends S ? any : T,
+			value: void extends S ? () => Promise<T> : () => Promise<S[T]>
+		): void extends S ? undefined | T : undefined | S[T];
+		<T extends void extends S ? any : keyof S>(
+			key: void extends S ? any : T,
+			value: void extends S ? () => T : () => S[T]
+		): void extends S ? T : S[T];
+		<T extends void extends S ? any : keyof S>(
+			key: void extends S ? any : T,
+			value: void extends S ? T : S[T]
+		): void extends S ? T : S[T];
 	};
-	get<T extends null extends S ? any : keyof S>(
-		key: null extends S ? any : T
-	): null extends S ? T | undefined : S[T] | undefined;
-	set<T extends null extends S ? any : keyof S>(
-		key: null extends S ? any : T,
-		value: null extends S ? T : S[T]
+	get<T extends void extends S ? any : keyof S>(
+		key: void extends S ? any : T
+	): void extends S ? T | undefined : S[T] | undefined;
+	set<T extends void extends S ? any : keyof S>(
+		key: void extends S ? any : T,
+		value: void extends S ? T : S[T]
 	): void;
 	clear(): void;
 }
 
-export function createICacheMiddleware<S = any>() {
+export function createICacheMiddleware<S = void>() {
 	const icache = factory(
 		({ middleware: { invalidator, cache } }): ICacheResult<S> => {
 			return {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The new typings for `icache` were working as expected in `@dojo/framework` were not working when installed as a downstream dependency. Change the default type for the interface to `void` seems to fix this and allow the types to be inferred as intended.

Existing tests should cover this type change and tested in a downstream project.