### PR TITLE
Middlware mocking documentation

### DIFF
--- a/src/testing/mocks/middleware/icache.ts
+++ b/src/testing/mocks/middleware/icache.ts
@@ -1,0 +1,73 @@
+/* tslint:disable:interface-name */
+import { create, invalidator } from '../../../core/vdom';
+import { MiddlewareResult } from '../../../core/interfaces';
+import Map from '../../../shim/Map';
+
+export function createICacheMock() {
+	const map = new Map<any, any>();
+	const factory = create({ invalidator });
+
+	const mockICacheFactory = factory(({ middleware: { invalidator } }) => {
+		return {
+			getOrSet<T = any>(key: any, value: any): T | undefined {
+				if (map.has(key)) {
+					return this.get(key);
+				} else {
+					this.set(key, value);
+					return undefined;
+				}
+			},
+			get<T = any>(key: any): T | undefined {
+				if (map.has(key)) {
+					const mapValue = map.get(key);
+					if (typeof mapValue === 'function') {
+						return undefined;
+					} else {
+						return mapValue as T;
+					}
+				}
+				return undefined;
+			},
+			set(key: any, value: any): void {
+				if (typeof value === 'function') {
+					value = value();
+					if (value.then && typeof value.then === 'function') {
+						value.then((result: any) => {
+							map.set(key, result);
+							invalidator();
+						});
+					}
+					map.set(key, value);
+				} else {
+					map.set(key, value);
+					invalidator();
+				}
+			},
+			clear(): void {}
+		};
+	});
+
+	function mockCache(): MiddlewareResult<any, any, any>;
+	function mockCache(key: string): Promise<any>;
+	function mockCache(key?: string): Promise<any> | MiddlewareResult<any, any, any> {
+		if (key) {
+			if (map.has(key)) {
+				const mapValue = map.get(key);
+
+				if (mapValue.then && typeof mapValue.then === 'function') {
+					return mapValue;
+				} else {
+					return Promise.resolve(mapValue);
+				}
+			} else {
+				return Promise.resolve(undefined);
+			}
+		} else {
+			return mockICacheFactory();
+		}
+	}
+
+	return mockCache;
+}
+
+export default createICacheMock;

--- a/tests/testing/unit/mocks/middleware/all.ts
+++ b/tests/testing/unit/mocks/middleware/all.ts
@@ -3,3 +3,4 @@ import './node';
 import './resize';
 import './store';
 import './breakpoint';
+import './icache';

--- a/tests/testing/unit/mocks/middleware/icache.tsx
+++ b/tests/testing/unit/mocks/middleware/icache.tsx
@@ -1,0 +1,30 @@
+const { it } = intern.getInterface('bdd');
+const { describe } = intern.getPlugin('jsdom');
+import * as sinon from 'sinon';
+import { tsx, create } from '../../../../../src/core/vdom';
+import harness from '../../../../../src/testing/harness';
+import createICacheMock from '../../../../../src/testing/mocks/middleware/icache';
+import icache from '../../../../../src/core/middleware/icache';
+import global from '../../../../../src/shim/global';
+
+describe('icache mock', () => {
+	it('should provide access to async icache loads', async () => {
+		const iCacheMock = createICacheMock();
+		const factory = create({ icache });
+		const App = factory(({ middleware: { icache } }) => {
+			const value = icache.getOrSet('users', async () => {
+				const response = await fetch('https://reqres.in/api/users');
+				return await response.json();
+			});
+
+			return value ? <div>{value}</div> : <div>Loading</div>;
+		});
+
+		global.fetch = sinon.stub().returns(Promise.resolve({ json: () => Promise.resolve('api data') }));
+
+		const h = harness(() => <App />, { middleware: [[icache, iCacheMock]] });
+		h.expect(() => <div>Loading</div>);
+		await iCacheMock('users');
+		h.expect(() => <div>api data</div>);
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Introduces an icache middleware mock as well as documentation for using it and creating custom middleware mocks.

Resolves #519
