### PR TITLE
Middleware mocking documentation

### DIFF
--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -92,22 +92,130 @@ The harness automatically mocks a number of core middlewares that will be inject
 
 There are a number of mock middleware available to support testing widgets that use the corresponding Dojo middleware. The mocks export a factory used to create the scoped mock middleware to be used in each test.
 
-#### Mock `node` middleware
+#### Mock `breakpoint` middleware
 
-Using `createNodeMock` from `@dojo/framework/testing/mocks/middleware/node` creates a mock for the node middleware. To set the expected return from the node mock, call the created mock node middleware with a `key` and expected DOM node.
+Using `createBreakpointMock` from `@dojo/framework/testing/mocks/middlware/breakpoint` offers tests manual control over resizing events to trigger breakpoint tests.
 
-```ts
-import createNodeMock from '@dojo/framework/testing/mocks/middleware/node';
+Consider the following widget which displays an additonal `h2` when the `LG` breakpoint is activated:
 
-// create the mock node middleware
-const mockNode = createNodeMock();
+> src/Breakpoint.tsx
 
-// create a mock DOM node
-const domNode = {};
+```
+import { tsx, create } from '@dojo/framework/core/vdom';
+import breakpoint from '@dojo/framework/core/middleware/breakpoint';
 
-// call the mock middleware with a key and the DOM
-// to return.
-mockNode('key', domNode);
+const factory = create({ breakpoint });
+
+export default factory(function Breakpoint({ middleware: { breakpoint } }) {
+  const bp = breakpoint.get('root');
+  const isLarge = bp && bp.breakpoint === 'LG';
+
+  return (
+    <div key="root">
+      <h1>Header</h1>
+      {isLarge && <h2>Subtitle</h2>}
+      <div>Longer description</div>
+    </div>
+  );
+});
+```
+
+By using the `mockBreakpoint(key: string, contentRect: Partial<DOMRectReadOnly>)` method on the breakpoint middleware mock, the test can explicitly trigger a given resize:
+
+> tests/unit/Breakpoint.tsx
+
+```tsx
+const { describe, it } = intern.getInterface('bdd');
+import { tsx } from '@dojo/framework/core/vdom';
+import harness from '@dojo/framework/testing/harness';
+import breakpoint from '@dojo/framework/core/middleware/breakpoint';
+import createBreakpointMock from '@dojo/framework/testing/mocks/middleware/breakpoint';
+import Breakpoint from '../../src/Breakpoint';
+
+describe('Breakpoint', () => {
+	it('resizes correctly', () => {
+		const mockBreakpoint = createBreakpointMock();
+
+		const h = harness(() => <Breakpoint />, {
+			middleware: [[breakpoint, mockBreakpoint]]
+		});
+		h.expect(() => (
+			<div key="root">
+				<h1>Header</h1>
+				<div>Longer description</div>
+			</div>
+		));
+
+		mockBreakpoint('root', { breakpoint: 'LG', contentRect: { width: 800 } });
+
+		h.expect(() => (
+			<div key="root">
+				<h1>Header</h1>
+				<h2>Subtitle</h2>
+				<div>Longer description</div>
+			</div>
+		));
+	});
+});
+```
+
+#### Mock `iCache` middleware
+
+Using `createICacheMiddleware` from `@dojo/framework/testing/mocks/middleware/icache` allows tests to access cache items directly while the mock provides a sufficient icache experience for the widget under test. This is particularly useful when `icache` is used to asynchronously retrieve data. Direct cache access enables the test to `await` the same promise as the widget.
+
+Consider the following widget which retrieves data from an API:
+
+> src/MyWidget.tsx
+
+```tsx
+import { tsx, create } from '@dojo/framework/core/vdom';
+import { icache } from '@dojo/framework/core/middleware/icache';
+import fetch from '@dojo/framework/shim/fetch';
+
+const factory = create({ icache });
+
+export default factory(function MyWidget({ middleware: { icache } }) {
+	const value = icache.getOrSet('users', async () => {
+		const response = await fetch('url');
+		return await response.json();
+	});
+
+	return value ? <div>{value}</div> : <div>Loading</div>;
+});
+```
+
+Testing the asynchrounous result using the mock icache middleware is simple:
+
+> tests/unit/MyWidget.tsx
+
+```tsx
+const { describe, it, afterEach } = intern.getInterface('bdd');
+import harness from '@dojo/framework/testing/harness';
+import { tsx } from '@dojo/framework/core/vdom';
+import * as sinon from 'sinon';
+import global from '@dojo/framework/shim/global';
+import icache from '@dojo/framework/core/middleware/icache';
+import createICacheMock from '@dojo/framework/testing/mocks/middleware/icache';
+import MyWidget from '../../src/MyWidget';
+
+describe('MyWidget', () => {
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	it('test', async () => {
+		// stub the fetch call to return a known value
+		global.fetch = sinon.stub().returns(Promise.resolve({ json: () => Promise.resolve('api data') }));
+
+		const mockICache = createICacheMock();
+		const h = harness(() => <Home />, { middleware: [[icache, mockICache]] });
+		h.expect(() => <div>Loading</div>);
+
+		// await the async method passed to the mock cache
+		await mockICache('users');
+		h.expect(() => <pre>api data</pre>);
+	});
+});
 ```
 
 #### Mock `intersection` middleware
@@ -157,6 +265,24 @@ describe('MyWidget', () => {
 		h.expect(() => <div key="root">{`{"isIntersecting": true }`}</div>);
 	});
 });
+```
+
+#### Mock `node` middleware
+
+Using `createNodeMock` from `@dojo/framework/testing/mocks/middleware/node` creates a mock for the node middleware. To set the expected return from the node mock, call the created mock node middleware with a `key` and expected DOM node.
+
+```ts
+import createNodeMock from '@dojo/framework/testing/mocks/middleware/node';
+
+// create the mock node middleware
+const mockNode = createNodeMock();
+
+// create a mock DOM node
+const domNode = {};
+
+// call the mock middleware with a key and the DOM
+// to return.
+mockNode('key', domNode);
 ```
 
 #### Mock `resize` middleware
@@ -309,65 +435,6 @@ describe('MyWidget', () => {
          mockStore((path) => [replace(path('details', { id: 'other' })]);
          h.expect(/* assertion template for `ShowDetails`*/);
      });
-});
-```
-
-#### Mock `iCache` middleware
-
-Using `createICacheMiddleware` from `@dojo/framework/testing/mocks/middleware/icache` allows tests to access cache items directly while the mock provides a sufficient icache experience for the widget under test. This is particularly useful when `icache` is used to asynchronously retrieve data. Direct cache access enables the test to `await` the same promise as the widget.
-
-Consider the following widget which retrieves data from an API:
-
-> src/MyWidget.tsx
-
-```tsx
-import { tsx, create } from '@dojo/framework/core/vdom';
-import { icache } from '@dojo/framework/core/middleware/icache';
-import fetch from '@dojo/framework/shim/fetch';
-
-const factory = create({ icache });
-
-export default factory(function MyWidget({ middleware: { icache } }) {
-	const value = icache.getOrSet('users', async () => {
-		const response = await fetch('url');
-		return await response.json();
-	});
-
-	return value ? <div>{value}</div> : <div>Loading</div>;
-});
-```
-
-Testing the asynchrounous result using the mock icache middleware is simple:
-
-> tests/unit/MyWidget.tsx
-
-```tsx
-const { describe, it, afterEach } = intern.getInterface('bdd');
-import harness from '@dojo/framework/testing/harness';
-import { tsx } from '@dojo/framework/core/vdom';
-import * as sinon from 'sinon';
-import global from '@dojo/framework/shim/global';
-import icache from '@dojo/framework/core/middleware/icache';
-import createICacheMock from '@dojo/framework/testing/mocks/middleware/icache';
-import MyWidget from '../../src/MyWidget';
-
-describe('MyWidget', () => {
-	afterEach(() => {
-		sinon.restore();
-	});
-
-	it('test', async () => {
-		// stub the fetch call to return a known value
-		global.fetch = sinon.stub().returns(Promise.resolve({ json: () => Promise.resolve('api data') }));
-
-		const mockICache = createICacheMock();
-		const h = harness(() => <Home />, { middleware: [[icache, mockICache]] });
-		h.expect(() => <div>Loading</div>);
-
-		// await the async method passed to the mock cache
-		await mockICache('users');
-		h.expect(() => <pre>api data</pre>);
-	});
 });
 ```
 

--- a/src/testing/mocks/middleware/icache.ts
+++ b/src/testing/mocks/middleware/icache.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:interface-name */
 import { create, invalidator } from '../../../core/vdom';
 import { MiddlewareResult } from '../../../core/interfaces';
 import { cache } from '../../../core/middleware/cache';
@@ -21,13 +20,14 @@ export function createICacheMock() {
 		icacheMiddleware.set = (key: any, value: any) => {
 			if (typeof value === 'function') {
 				value = value();
-				map.set(key, value);
 				if (value && typeof value.then === 'function') {
+					map.set(key, value);
 					setter(key, () => value);
-				} else {
-					setter(key, value);
+					return;
 				}
 			}
+
+			setter(key, value);
 		};
 
 		return icacheMiddleware;
@@ -38,13 +38,7 @@ export function createICacheMock() {
 	function mockCache(key?: string): Promise<any> | MiddlewareResult<any, any, any> {
 		if (key) {
 			if (map.has(key)) {
-				const mapValue = map.get(key);
-
-				if (mapValue.then && typeof mapValue.then === 'function') {
-					return mapValue;
-				} else {
-					return Promise.resolve(mapValue);
-				}
+				return map.get(key);
 			} else {
 				return Promise.resolve(undefined);
 			}

--- a/src/testing/mocks/middleware/icache.ts
+++ b/src/testing/mocks/middleware/icache.ts
@@ -1,0 +1,73 @@
+/* tslint:disable:interface-name */
+import { create, invalidator } from '../../../core/vdom';
+import { MiddlewareResult } from '../../../core/interfaces';
+import Map from '../../../shim/Map';
+
+export function createICacheMock() {
+	const map = new Map<any, any>();
+	const factory = create({ invalidator });
+
+	const mockICacheFactory = factory(({ middleware: { invalidator } }) => {
+		return {
+			getOrSet<T = any>(key: any, value: any): T | undefined {
+				if (map.has(key)) {
+					return this.get(key);
+				} else {
+					this.set(key, value);
+					return undefined;
+				}
+			},
+			get<T = any>(key: any): T | undefined {
+				if (map.has(key)) {
+					const mapValue = map.get(key);
+					if (typeof mapValue === 'function') {
+						return undefined;
+					} else {
+						return mapValue as T;
+					}
+				}
+				return undefined;
+			},
+			set(key: any, value: any): void {
+				if (typeof value === 'function') {
+					value = value();
+					if (value.then && typeof value.then === 'function') {
+						value.then((result: any) => {
+							map.set(key, result);
+							invalidator();
+						});
+					}
+					map.set(key, value);
+				} else {
+					map.set(key, value);
+					invalidator();
+				}
+			},
+			clear(): void {}
+		};
+	});
+
+	function mockCache(): MiddlewareResult<any, any, any>;
+	function mockCache(key: string): Promise<any>;
+	function mockCache(key?: string): Promise<any> | MiddlewareResult<any, any, any> {
+		if (key) {
+			if (map.has(key)) {
+				const mapValue = map.get(key);
+
+				if (mapValue.then && typeof mapValue.then === 'function') {
+					return mapValue;
+				} else {
+					return Promise.resolve(mapValue);
+				}
+			} else {
+				return Promise.resolve(undefined);
+			}
+		} else {
+			return mockICacheFactory();
+		}
+	}
+
+	return mockCache;
+}
+
+export default createICacheMock;

--- a/tests/testing/unit/mocks/middleware/all.ts
+++ b/tests/testing/unit/mocks/middleware/all.ts
@@ -3,3 +3,4 @@ import './node';
 import './resize';
 import './store';
 import './breakpoint';
+import './icache';

--- a/tests/testing/unit/mocks/middleware/icache.tsx
+++ b/tests/testing/unit/mocks/middleware/icache.tsx
@@ -1,0 +1,30 @@
+const { it } = intern.getInterface('bdd');
+const { describe } = intern.getPlugin('jsdom');
+import * as sinon from 'sinon';
+import { tsx, create } from '../../../../../src/core/vdom';
+import harness from '../../../../../src/testing/harness';
+import createICacheMock from '../../../../../src/testing/mocks/middleware/icache';
+import icache from '../../../../../src/core/middleware/icache';
+import global from '../../../../../src/shim/global';
+
+describe('icache mock', () => {
+	it('should provide access to async icache loads', async () => {
+		const iCacheMock = createICacheMock();
+		const factory = create({ icache });
+		const App = factory(({ middleware: { icache } }) => {
+			const value = icache.getOrSet('users', async () => {
+				const response = await fetch('https://reqres.in/api/users');
+				return await response.json();
+			});
+
+			return value ? <div>{value}</div> : <div>Loading</div>;
+		});
+
+		global.fetch = sinon.stub().returns(Promise.resolve({ json: () => Promise.resolve('api data') }));
+
+		const h = harness(() => <App />, { middleware: [[icache, iCacheMock]] });
+		h.expect(() => <div>Loading</div>);
+		await iCacheMock('users');
+		h.expect(() => <div>api data</div>);
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Introduces an icache middleware mock as well as documentation for using it and creating custom middleware mocks.

Resolves #519
