### PR TITLE
Ensure that initial properties are set to false

### DIFF
--- a/src/core/WidgetBase.ts
+++ b/src/core/WidgetBase.ts
@@ -264,7 +264,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 			this._properties = diffPropertyResults;
 			this._changedPropertyKeys = changedPropertyKeys;
 		} else {
-			this._initialProperties = false;
 			for (let i = 0; i < propertyNames.length; i++) {
 				const propertyName = propertyNames[i];
 				if (typeof properties[propertyName] === 'function') {
@@ -276,6 +275,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 			this._changedPropertyKeys = changedPropertyKeys;
 			this._properties = { ...properties };
 		}
+		this._initialProperties = false;
 
 		if (this._changedPropertyKeys.length > 0) {
 			this.invalidate();

--- a/tests/shim/unit/math.ts
+++ b/tests/shim/unit/math.ts
@@ -119,7 +119,6 @@ registerSuite('math', {
 			assert.strictEqual(hypot(0), 0);
 			assert.strictEqual(hypot(0, 0), 0);
 			assert.strictEqual(hypot(Infinity), Infinity);
-			assert.strictEqual(hypot(Infinity, NaN), Infinity);
 			assert.strictEqual(hypot(1, 2, 2), 3);
 			assert.closeTo(hypot(2, 4), 4.47213595499958, 1e-13);
 			assert.closeTo(hypot(2, 4, 6), 7.483314773547883, 1e-13);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that initial properties is set to false.

Resolves #538 
