### PR TITLE
Adding drag meta

### DIFF
--- a/src/core/middleware/drag.ts
+++ b/src/core/middleware/drag.ts
@@ -1,0 +1,276 @@
+import { deepAssign } from '../util';
+import global from '../../shim/global';
+import { assign } from '../../shim/object';
+import WeakMap from '../../shim/WeakMap';
+import { node, create, invalidator } from '../vdom';
+
+export interface DragResults {
+	/**
+	 * The movement of pointer during the duration of the drag state
+	 */
+	delta: Position;
+
+	/**
+	 * Is the DOM node currently in a drag state
+	 */
+	isDragging: boolean;
+
+	/**
+	 * A matrix of posistions that represent the start position for the current drag interaction
+	 */
+	start?: PositionMatrix;
+}
+
+interface NodeData {
+	dragResults: DragResults;
+	invalidate: () => void;
+	last: PositionMatrix;
+	start: PositionMatrix;
+}
+
+/**
+ * An x/y position structure
+ */
+export interface Position {
+	x: number;
+	y: number;
+}
+
+/**
+ * A matrix of x/y positions
+ */
+export interface PositionMatrix {
+	/**
+	 * Client x/y position
+	 */
+	client: Position;
+
+	/**
+	 * Offset x/y position
+	 */
+	offset: Position;
+
+	/**
+	 * Page x/y position
+	 */
+	page: Position;
+
+	/**
+	 * Screen x/y position
+	 */
+	screen: Position;
+}
+
+function createNodeData(invalidate: () => void): NodeData {
+	return {
+		dragResults: deepAssign({}, emptyResults),
+		invalidate,
+		last: createPositionMatrix(),
+		start: createPositionMatrix()
+	};
+}
+
+/**
+ * Creates an empty position
+ */
+function createPosition(): Position {
+	return { x: 0, y: 0 };
+}
+
+/**
+ * Create an empty position matrix
+ */
+function createPositionMatrix(): PositionMatrix {
+	return {
+		client: { x: 0, y: 0 },
+		offset: { x: 0, y: 0 },
+		page: { x: 0, y: 0 },
+		screen: { x: 0, y: 0 }
+	};
+}
+
+/**
+ * A frozen empty result object, frozen to ensure that no one downstream modifies it
+ */
+const emptyResults: DragResults = Object.freeze({
+	delta: Object.freeze(createPosition()),
+	isDragging: false
+});
+
+/**
+ * Return the x/y position matrix for an event
+ * @param event The pointer event
+ */
+function getPositionMatrix(event: PointerEvent): PositionMatrix {
+	return {
+		client: {
+			x: event.clientX,
+			y: event.clientY
+		},
+		offset: {
+			x: event.offsetX,
+			y: event.offsetY
+		},
+		page: {
+			x: event.pageX,
+			y: event.pageY
+		},
+		screen: {
+			x: event.screenX,
+			y: event.screenY
+		}
+	};
+}
+
+/**
+ * Return the delta position between two positions
+ * @param start The first position
+ * @param current The second position
+ */
+function getDelta(start: PositionMatrix, current: PositionMatrix): Position {
+	return {
+		x: current.client.x - start.client.x,
+		y: current.client.y - start.client.y
+	};
+}
+
+/**
+ * Sets the `touch-action` on nodes so that PointerEvents are always emitted for the node
+ * @param node The node to init
+ */
+function initNode(node: HTMLElement): void {
+	// Ensure that the node has `touch-action` none
+	node.style.touchAction = 'none';
+	// PEP requires an attribute of `touch-action` to be set on the element
+	node.setAttribute('touch-action', 'none');
+}
+
+class DragController {
+	private _nodeMap = new WeakMap<HTMLElement, NodeData>();
+	private _dragging: HTMLElement | undefined = undefined;
+
+	private _getData(target: HTMLElement): { state: NodeData; target: HTMLElement } | undefined {
+		if (this._nodeMap.has(target)) {
+			return { state: this._nodeMap.get(target)!, target };
+		}
+		if (target.parentElement) {
+			return this._getData(target.parentElement);
+		}
+	}
+
+	private _onDragStart = (event: PointerEvent) => {
+		const { _dragging } = this;
+		if (!event.isPrimary && _dragging) {
+			// we have a second touch going on here, while we are dragging, so we aren't really dragging, so we
+			// will close this down
+			const state = this._nodeMap.get(_dragging)!;
+			state.dragResults.isDragging = false;
+			state.invalidate();
+			this._dragging = undefined;
+			return;
+		}
+		if (event.button !== 0) {
+			// it isn't the primary button that is being clicked, so we will ignore this
+			return;
+		}
+		const data = this._getData(event.target as HTMLElement);
+		if (data) {
+			const { state, target } = data;
+			this._dragging = target;
+			state.last = state.start = getPositionMatrix(event);
+			state.dragResults.delta = createPosition();
+			state.dragResults.start = deepAssign({}, state.start);
+			state.dragResults.isDragging = true;
+			state.invalidate();
+
+			event.preventDefault();
+			event.stopPropagation();
+		} // else, we are ignoring the event
+	};
+
+	private _onDrag = (event: PointerEvent) => {
+		const { _dragging } = this;
+		if (!_dragging) {
+			return;
+		}
+		// state cannot be unset, using ! operator
+		const state = this._nodeMap.get(_dragging)!;
+		state.last = getPositionMatrix(event);
+		state.dragResults.delta = getDelta(state.start, state.last);
+		if (!state.dragResults.start) {
+			state.dragResults.start = deepAssign({}, state.start);
+		}
+		state.invalidate();
+
+		event.preventDefault();
+		event.stopPropagation();
+	};
+
+	private _onDragStop = (event: PointerEvent) => {
+		const { _dragging } = this;
+		if (!_dragging) {
+			return;
+		}
+		// state cannot be unset, using ! operator
+		const state = this._nodeMap.get(_dragging)!;
+		state.last = getPositionMatrix(event);
+		state.dragResults.delta = getDelta(state.start, state.last);
+		if (!state.dragResults.start) {
+			state.dragResults.start = deepAssign({}, state.start);
+		}
+		state.dragResults.isDragging = false;
+		state.invalidate();
+		this._dragging = undefined;
+
+		event.preventDefault();
+		event.stopPropagation();
+	};
+
+	constructor() {
+		const win: Window = global.window;
+		win.addEventListener('pointerdown', this._onDragStart);
+		// Use capture phase, to determine the right node target, as it will be top down versus bottom up
+		win.addEventListener('pointermove', this._onDrag, true);
+		win.addEventListener('pointerup', this._onDragStop, true);
+	}
+
+	public get(node: HTMLElement, invalidate: () => void): DragResults {
+		const { _nodeMap } = this;
+		// first time we see a node, we will initialize its state and properties
+		if (!_nodeMap.has(node)) {
+			_nodeMap.set(node, createNodeData(invalidate));
+			initNode(node);
+			return emptyResults;
+		}
+
+		const state = _nodeMap.get(node)!;
+		// shallow "clone" the results, so no downstream manipulation can occur
+		const dragResults = assign({}, state.dragResults);
+		// we are offering up an accurate delta, so we need to take the last event position and move it to the start so
+		// that our deltas are calculated from the last time they are read
+		state.start = state.last;
+		// reset the delta after we have read, as any future reads should have an empty delta
+		state.dragResults.delta = createPosition();
+		// clear the start state
+		delete state.dragResults.start;
+
+		return dragResults;
+	}
+}
+
+const factory = create({ node, invalidator });
+export const drag = factory(function drag({ middleware }) {
+	const controller = new DragController();
+
+	return {
+		get: (key: string | number) => {
+			const node = middleware.node.get(key) as HTMLElement;
+
+			if (!node) {
+				return emptyResults;
+			}
+
+			return controller.get(node, middleware.invalidator);
+		}
+	};
+});

--- a/tests/core/functional/Drag.ts
+++ b/tests/core/functional/Drag.ts
@@ -3,70 +3,139 @@ const { assert } = intern.getPlugin('chai');
 import { DragResults } from '../../../src/core/meta/Drag';
 import Test from 'intern/lib/Test';
 
-function getPage(test: Test) {
+function getMetaPage(test: Test) {
 	return test.remote.get(`${__dirname}/meta/Drag.html`).setFindTimeout(5000);
 }
 
-registerSuite('Drag', {
-	'touch drag'() {
-		if (!this.remote.session.capabilities.touchEnabled) {
-			this.skip('Not touch enabled device');
-		}
-		return getPage(this)
-			.findById('results')
-			.pressFinger(50, 50)
-			.sleep(100)
-			.moveFinger(100, 100)
-			.sleep(100)
-			.findById('results')
-			.getVisibleText()
-			.then((text) => {
-				const result: DragResults = JSON.parse(text);
-				assert.isTrue(result.isDragging, 'should be in a drag state');
-				assert.deepEqual(result.delta, { x: 50, y: 50 }, 'should have dragged expected distance');
-			})
-			.releaseFinger(100, 100)
-			.sleep(50)
-			.findById('results')
-			.getVisibleText()
-			.then((text) => {
-				const result: DragResults = JSON.parse(text);
-				assert.isFalse(result.isDragging, 'should be no longer dragging');
-				assert.deepEqual(result.delta, { x: 0, y: 0 }, 'should not have moved further');
-			});
-	},
+function getMiddlewarePage(test: Test) {
+	return test.remote.get(`${__dirname}/middleware/drag.html`).setFindTimeout(5000);
+}
 
-	'mouse drag'() {
-		const { browser, browserName, mouseEnabled } = this.remote.session.capabilities;
-		if (!mouseEnabled || browser === 'iPhone' || browser === 'iPad') {
-			this.skip('Not mouse enabled device');
+registerSuite('Drag', {
+	meta: {
+		'touch drag'() {
+			if (!this.remote.session.capabilities.touchEnabled) {
+				this.skip('Not touch enabled device');
+			}
+			return getMetaPage(this)
+				.findById('results')
+				.pressFinger(50, 50)
+				.sleep(100)
+				.moveFinger(100, 100)
+				.sleep(100)
+				.findById('results')
+				.getVisibleText()
+				.then((text) => {
+					const result: DragResults = JSON.parse(text);
+					assert.isTrue(result.isDragging, 'should be in a drag state');
+					assert.deepEqual(result.delta, { x: 50, y: 50 }, 'should have dragged expected distance');
+				})
+				.releaseFinger(100, 100)
+				.sleep(50)
+				.findById('results')
+				.getVisibleText()
+				.then((text) => {
+					const result: DragResults = JSON.parse(text);
+					assert.isFalse(result.isDragging, 'should be no longer dragging');
+					assert.deepEqual(result.delta, { x: 0, y: 0 }, 'should not have moved further');
+				});
+		},
+
+		'mouse drag'() {
+			const { browser, browserName, mouseEnabled } = this.remote.session.capabilities;
+			if (!mouseEnabled || browser === 'iPhone' || browser === 'iPad') {
+				this.skip('Not mouse enabled device');
+			}
+			if (browserName === 'MicrosoftEdge') {
+				this.skip('For some reason, findById not working on Edge ATM.');
+			}
+			if (browserName === 'internet explorer') {
+				this.skip('Dragging is not working on Internet Explorer.');
+			}
+			return getMetaPage(this)
+				.findById('results')
+				.moveMouseTo(50, 50)
+				.pressMouseButton()
+				.sleep(100)
+				.moveMouseTo(100, 100)
+				.sleep(100)
+				.getVisibleText()
+				.then((text) => {
+					const result: DragResults = JSON.parse(text);
+					assert.isTrue(result.isDragging, 'should be in a drag state');
+					assert.deepEqual(result.delta, { x: 50, y: 50 }, 'should have dragged expected distance');
+				})
+				.releaseMouseButton()
+				.sleep(50)
+				.getVisibleText()
+				.then((text) => {
+					const result: DragResults = JSON.parse(text);
+					assert.isFalse(result.isDragging, 'should be no longer dragging');
+					assert.deepEqual(result.delta, { x: 0, y: 0 }, 'should have dragged expected distance');
+				});
 		}
-		if (browserName === 'MicrosoftEdge') {
-			this.skip('For some reason, findById not working on Edge ATM.');
+	},
+	middleware: {
+		'touch drag'() {
+			if (!this.remote.session.capabilities.touchEnabled) {
+				this.skip('Not touch enabled device');
+			}
+			return getMiddlewarePage(this)
+				.findById('results')
+				.pressFinger(50, 50)
+				.sleep(100)
+				.moveFinger(100, 100)
+				.sleep(100)
+				.findById('results')
+				.getVisibleText()
+				.then((text) => {
+					const result: DragResults = JSON.parse(text);
+					assert.isTrue(result.isDragging, 'should be in a drag state');
+					assert.deepEqual(result.delta, { x: 50, y: 50 }, 'should have dragged expected distance');
+				})
+				.releaseFinger(100, 100)
+				.sleep(50)
+				.findById('results')
+				.getVisibleText()
+				.then((text) => {
+					const result: DragResults = JSON.parse(text);
+					assert.isFalse(result.isDragging, 'should be no longer dragging');
+					assert.deepEqual(result.delta, { x: 0, y: 0 }, 'should not have moved further');
+				});
+		},
+
+		'mouse drag'() {
+			const { browser, browserName, mouseEnabled } = this.remote.session.capabilities;
+			if (!mouseEnabled || browser === 'iPhone' || browser === 'iPad') {
+				this.skip('Not mouse enabled device');
+			}
+			if (browserName === 'MicrosoftEdge') {
+				this.skip('For some reason, findById not working on Edge ATM.');
+			}
+			if (browserName === 'internet explorer') {
+				this.skip('Dragging is not working on Internet Explorer.');
+			}
+			return getMiddlewarePage(this)
+				.findById('results')
+				.moveMouseTo(50, 50)
+				.pressMouseButton()
+				.sleep(100)
+				.moveMouseTo(100, 100)
+				.sleep(100)
+				.getVisibleText()
+				.then((text) => {
+					const result: DragResults = JSON.parse(text);
+					assert.isTrue(result.isDragging, 'should be in a drag state');
+					assert.deepEqual(result.delta, { x: 50, y: 50 }, 'should have dragged expected distance');
+				})
+				.releaseMouseButton()
+				.sleep(50)
+				.getVisibleText()
+				.then((text) => {
+					const result: DragResults = JSON.parse(text);
+					assert.isFalse(result.isDragging, 'should be no longer dragging');
+					assert.deepEqual(result.delta, { x: 0, y: 0 }, 'should have dragged expected distance');
+				});
 		}
-		if (browserName === 'internet explorer') {
-			this.skip('Dragging is not working on Internet Explorer.');
-		}
-		return getPage(this)
-			.findById('results')
-			.moveMouseTo(50, 50)
-			.pressMouseButton()
-			.sleep(100)
-			.moveMouseTo(100, 100)
-			.sleep(100)
-			.getVisibleText()
-			.then((text) => {
-				const result: DragResults = JSON.parse(text);
-				assert.isTrue(result.isDragging, 'should be in a drag state');
-				assert.deepEqual(result.delta, { x: 50, y: 50 }, 'should have dragged expected distance');
-			})
-			.releaseMouseButton()
-			.sleep(50)
-			.getVisibleText()
-			.then((text) => {
-				const result: DragResults = JSON.parse(text);
-				assert.isFalse(result.isDragging, 'should be no longer dragging');
-				assert.deepEqual(result.delta, { x: 0, y: 0 }, 'should have dragged expected distance');
-			});
 	}
 });

--- a/tests/core/functional/middleware/drag.html
+++ b/tests/core/functional/middleware/drag.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Drag Middleware Test</title>
+</head>
+<body>
+<script src="../../../../src/shim/util/amd.js"></script>
+<script src="../../../../../node_modules/@dojo/loader/loader.js"></script>
+<script>
+    require.config(shimAmdDependencies({
+        baseUrl: '../../../../../',
+        packages: [
+            { name: 'src', location: 'dist/dev/src' },
+            { name: 'tests', location: 'dist/dev/tests' }
+        ]
+    }));
+
+    require(['src/shim/main', 'src/shim/browser'], function () {
+        require([ 'tests/core/functional/middleware/drag' ], function () {});
+    });
+</script>
+</body>
+</html>

--- a/tests/core/functional/middleware/drag.ts
+++ b/tests/core/functional/middleware/drag.ts
@@ -1,0 +1,25 @@
+import { drag } from '../../../../src/core/middleware/drag';
+import renderer, { create, v, w } from '../../../../src/core/vdom';
+
+const factory = create({ drag });
+const DragExample = factory(function DragExample({ middleware: { drag } }) {
+	const dragResults = drag.get('root');
+	return v(
+		'div',
+		{
+			key: 'root',
+			styles: {
+				'background-color': dragResults.isDragging ? 'green' : 'white',
+				border: '1px solid black',
+				color: dragResults.isDragging ? 'white' : 'black',
+				height: '400px',
+				'user-select': 'none',
+				width: '200px'
+			}
+		},
+		[v('pre', { id: 'results' }, [JSON.stringify(dragResults, null, '  ')])]
+	);
+});
+
+const r = renderer(() => w(DragExample, {}));
+r.mount();

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -2,6 +2,7 @@ import './block';
 import './breakpoint';
 import './cache';
 import './dimensions';
+import './drag';
 import './i18n';
 import './focus';
 import './icache';

--- a/tests/core/unit/middleware/drag.ts
+++ b/tests/core/unit/middleware/drag.ts
@@ -1,0 +1,662 @@
+import { sandbox, SinonSpy } from 'sinon';
+import { drag } from '../../../../src/core/middleware/drag';
+import global from '../../../../src/shim/global';
+const { it, afterEach, beforeEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+const { describe } = intern.getPlugin('jsdom');
+
+const sb = sandbox.create();
+const nodeStub = {
+	get: sb.stub()
+};
+const invalidatorStub = sb.stub();
+
+const domNode = {
+	style: {
+		touchAction: ''
+	},
+	setAttribute: sb.stub()
+};
+
+const emptyResult = {
+	isDragging: false,
+	delta: { x: 0, y: 0 }
+};
+
+let oldEventListener: any;
+
+function createEvent(coords: Partial<PointerEvent>) {
+	return {
+		target: domNode,
+		bubbles: true,
+		isPrimary: true,
+		button: 0,
+		clientX: 0,
+		clientY: 0,
+		offsetX: 0,
+		offsetY: 0,
+		pageX: 0,
+		pageY: 0,
+		screenX: 0,
+		screenY: 0,
+		preventDefault: sb.stub(),
+		stopPropagation: sb.stub(),
+		...coords
+	};
+}
+
+describe('drag middleware', () => {
+	beforeEach(() => {
+		oldEventListener = global.window.addEventListener;
+		global.window.addEventListener = sb.stub();
+	});
+
+	afterEach(() => {
+		global.window.addEventListener = oldEventListener;
+
+		sb.resetHistory();
+		domNode.style.touchAction = '';
+	});
+
+	it('should override touch action', () => {
+		const { callback } = drag();
+		nodeStub.get.withArgs('root').returns(domNode);
+
+		const d = callback({
+			id: 'test',
+			middleware: {
+				node: nodeStub,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		const results = d.get('root');
+
+		assert.deepEqual(results, emptyResult, 'Should have returned an empty result');
+		assert.equal(domNode.style.touchAction, 'none', 'Should have set touch-action type to none');
+		assert.isTrue(
+			domNode.setAttribute.calledWith('touch-action', 'none'),
+			'Should have set touch-action attribute to none'
+		);
+	});
+
+	it('drags a node with the pointer', () => {
+		const { callback } = drag();
+		nodeStub.get.withArgs('root').returns(domNode);
+
+		const d = callback({
+			id: 'test',
+			middleware: {
+				node: nodeStub,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		d.get('root');
+
+		const pointerDown = global.window.addEventListener.getCall(0).args[1];
+		const pointerMove = global.window.addEventListener.getCall(1).args[1];
+		const pointerUp = global.window.addEventListener.getCall(2).args[1];
+
+		const downEvent = createEvent({
+			clientX: 100,
+			clientY: 50,
+			offsetX: 10,
+			offsetY: 5,
+			pageX: 100,
+			pageY: 50,
+			screenX: 1100,
+			screenY: 1050
+		});
+
+		pointerDown(downEvent);
+
+		assert.isTrue((downEvent.preventDefault as SinonSpy).called);
+		assert.isTrue((downEvent.stopPropagation as SinonSpy).called);
+
+		const downResult = d.get('root');
+		assert.deepEqual(downResult, {
+			isDragging: true,
+			delta: { x: 0, y: 0 },
+			start: {
+				client: {
+					x: 100,
+					y: 50
+				},
+				offset: {
+					x: 10,
+					y: 5
+				},
+				page: {
+					x: 100,
+					y: 50
+				},
+				screen: {
+					x: 1100,
+					y: 1050
+				}
+			}
+		});
+
+		const moveEvent = createEvent({
+			clientX: 110,
+			clientY: 55,
+			offsetX: 10,
+			offsetY: 5,
+			pageX: 110,
+			pageY: 55,
+			screenX: 1100,
+			screenY: 1050
+		});
+
+		pointerMove(moveEvent);
+
+		assert.isTrue((moveEvent.preventDefault as SinonSpy).called);
+		assert.isTrue((moveEvent.stopPropagation as SinonSpy).called);
+
+		const moveResult = d.get('root');
+		assert.deepEqual(moveResult, {
+			isDragging: true,
+			delta: { x: 10, y: 5 },
+			start: {
+				client: {
+					x: 100,
+					y: 50
+				},
+				offset: {
+					x: 10,
+					y: 5
+				},
+				page: {
+					x: 100,
+					y: 50
+				},
+				screen: {
+					x: 1100,
+					y: 1050
+				}
+			}
+		});
+
+		pointerMove(
+			createEvent({
+				clientX: 115,
+				clientY: 65,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 115,
+				pageY: 65,
+				screenX: 1100,
+				screenY: 1050
+			})
+		);
+
+		const move2Result = d.get('root');
+		assert.deepEqual(move2Result, {
+			isDragging: true,
+			delta: { x: 5, y: 10 },
+			start: {
+				client: {
+					x: 110,
+					y: 55
+				},
+				offset: {
+					x: 10,
+					y: 5
+				},
+				page: {
+					x: 110,
+					y: 55
+				},
+				screen: {
+					x: 1100,
+					y: 1050
+				}
+			}
+		});
+
+		const upEvent = createEvent({
+			clientX: 120,
+			clientY: 70,
+			offsetX: 10,
+			offsetY: 5,
+			pageX: 120,
+			pageY: 70,
+			screenX: 1100,
+			screenY: 1050
+		});
+
+		pointerUp(upEvent);
+
+		const upResult = d.get('root');
+		assert.deepEqual(upResult, {
+			isDragging: false,
+			delta: { x: 5, y: 5 },
+			start: {
+				client: {
+					x: 115,
+					y: 65
+				},
+				offset: {
+					x: 10,
+					y: 5
+				},
+				page: {
+					x: 115,
+					y: 65
+				},
+				screen: {
+					x: 1100,
+					y: 1050
+				}
+			}
+		});
+	});
+
+	it('accumulates movements across renders', () => {
+		const { callback } = drag();
+		nodeStub.get.withArgs('root').returns(domNode);
+
+		const d = callback({
+			id: 'test',
+			middleware: {
+				node: nodeStub,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		d.get('root');
+
+		const pointerDown = global.window.addEventListener.getCall(0).args[1];
+		const pointerMove = global.window.addEventListener.getCall(1).args[1];
+
+		pointerDown(
+			createEvent({
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 100,
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
+			})
+		);
+
+		d.get('root');
+
+		pointerMove(
+			createEvent({
+				clientX: 110,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 110,
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
+			})
+		);
+
+		pointerMove(
+			createEvent({
+				clientX: 115,
+				clientY: 60,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 115,
+				pageY: 60,
+				screenX: 1100,
+				screenY: 1050
+			})
+		);
+
+		const result = d.get('root');
+
+		assert.deepEqual(result, {
+			isDragging: true,
+			delta: { x: 15, y: 10 },
+			start: {
+				client: {
+					x: 100,
+					y: 50
+				},
+				offset: {
+					x: 10,
+					y: 5
+				},
+				page: {
+					x: 100,
+					y: 50
+				},
+				screen: {
+					x: 1100,
+					y: 1050
+				}
+			}
+		});
+	});
+
+	it('render not done between drag and pointer up should be cumulative', () => {
+		const { callback } = drag();
+		nodeStub.get.withArgs('root').returns(domNode);
+
+		const d = callback({
+			id: 'test',
+			middleware: {
+				node: nodeStub,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		d.get('root');
+
+		const pointerDown = global.window.addEventListener.getCall(0).args[1];
+		const pointerMove = global.window.addEventListener.getCall(1).args[1];
+		const pointerUp = global.window.addEventListener.getCall(2).args[1];
+
+		pointerDown(
+			createEvent({
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 100,
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
+			})
+		);
+
+		d.get('root');
+
+		pointerMove(
+			createEvent({
+				clientX: 110,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 110,
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
+			})
+		);
+
+		pointerMove(
+			createEvent({
+				clientX: 115,
+				clientY: 60,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 115,
+				pageY: 60,
+				screenX: 1100,
+				screenY: 1050
+			})
+		);
+
+		pointerUp(
+			createEvent({
+				clientX: 120,
+				clientY: 70,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 120,
+				pageY: 70,
+				screenX: 1100,
+				screenY: 1050
+			})
+		);
+
+		const result = d.get('root');
+
+		assert.deepEqual(result, {
+			isDragging: false,
+			delta: { x: 20, y: 20 },
+			start: {
+				client: {
+					x: 100,
+					y: 50
+				},
+				offset: {
+					x: 10,
+					y: 5
+				},
+				page: {
+					x: 100,
+					y: 50
+				},
+				screen: {
+					x: 1100,
+					y: 1050
+				}
+			}
+		});
+	});
+
+	it('ignores movement if start event is not present', () => {
+		const { callback } = drag();
+		nodeStub.get.withArgs('root').returns(domNode);
+
+		const d = callback({
+			id: 'test',
+			middleware: {
+				node: nodeStub,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		d.get('root');
+
+		const pointerMove = global.window.addEventListener.getCall(1).args[1];
+		const pointerUp = global.window.addEventListener.getCall(2).args[1];
+
+		const moveEvent = createEvent({});
+
+		pointerMove(moveEvent);
+		assert.isFalse((moveEvent.preventDefault as SinonSpy).called);
+		assert.isFalse((moveEvent.stopPropagation as SinonSpy).called);
+
+		const upEvent = createEvent({});
+
+		pointerUp(upEvent);
+		assert.isFalse((upEvent.preventDefault as SinonSpy).called);
+		assert.isFalse((upEvent.stopPropagation as SinonSpy).called);
+	});
+
+	it('dragging where descendent is target', () => {
+		const { callback } = drag();
+		nodeStub.get.withArgs('root').returns(domNode);
+
+		const d = callback({
+			id: 'test',
+			middleware: {
+				node: nodeStub,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		d.get('root');
+
+		const pointerDown = global.window.addEventListener.getCall(0).args[1];
+
+		pointerDown(
+			createEvent({
+				target: {
+					parentElement: domNode
+				} as any
+			})
+		);
+
+		const result = d.get('root');
+
+		assert.deepEqual(result, {
+			isDragging: true,
+			delta: { x: 0, y: 0 },
+			start: {
+				client: {
+					x: 0,
+					y: 0
+				},
+				offset: {
+					x: 0,
+					y: 0
+				},
+				page: {
+					x: 0,
+					y: 0
+				},
+				screen: {
+					x: 0,
+					y: 0
+				}
+			}
+		});
+	});
+
+	it('dragging untracked node should not report results', () => {
+		const { callback } = drag();
+		nodeStub.get.withArgs('root').returns(domNode);
+
+		const d = callback({
+			id: 'test',
+			middleware: {
+				node: nodeStub,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		d.get('root');
+
+		const pointerDown = global.window.addEventListener.getCall(0).args[1];
+
+		const event = createEvent({
+			target: {} as any
+		});
+
+		pointerDown(event);
+
+		assert.isFalse((event.preventDefault as SinonSpy).called);
+		assert.isFalse((event.stopPropagation as SinonSpy).called);
+	});
+
+	it('ignores drag events from non-primary events', () => {
+		const { callback } = drag();
+		nodeStub.get.withArgs('root').returns(domNode);
+
+		const d = callback({
+			id: 'test',
+			middleware: {
+				node: nodeStub,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		d.get('root');
+
+		const pointerDown = global.window.addEventListener.getCall(0).args[1];
+
+		const downEvent = createEvent({
+			isPrimary: false,
+			button: 1
+		});
+
+		pointerDown(downEvent);
+
+		assert.isFalse((downEvent.preventDefault as SinonSpy).called);
+		assert.isFalse((downEvent.stopPropagation as SinonSpy).called);
+	});
+
+	it('should stop dragging on two finger touch', () => {
+		const { callback } = drag();
+		nodeStub.get.withArgs('root').returns(domNode);
+
+		const d = callback({
+			id: 'test',
+			middleware: {
+				node: nodeStub,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		d.get('root');
+
+		const pointerDown = global.window.addEventListener.getCall(0).args[1];
+
+		pointerDown(
+			createEvent({
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 100,
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
+			})
+		);
+
+		const result1 = d.get('root');
+
+		assert.deepEqual(result1, {
+			isDragging: true,
+			delta: { x: 0, y: 0 },
+			start: {
+				client: {
+					x: 100,
+					y: 50
+				},
+				offset: {
+					x: 10,
+					y: 5
+				},
+				page: {
+					x: 100,
+					y: 50
+				},
+				screen: {
+					x: 1100,
+					y: 1050
+				}
+			}
+		});
+
+		pointerDown({
+			isPrimary: false,
+			clientX: 100,
+			clientY: 50,
+			offsetX: 10,
+			offsetY: 5,
+			pageX: 100,
+			pageY: 50,
+			screenX: 1100,
+			screenY: 1050
+		});
+
+		const result2 = d.get('root');
+
+		assert.deepEqual(result2, {
+			isDragging: false,
+			delta: { x: 0, y: 0 }
+		});
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Converting `Drag` meta to `drag` middleware. This is basically a direct port of the drag meta. I tried a few ways to be clever but having a single copy of the event listeners, like this has, seemed like a better way to go.

Resolves #514 
