### PR TITLE
Properly invalidate if required attribute/property changes

### DIFF
--- a/src/core/meta/InputValidity.ts
+++ b/src/core/meta/InputValidity.ts
@@ -1,14 +1,15 @@
 import Base from './Base';
 
 export class InputValidity extends Base {
-	get(key: string | number, value: string) {
+	get(key: string | number, value: string, required: boolean) {
 		const node = this.getNode(key) as HTMLFormElement | undefined;
 
 		if (!node) {
 			return { valid: undefined, message: '' };
 		}
 
-		if (value !== node.value) {
+		const nodeRequired = node.attributes.getNamedItem('required');
+		if (value !== node.value && required !== Boolean(nodeRequired && nodeRequired.value)) {
 			// if the vdom is out of sync with the real dom our
 			// validation check will be one render behind.
 			// Call invalidate on the next loop.

--- a/src/core/middleware/validity.ts
+++ b/src/core/middleware/validity.ts
@@ -4,14 +4,15 @@ const factory = create({ node, invalidator });
 
 const validity = factory(function({ middleware: { node, invalidator } }) {
 	return {
-		get(key: string | number, value: string) {
+		get(key: string | number, value: string, required: boolean) {
 			const domNode = node.get(key) as HTMLFormElement | undefined;
 
 			if (!domNode) {
 				return { valid: undefined, message: '' };
 			}
 
-			if (value !== domNode.value) {
+			const nodeRequired = domNode.attributes.getNamedItem('required');
+			if (value !== domNode.value && required !== Boolean(nodeRequired && nodeRequired.value)) {
 				setTimeout(() => invalidator());
 			}
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Current `InputValidity` meta and `validity` middleware do not invalidate when the required status of a field changes. This results in an outside trigger being required before the correct validity is captured.

This change, which is breaking, takes the expected `required` value and compares it to the `required` attribute on the `HTMLFormElement` node. If they do not match, it invalidates (same behavior as when the values do not match).