### PR TITLE
Add some missing jsdoc for property interfaces

### DIFF
--- a/src/core/mixins/Focus.ts
+++ b/src/core/mixins/Focus.ts
@@ -3,7 +3,8 @@ import { WidgetBase } from './../WidgetBase';
 import { diffProperty } from './../decorators/diffProperty';
 
 export interface FocusProperties {
-	focus?: (() => boolean);
+	/** Function to determine if the widget should focus */
+	focus?: () => boolean;
 }
 
 export interface FocusMixin {

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -38,7 +38,7 @@ export interface ThemedProperties<T = ClassNames> {
 	theme?: Theme;
 	/** Map of widget keys and associated overriding classes */
 	classes?: Classes;
-	/** Extra classes for to be applied to the widget */
+	/** Extra classes to be applied to the widget */
 	extraClasses?: { [P in keyof T]?: string };
 }
 

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -34,8 +34,11 @@ export interface Classes {
  * Properties required for the Themed mixin
  */
 export interface ThemedProperties<T = ClassNames> {
+	/** Overriding custom theme for the widget */
 	theme?: Theme;
+	/** Map of widget keys and associated overriding classes */
 	classes?: Classes;
+	/** Extra classes for to be applied to the widget */
 	extraClasses?: { [P in keyof T]?: string };
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add JsDoc for property interfaces.