### PR TITLE
Decouple Theme and I18n Middleware and Mixins

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -1,3 +1,5 @@
+/* tslint:disable:interface-name */
+import { Bundle, Messages } from '../i18n/i18n';
 import { Destroyable } from '../core/Destroyable';
 import { Evented, EventType, EventObject } from '../core/Evented';
 import Map from '../shim/Map';
@@ -113,6 +115,20 @@ export interface Projection {
 }
 
 export type SupportedClassName = string | null | undefined | boolean;
+
+export type ClassNames = {
+	[key: string]: string;
+};
+
+export interface Theme {
+	[key: string]: object;
+}
+
+export interface Classes {
+	[widgetKey: string]: {
+		[classKey: string]: SupportedClassName[];
+	};
+}
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 
@@ -601,3 +617,55 @@ export interface AfterRender {
 export interface BeforeProperties<P = any> {
 	(properties: P): P;
 }
+
+export interface LocaleData {
+	/**
+	 * The locale for the widget. If not specified, then the root locale (as determined by `@dojo/i18n`) is assumed.
+	 * If specified, the widget's node will have a `lang` property set to the locale.
+	 */
+	locale?: string;
+
+	/**
+	 * An optional flag indicating the widget's text direction. If `true`, then the underlying node's `dir`
+	 * property is set to "rtl". If it is `false`, then the `dir` property is set to "ltr". Otherwise, the property
+	 * is not set.
+	 */
+	rtl?: boolean;
+}
+
+export interface I18nProperties extends LocaleData {
+	/**
+	 * An optional override for the bundle passed to the `localizeBundle`. If the override contains a `messages` object,
+	 * then it will completely replace the underlying bundle. Otherwise, a new bundle will be created with the additional
+	 * locale loaders.
+	 */
+	i18nBundle?: Bundle<Messages> | Map<Bundle<Messages>, Bundle<Messages>>;
+}
+
+export type LocalizedMessages<T extends Messages> = {
+	/**
+	 * Indicates whether the messages are placeholders while waiting for the actual localized messages to load.
+	 * This is always `false` if the associated bundle does not list any supported locales.
+	 */
+	readonly isPlaceholder: boolean;
+
+	/**
+	 * Formats an ICU-formatted message template for the represented bundle.
+	 *
+	 * @param key
+	 * The message key.
+	 *
+	 * @param options
+	 * The values to pass to the formatter.
+	 *
+	 * @return
+	 * The formatted string.
+	 */
+	format(key: string, options?: any): string;
+
+	/**
+	 * The localized messages if available, or either the default messages or a blank bundle depending on the
+	 * call signature for `localizeBundle`.
+	 */
+	readonly messages: T;
+};

--- a/src/core/middleware/i18n.ts
+++ b/src/core/middleware/i18n.ts
@@ -4,7 +4,20 @@ import { create, invalidator, getRegistry } from '../vdom';
 import injector from './injector';
 import Map from '../../shim/Map';
 import Injector from '../Injector';
-import { I18nProperties, LocaleData, LocalizedMessages, INJECTOR_KEY, registerI18nInjector } from '../mixins/I18n';
+import Registry from '../Registry';
+import { I18nProperties, LocalizedMessages, LocaleData } from '../interfaces';
+export { LocalizedMessages, I18nProperties, LocaleData } from './../interfaces';
+
+export const INJECTOR_KEY = '__i18n_injector';
+
+export function registerI18nInjector(localeData: LocaleData, registry: Registry): Injector {
+	const injector = new Injector(localeData);
+	registry.defineInjector(INJECTOR_KEY, (invalidator) => {
+		injector.setInvalidator(invalidator);
+		return () => injector;
+	});
+	return injector;
+}
 
 const factory = create({ invalidator, injector, getRegistry }).properties<I18nProperties>();
 

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -1,28 +1,44 @@
+import { Theme, Classes, ClassNames } from './../interfaces';
 import { create, invalidator, diffProperty, getRegistry } from '../vdom';
 import cache from './cache';
 import injector from './injector';
 import Injector from '../Injector';
 import Set from '../../shim/Set';
-import { registerThemeInjector, Theme, Classes, ClassNames, INJECTED_THEME_KEY, THEME_KEY } from '../mixins/Themed';
 import { shallow } from '../diff';
+import Registry from '../Registry';
 
-export interface ThemedProperties {
+export { Theme, Classes, ClassNames } from './../interfaces';
+
+export interface ThemeProperties {
 	theme?: Theme;
 	classes?: Classes;
 }
 
-const factory = create({ invalidator, cache, diffProperty, injector, getRegistry }).properties<ThemedProperties>();
+export const THEME_KEY = ' _key';
+
+export const INJECTED_THEME_KEY = '__theme_injector';
+
+function registerThemeInjector(theme: any, themeRegistry: Registry): Injector {
+	const themeInjector = new Injector(theme);
+	themeRegistry.defineInjector(INJECTED_THEME_KEY, (invalidator) => {
+		themeInjector.setInvalidator(invalidator);
+		return () => themeInjector;
+	});
+	return themeInjector;
+}
+
+const factory = create({ invalidator, cache, diffProperty, injector, getRegistry }).properties<ThemeProperties>();
 
 export const theme = factory(
 	({ middleware: { invalidator, cache, diffProperty, injector, getRegistry }, properties }) => {
 		let themeKeys = new Set();
-		diffProperty('theme', (current: ThemedProperties, next: ThemedProperties) => {
+		diffProperty('theme', (current: ThemeProperties, next: ThemeProperties) => {
 			if (current.theme !== next.theme) {
 				cache.clear();
 				invalidator();
 			}
 		});
-		diffProperty('classes', (current: ThemedProperties, next: ThemedProperties) => {
+		diffProperty('classes', (current: ThemeProperties, next: ThemeProperties) => {
 			let result = false;
 			if ((current.classes && !next.classes) || (!current.classes && next.classes)) {
 				result = true;

--- a/src/core/mixins/I18n.ts
+++ b/src/core/mixins/I18n.ts
@@ -4,74 +4,15 @@ import Map from '../../shim/Map';
 import { isVNode } from './../vdom';
 import { afterRender } from './../decorators/afterRender';
 import { inject } from './../decorators/inject';
-import { Constructor, DNode, VNodeProperties } from './../interfaces';
+import { Constructor, DNode, VNodeProperties, LocalizedMessages, I18nProperties, LocaleData } from './../interfaces';
 import { Injector } from './../Injector';
 import { Registry } from './../Registry';
 import { WidgetBase } from './../WidgetBase';
 import { decorate } from '../util';
 
+export { LocalizedMessages, I18nProperties, LocaleData } from './../interfaces';
+
 export const INJECTOR_KEY = '__i18n_injector';
-
-export interface LocaleData {
-	/**
-	 * The locale for the widget. If not specified, then the root locale (as determined by `@dojo/i18n`) is assumed.
-	 * If specified, the widget's node will have a `lang` property set to the locale.
-	 */
-	locale?: string;
-
-	/**
-	 * An optional flag indicating the widget's text direction. If `true`, then the underlying node's `dir`
-	 * property is set to "rtl". If it is `false`, then the `dir` property is set to "ltr". Otherwise, the property
-	 * is not set.
-	 */
-	rtl?: boolean;
-}
-
-export interface I18nProperties extends LocaleData {
-	/**
-	 * An optional override for the bundle passed to the `localizeBundle`. If the override contains a `messages` object,
-	 * then it will completely replace the underlying bundle. Otherwise, a new bundle will be created with the additional
-	 * locale loaders.
-	 */
-	i18nBundle?: Bundle<Messages> | Map<Bundle<Messages>, Bundle<Messages>>;
-}
-
-/**
- * @private
- * An internal helper interface for defining locale and text direction attributes on widget nodes.
- */
-interface I18nVNodeProperties extends VNodeProperties {
-	dir: string;
-	lang: string;
-}
-
-export type LocalizedMessages<T extends Messages> = {
-	/**
-	 * Indicates whether the messages are placeholders while waiting for the actual localized messages to load.
-	 * This is always `false` if the associated bundle does not list any supported locales.
-	 */
-	readonly isPlaceholder: boolean;
-
-	/**
-	 * Formats an ICU-formatted message template for the represented bundle.
-	 *
-	 * @param key
-	 * The message key.
-	 *
-	 * @param options
-	 * The values to pass to the formatter.
-	 *
-	 * @return
-	 * The formatted string.
-	 */
-	format(key: string, options?: any): string;
-
-	/**
-	 * The localized messages if available, or either the default messages or a blank bundle depending on the
-	 * call signature for `localizeBundle`.
-	 */
-	readonly messages: T;
-};
 
 /**
  * interface for I18n functionality
@@ -92,6 +33,15 @@ export interface I18nMixin {
 	localizeBundle<T extends Messages>(bundle: Bundle<T>): LocalizedMessages<T>;
 
 	properties: I18nProperties;
+}
+
+/**
+ * @private
+ * An internal helper interface for defining locale and text direction attributes on widget nodes.
+ */
+interface I18nVNodeProperties extends VNodeProperties {
+	dir: string;
+	lang: string;
 }
 
 export function registerI18nInjector(localeData: LocaleData, registry: Registry): Injector {

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -1,4 +1,4 @@
-import { Constructor, SupportedClassName } from './../interfaces';
+import { Theme, Classes, ClassNames, Constructor, SupportedClassName } from './../interfaces';
 import { Registry } from './../Registry';
 import { Injector } from './../Injector';
 import { inject } from './../decorators/inject';
@@ -7,28 +7,7 @@ import { handleDecorator } from './../decorators/handleDecorator';
 import { diffProperty } from './../decorators/diffProperty';
 import { shallow } from './../diff';
 
-/**
- * A lookup object for available class names
- */
-export type ClassNames = {
-	[key: string]: string;
-};
-
-/**
- * A lookup object for available widget classes names
- */
-export interface Theme {
-	[key: string]: object;
-}
-
-/**
- * Classes property interface
- */
-export interface Classes {
-	[widgetKey: string]: {
-		[classKey: string]: SupportedClassName[];
-	};
-}
+export { Theme, Classes, ClassNames } from './../interfaces';
 
 /**
  * Properties required for the Themed mixin


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The `theme` and `i18n` middlewares are currently coupled to their equivalent mixin. This is strange for users as they would need to import interfaces from a mixin when using a middleware and also result in the mixin and it's dependencies being included in an application bundle.
