### PR TITLE
Use typeof to support vdom module being loaded without build tooling

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -232,7 +232,7 @@ const VNODE = '__VNODE_TYPE';
 const DOMVNODE = '__DOMVNODE_TYPE';
 
 // @ts-ignore
-const scope = typeof __DOJO_SCOPE === 'string' ? __DOJO_SCOPE : 'dojo';
+const scope = typeof __DOJO_SCOPE === 'string' ? __DOJO_SCOPE : 'dojo_scope';
 
 if (!global[scope]) {
 	global[scope] = {};

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -232,7 +232,7 @@ const VNODE = '__VNODE_TYPE';
 const DOMVNODE = '__DOMVNODE_TYPE';
 
 // @ts-ignore
-const scope = __DOJO_SCOPE;
+const scope = typeof __DOJO_SCOPE === 'string' ? __DOJO_SCOPE : 'dojo';
 
 if (!global[scope]) {
 	global[scope] = {};

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -6405,27 +6405,27 @@ jsdomDescribe('vdom', () => {
 
 	describe('render hooks', () => {
 		beforeEach(() => {
-			global.dojo = {};
+			global.dojo_scope = {};
 		});
 
 		it('set rendering', () => {
-			assert.strictEqual(global.dojo.rendering, undefined);
+			assert.strictEqual(global.dojo_scope.rendering, undefined);
 			setRendering(true);
-			assert.strictEqual(global.dojo.rendering, true);
+			assert.strictEqual(global.dojo_scope.rendering, true);
 			setRendering(false);
-			assert.strictEqual(global.dojo.rendering, false);
+			assert.strictEqual(global.dojo_scope.rendering, false);
 		});
 
 		it('block count', () => {
-			assert.strictEqual(global.dojo.blocksPending, undefined);
+			assert.strictEqual(global.dojo_scope.blocksPending, undefined);
 			incrementBlockCount();
-			assert.strictEqual(global.dojo.blocksPending, 1);
+			assert.strictEqual(global.dojo_scope.blocksPending, 1);
 			incrementBlockCount();
-			assert.strictEqual(global.dojo.blocksPending, 2);
+			assert.strictEqual(global.dojo_scope.blocksPending, 2);
 			decrementBlockCount();
-			assert.strictEqual(global.dojo.blocksPending, 1);
+			assert.strictEqual(global.dojo_scope.blocksPending, 1);
 			decrementBlockCount();
-			assert.strictEqual(global.dojo.blocksPending, 0);
+			assert.strictEqual(global.dojo_scope.blocksPending, 0);
 		});
 	});
 

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -6405,27 +6405,27 @@ jsdomDescribe('vdom', () => {
 
 	describe('render hooks', () => {
 		beforeEach(() => {
-			global.dojo_test_scope = {};
+			global.dojo = {};
 		});
 
 		it('set rendering', () => {
-			assert.strictEqual(global.dojo_test_scope.rendering, undefined);
+			assert.strictEqual(global.dojo.rendering, undefined);
 			setRendering(true);
-			assert.strictEqual(global.dojo_test_scope.rendering, true);
+			assert.strictEqual(global.dojo.rendering, true);
 			setRendering(false);
-			assert.strictEqual(global.dojo_test_scope.rendering, false);
+			assert.strictEqual(global.dojo.rendering, false);
 		});
 
 		it('block count', () => {
-			assert.strictEqual(global.dojo_test_scope.blocksPending, undefined);
+			assert.strictEqual(global.dojo.blocksPending, undefined);
 			incrementBlockCount();
-			assert.strictEqual(global.dojo_test_scope.blocksPending, 1);
+			assert.strictEqual(global.dojo.blocksPending, 1);
 			incrementBlockCount();
-			assert.strictEqual(global.dojo_test_scope.blocksPending, 2);
+			assert.strictEqual(global.dojo.blocksPending, 2);
 			decrementBlockCount();
-			assert.strictEqual(global.dojo_test_scope.blocksPending, 1);
+			assert.strictEqual(global.dojo.blocksPending, 1);
 			decrementBlockCount();
-			assert.strictEqual(global.dojo_test_scope.blocksPending, 0);
+			assert.strictEqual(global.dojo.blocksPending, 0);
 		});
 	});
 

--- a/tests/shim/support/has-plugin.ts
+++ b/tests/shim/support/has-plugin.ts
@@ -6,16 +6,13 @@ intern.registerPlugin('has', () => {
 	};
 	if (typeof global !== 'undefined') {
 		(global as any).DojoHasEnvironment = DojoHasEnvironment;
-		(global as any).__DOJO_SCOPE = 'dojo_test_scope';
 	}
 
 	if (typeof self !== 'undefined') {
 		(self as any).DojoHasEnvironment = DojoHasEnvironment;
-		(self as any).__DOJO_SCOPE = 'dojo_test_scope';
 	}
 
 	if (typeof window !== 'undefined') {
 		(window as any).DojoHasEnvironment = DojoHasEnvironment;
-		(window as any).__DOJO_SCOPE = 'dojo_test_scope';
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Using `typeof` allows using `__DOJO_SCOPE` without dojo build tooling, instead of throwing error `VM69:2 Uncaught ReferenceError: __DOJO_SCOPE is not defined`