### PR TITLE
Missing edge case for children typing

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -427,7 +427,7 @@ export interface MiddlewareResultFactory<Props, Children, Middleware, ReturnValu
 export interface DefaultChildrenWNodeFactory<W extends WNodeFactoryTypes> {
 	(properties: W['properties'], children?: W['children'] extends any[] ? W['children'] : [W['children']]): WNode<W>;
 	new (): {
-		__properties__: W['properties'] & { __children__?: DNode | DNode[] };
+		__properties__: W['properties'] & { __children__?: DNode | DNode[] | (DNode | DNode[])[] };
 	};
 	properties: W['properties'];
 	children: W['children'];
@@ -473,7 +473,7 @@ export interface WNode<W extends WidgetBaseTypes = any> {
 	/**
 	 * DNode children
 	 */
-	children: any[];
+	children: DNode[];
 
 	/**
 	 * The type of node


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

TSX supports a mix of `DNode` and `DNode[]` which needs to be included in the default typing. Also the children of `WNode` should be `DNode[]`, this was mistakenly changed to `any[]` with the initial children typing PR.