### PR TITLE
Backport Simplified Chinese Content

### DIFF
--- a/docs/zh-CN/building/introduction.md
+++ b/docs/zh-CN/building/introduction.md
@@ -1,0 +1,91 @@
+# 介绍
+
+<!--
+https://github.com/dojo/framework/blob/master/docs/en/building/introduction.md
+commit b8e0228c4025cb803d1c56521b054f6d5e6dfdb2
+-->
+
+Dojo 提供了一套强大的命令行工具，让构建现代应用程序更加简单。
+
+可以自动创建包（Bundle），可以使用 PWA 在本地缓存文件，可以在构建阶段渲染初始的 HTML 和 CSS，也可以使用 Dojo 的 CLI 工具和 `.dojorc` 配置文件按条件忽略一些代码。或者脱离（eject） Dojo 的构建工具，直接使用底层的构建工具以做到完全掌控。
+
+| 功能               | 描述                                                                                                                                                                                                 |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Dojo CLI**       | 模块化的命令行工具，用于快速启动新的应用程序、创建部件和运行测试等。                                                                                                                                 |
+| **开发服务器**     | 开发时使用的本地 web 服务器，用于监听文件系统，当检测到变化时会自动重新构建。也支持 HTTPS 和设置代理。                                                                                               |
+| **包(bundle)**     | 通过减少用户需要下载的内容和优化用户实际需要的应用程序交互时间（Time-to-Interactive）以提高用户体验。可以根据路由自动创建包，或者在配置文件中明确定义包。                                            |
+| **按条件纳入代码** | 通过 `.dojorc` 配置文件可以静态方式关闭或打开使用 dojo/has 定义的功能。由于这些配置而无法访问到的代码分支会被自动忽略掉。这就很容易为特定目标（如 IE11 或 mobile）提供特定功能，而不会影响包的大小。 |
+| **PWA 支持**       | 渐进式 Web 应用程序通过缓存内容甚至脱机工作，创建更快、更可靠的用户体验。通过配置文件或者在代码中定义，dojo 很容易创建一个 service work，并将其构建为应用程序的一部分。                              |
+| **构建时渲染**     | 在构建时渲染路由以生成初始的 HTML 和 CSS。在构建时渲染，Dojo 可以节省出初始渲染的成本，创建出一个响应性更高的应用程序，且不会引入额外的复杂性。                                                      |
+
+# 基本用法
+
+Dojo 提供了一组 CLI 命令，辅助创建和构建应用程序。本指南假设已全局安装 `@dojo/cli`，且在项目中安装了 [@dojo/cli-build-app](https://github.com/dojo/cli-build-app) 和 [@dojo/cli-test-intern](https://github.com/dojo/cli-test-intern)。如果项目是使用 [@dojo/cli-create-app](https://github.com/dojo/cli-create-app) 初始化的，那么这些依赖应该已经存在。
+
+## 构建
+
+Dojo 的 CLI 工具支持多种构建目标或 `mode`。在 `dojo create app` 为 `package.json` 生成的几个脚本（scripts）中可看到所有模式。
+
+运行以下命令，创建一个为生产环境优化过的构建。
+
+```bash
+> dojo build --mode dist
+```
+
+此次构建使用 `dist` 模式创建应用程序包，并将结果输出到 `output/dist` 目录中。
+
+## 运行服务和监听变化
+
+当在 `dev` 或 `dist` 模式下运行时，可以使用 `--serve` 标记启动一个 web 服务器。应用程序默认运行在 9999 端口上。可以使用 `--port` 标记修改端口。使用 `--watch` 标记，Dojo 的构建工具也可以监听应用程序的变化并自动重新构建。
+
+生成的 `package.json` 文件中包含 `dev` 脚本，它使用这些标记运行应用程序的构建版本，并监听到磁盘上的文件发生变化后会自动重新构建。
+
+```bash
+> dojo build --mode dev --watch file --serve
+```
+
+应用程序也会提供 source map。这样调试器就可以将构建的 JavaScript 代码映射回位于 `src/` 文件夹下原本的 TypeScript 代码上。
+
+## 测试
+
+Dojo 使用 [Intern](https://theintern.io/) 运行单元和功能测试。
+
+T 运行 `tests/unit` 中单元测试的最快方式，是使用新建 Dojo 应用程序时创建的 NPM 脚本。
+
+> 命令行
+
+```bash
+# execute unit tests
+npm run test:unit
+# execute functional tests locally using headless Chrome and Selenium
+npm run test:functional
+```
+
+## 支持的浏览器
+
+Dojo 是一个持续演变的框架。默认情况下，发布的 dojo 版本会支持最新浏览器的最近两个版本。Dojo 要跨浏览器实现标准功能，其所需的 polyfill 都是通过 `@dojo/framework/shim` 按需提供的。要支持 IE11，需要打开 `--legacy` 标记。
+
+# Dojo 配置
+
+可在 `.dojorc` 中添加其它配置选项。这些选项通常通过命令行扩展可用的设置，并支持更高级的功能，如国际化、代码拆分、PWA 清单和忽略代码等。
+
+`.dojorc` 文件中包含一个 JSON 对象，可以为能在 dojo 命令行工具上运行的任何命令配置信息。在配置对象中为每个命令分配一个节点，可在其中存储配置信息。
+
+```json
+{
+	"build-app": {
+		"pwa": {
+			"manifest": {
+				"name": "My Application",
+				"description": "My amazing application"
+			}
+		}
+	},
+	"test-intern": {},
+	"create-widget": {
+		"tests": "tests/unit"
+	}
+}
+```
+
+本示例中，[@dojo/cli-build-app](https://github.com/dojo/cli-build-app/)、[@dojo/cli-test-intern](https://github.com/dojo/cli-test-intern) 和 [@dojo/cli-create-widget](https://github.com/dojo/cli-create-widget) 三个 CLI 命令模块各对应一个节点。配置 _总是_ 分层的，按照 command => feature => configuration 的顺序排列。

--- a/docs/zh-CN/building/supplemental.md
+++ b/docs/zh-CN/building/supplemental.md
@@ -1,0 +1,493 @@
+# 创建包
+
+<!--
+https://github.com/dojo/framework/blob/master/docs/en/building/supplemental.md
+commit b8e0228c4025cb803d1c56521b054f6d5e6dfdb2
+-->
+
+一个包就是一部分代码，它用于表示一部分功能。可以按需异步、并行加载包。与不使用任何代码拆分技术的应用程序相比，合理分包的应用程序可以显著提高响应速度，需要请求的字节数更少，加载的时间更短。在处理大型应用程序时，这一点尤其重要，因为这类应用程序的大部分表现层逻辑在初始化时是不需要加载的。
+
+Dojo 尝试使用路由和 outlet 智能地做出选择，自动将代码拆分为更小的包。通常各个包内的代码都是紧密相关的。这是构建系统内置的功能，可直接使用。但是，对于有特殊分包需求的用户，Dojo 还允许在 `.dojorc` 配置文件中显示定义包。
+
+默认情况下，Dojo 应用程序只创建一个应用程序包。但是 [@dojo/cli-build-app](https://github.com/dojo/cli-build-app) 提供了很多配置选项，这些选项可将应用程序拆分为较小的、可逐步加载的包。
+
+## 使用路由自动分包
+
+默认情况下，Dojo 会基于应用程序的路由自动创建包。要做到这一点需要遵循以下几条规则。
+
+1.  `src/routes.ts` 必须默认导出路由配置信息
+2.  部件所属的模块必须默认导出部件
+3.  `Outlet` 的 `render` 函数必须使用内联函数
+
+> src/routes.ts
+
+```ts
+export default [
+	{
+		path: 'home',
+		outlet: 'home',
+		defaultRoute: true
+	},
+	{
+		path: 'about',
+		outlet: 'about'
+	},
+	{
+		path: 'profile',
+		outlet: 'profile'
+	}
+];
+```
+
+> src/App.ts
+
+```tsx
+export default class App extends WidgetBase {
+	protected render() {
+		return (
+			<div classes={[css.root]}>
+				<Menu />
+				<div>
+					<Outlet key="home" id="home" renderer={() => <Home />} />
+					<Outlet key="about" id="about" renderer={() => <About />} />
+					<Outlet key="profile" id="profile" renderer={() => <Profile username="Dojo User" />} />
+				</div>
+			</div>
+		);
+	}
+}
+```
+
+将会为应用程序的每个顶级路由生成单独的包。在本例中，会生成一个应用程序的主包以及 `src/Home`、`src/About` 和 `src/Profile` 三个包。
+
+使用 [@dojo/cli-create-app](https://github.com/dojo/cli-create-app/) 新建一个应用程序，然后运行 `npm run build`，就可看到自动分包的实际效果。Dojo 将自动为示例应用程序中的所有路由创建包。
+
+## 手动分包
+
+可以在 `.dojorc` 配置文件中手动分包，这就为应用程序提供了一种声明式代码拆分的手段。当自动根据路由分包无法满足需求时，这对于将应用程序拆分为更小的包是极其有用的。
+
+`bundles` 功能是 build app 命令的一部分。配置由由一组包名和紧随其后的文件列表或匹配符组成。
+
+例如，以下配置将 `About` 和 `Profile` 合在一个包中，并命名为 `additional.[hash].js`。在 `w()` 中使用的部件模块将被自动转换为在父部件中延迟加载的本地注册项。
+
+> .dojorc
+
+```json
+{
+	"build-app": {
+		"bundles": {
+			"additional": ["src/widgets/About", "src/widgets/Profile"]
+		}
+	}
+}
+```
+
+如果我们想分地区创建国际化模块，我们应该使用通配符以确保将每个语言目录下的所有文件都会包含在内。
+
+> .dojorc
+
+```json
+{
+	"build-app": {
+		"bundles": {
+			"fr": ["src/**/nls/fr/**"],
+			"de": ["src/**/nls/de/**"]
+		}
+	}
+}
+```
+
+在这种情况下，Dojo 将创建名为 `fr.[hash].js` 的包，和名为 `de.[hash].js` 的包。想了解更新信息，请参阅国际化参考指南中的[使用消息包](/learn/i18n/working-with-message-bundles)。
+
+## 分包注意事项
+
+<!-- TODO I am not confident in what I am saying here. Under what conditions will duplication of common/shared resources occur? How do we avoid this? Can we define a bundle for common widgets? Should I talk about the [bundle analyzer](https://github.com/dojo/cli-build-app/blob/master/README.md#bundle-analyzer) -->
+
+有时，根据构建工具自动分包或者在 `.dojorc` 中手动定义的包中会重复包含被多个包共享的资源。有一些是无法避免的。一个避免重复的法则是尝试将共享代码移到应用程序依赖树的最外围。换句话说，就是尽可能减少共享代码之间的依赖。如果大量的代码在包之间共享（例如，公共的部件），请考虑将这些资源放在一个包中。
+
+# 静态资源
+
+很多静态资源，如在模块中导入的 CSS 和图片，在构建过程中会被自动内联。但是，有时还需要为网站图标（favicon）或视频文件等静态资源提供服务。
+
+静态资源存放在项目根目录下的 `assets/` 文件夹中。在构建时，这些资源会被复制到应用程序构建版本的 `assets/` 文件夹中。
+
+构建也会解析 `src/index.html` 中引用的 CSS、JavaScript 和图片资源等，对这些资源名进行哈希处理，并在输出文件夹中包含这些资源。可以将 favicon 存放在 `src` 文件夹中，然后在 `src/index.html` 中引用。构建会自动对 favicon 文件名进行哈希处理，并会将文件复制到输出文件夹中，然后重命名为 `favicon.[hash].ico`。
+
+# 渐进式 web 应用程序
+
+渐进式 web 应用程序（PWA）由一系列技术和模式组成，主要用于改善用户体验，帮助创建更可靠和可用的应用程序。尤其是移动用户，他们会发现应用程序能更好的集成到他们的设备中，就跟本地安装的应用程序一样。
+
+渐进式 web 应用程序主要由两种技术组成：Service Worker 和 Manifest。Dojo 的构建命令通过 `.dojorc` 的 `pwa` 对象支持这两种技术。
+
+## Manifest
+
+[Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) 在一个 JSON 文件中描述一个应用程序，并提供了一些详细信息，因此可以直接从万维网安装到设备的主屏幕上。
+
+> .dojorc
+
+```json
+{
+	"build-app": {
+		"pwa": {
+			"manifest": {
+				"name": "Todo MVC",
+				"description": "A simple to-do application created with Dojo",
+				"icons": [
+					{ "src": "./favicon-16x16.png", "sizes": "16x16", "type": "image/png" },
+					{ "src": "./favicon-32x32.png", "sizes": "32x32", "type": "image/png" },
+					{ "src": "./favicon-48x48.png", "sizes": "48x48", "type": "image/png" },
+					{ "src": "./favicon-256x256.png", "sizes": "256x256", "type": "image/png" }
+				]
+			}
+		}
+	}
+}
+```
+
+当提供了 manifest 信息时，`dojo build` 将在应用程序的 `index.html` 中注入必需的 `<meta>` 标签。
+
+-   `mobile-web-app-capable="yes"`: 告知 Android 上的 Chrome 可以将此应用程序添加到用户的主界面上。
+-   `apple-mobile-web-app-capable="yes"`: 告知 iOS 设备可以将此应用程序添加到用户的主界面上。
+-   `apple-mobile-web-app-status-bar-style="default"`: 告知 iOS 设备，状态栏使用默认外观。
+-   `apple-touch-icon="{{icon}}"`: 相当于 Manifest 中的 icons，因为 iOS 当前没有从 Manifest 中读取 icons，所以需要为 icons 数组中每张图片单独注入一个 meta 标签。
+
+## Service worker
+
+Service worder 是一种 web worker，能够拦截网络请求、缓存和提供资源。Dojo 的 build 命令能够自动构建功能全面的 service worker，它会在启动时激活，然后使用配置文件完成预缓存和自定义路由处理。
+
+例如，我们编写一个配置文件来创建一个简单的 service worker，它会缓存除了 admin 包之外的所有应用程序包，也会缓存应用程序最近访问的图像和文章。
+
+> .dojorc
+
+```json
+{
+	"build-app": {
+		"pwa": {
+			"serviceWorker": {
+				"cachePrefix": "my-app",
+				"excludeBundles": ["admin"],
+				"routes": [
+					{
+						"urlPattern": ".*\\.(png|jpg|gif|svg)",
+						"strategy": "cacheFirst",
+						"cacheName": "my-app-images",
+						"expiration": { "maxEntries": 10, "maxAgeSeconds": 604800 }
+					},
+					{
+						"urlPattern": "http://my-app-url.com/api/articles",
+						"strategy": "cacheFirst",
+						"expiration": { "maxEntries": 25, "maxAgeSeconds": 86400 }
+					}
+				]
+			}
+		}
+	}
+}
+```
+
+### ServiceWorker 配置
+
+在底层，`@dojo/webpack-contrib` 中的 `ServicerWorkerPlugin` 用于生成 service worker，它的所有选项都是有效的 `pwa.serviceWorker` 属性。
+
+| 属性           | 类型       | 可选 | 描述                                                          |
+| -------------- | ---------- | ---- | ------------------------------------------------------------- |
+| bundles        | `string[]` | 是   | 需要进行预缓存的一组包。默认是所有包。                        |
+| cachePrefix    | `string`   | 是   | 在运行时进行预缓存使用的前缀。                                |
+| clientsClaim   | `boolean`  | 是   | Service worker 是否要在开始激活时控制客户端。默认为 `false`。 |
+| excludeBundles | `string[]` | 是   | 要从预缓存中排除的一组包。默认为 `[]`。                       |
+| importScripts  | `string[]` | 是   | 需要在 service worker 中加载的一组脚本的路径。                |
+| precache       | `object`   | 是   | 描述预缓存配置选项的对象（见下文）。                          |
+| routes         | `object[]` | 是   | 一组描述要在运行时缓存的配置对象（见下文）。                  |
+| skipWaiting    | `boolean`  | 是   | Service worker 是否要跳过“等待”生命周期。                     |
+
+#### 预缓存
+
+`precache` 选项使用以下选项控制预缓存行为：
+
+| 属性         | 类型                   | 可选 | 描述                                                                                               |
+| ------------ | ---------------------- | ---- | -------------------------------------------------------------------------------------------------- |
+| baseDir      | `string`               | 是   | 匹配 `include` 时使用的根目录。                                                                    |
+| ignore       | `string[]`             | 是   | 一组通配符模式的字符串，当生成预缓存项时用于匹配需要忽略的文件。默认为 `[ 'node_modules/**/*' ]`。 |
+| include      | `string` or `string[]` | 是   | 一个或者一组通配符模式的字符串，用于匹配 precache 应该包含的文件。默认是构建管道中的所有文件。     |
+| index        | `string`               | 是   | 如果请求以 `/` 结尾的 URL 失败，则应该查找的 index 文件名。默认为 `'index.html'`。                 |
+| maxCacheSize | `number`               | 是   | 往预缓存中添加的每一个文件不应超过的最大字节数。默认为 `2097152` （2 MB）。                        |
+| strict       | `boolean`              | 是   | 如果为 `true`，则 `include` 模式匹配到一个不存在的文件夹时，构建就会失败。默认为 `true`。          |
+| symlinks     | `boolean`              | 是   | 当生成预缓存时是否允许软连接（symlinks）。默认为 `true`。                                          |
+
+#### 运行时缓存
+
+除了预缓存之外，还可以为特定路由提供缓存策略，以确定它们是否可以缓存以及如何缓存。`routes` 选项是一组包含以下属性的对象：
+
+| 属性                  | 类型     | 可选 | 描述                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------- | -------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| urlPattern            | `string` | 否   | 用于匹配特定路由的模式字符串（会被转换为正则表达式）。                                                                                                                                                                                                                                                                                                                                                                         |
+| strategy              | `string` | 否   | 缓存策略（见下文）。                                                                                                                                                                                                                                                                                                                                                                                                           |
+| options               | `object` | 是   | 一个描述附加选项的对象。每个选项的详情如下。                                                                                                                                                                                                                                                                                                                                                                                   |
+| cacheName             | `string` | 是   | 路由使用的缓存名称。注意 `cachePrefix` _不会_ 添加到缓存名前。默认为主运行时缓存（`${cachePrefix}-runtime-${domain}`）。                                                                                                                                                                                                                                                                                                       |
+| cacheableResponse     | `object` | 是   | 使用 HTTP 状态码或者报头（Header）信息来决定是否可以缓存响应的内容。此对象有两个可选属性：`statuses` 和 `headers`。`statuses` 是一组对缓存生效的状态码。`headers` 是一组 HTTP 的 header 和 value 键值对；至少要与一个报头匹配，响应才会被视为有效。当 `strategy` 的值是 `'cacheFirst'` 时，默认为 `{ statuses: [ 200 ] }`；当 `strategy` 的值为 `networkFirst` 或者 `staleWhileRevalidate` 时，默认为 `{ statuses: [0, 200] }` |
+| expiration            | `object` | 是   | 控制如何让缓存失效。此对象有两个可选属性。`maxEntries` 是任何时间可以缓存的响应个数。一旦超过此最大值，就会删除最旧的条目。`maxAgeSeconds` 是一个响应能缓存的最长时间（以秒为单位），超过此时长就会被删除。                                                                                                                                                                                                                    |
+| networkTimeoutSeconds | `number` | 是   | 与 `networkFirst` 策略一起使用，指定当网络请求的响应多久没有返回时就从缓存中获取资源，单位为秒。                                                                                                                                                                                                                                                                                                                               |
+
+目前支持四种路由策略：
+
+-   `networkFirst` 尝试通过网络加载资源，如果请求失败或超时才从缓存中获取资源。对于频繁更改或者可能频繁更改（即没有版本控制）的资源，这是一个很有用的策略。
+-   `cacheFirst` 优先从缓存中加载资源，如果缓存中不存在，则通过网络获取。这对于很少更改或者能缓存很长一段时间的资源（受版本控制的资源）来说是最好的策略。
+-   `networkOnly` 强制始终通过网络获取资源，对于无需离线处理的资源是很有用的策略。
+-   `staleWhileRevalidate` 同时从缓存和网络中请求资源。网络成功响应后都会更新缓存。此策略最适用于不需要持续更新的资源，比如用户信息。但是，当获取第三方资源时没有发送 CORS 报头，就无法读取响应的内容或验证状态码。因此，可能会缓存错误的响应。在这种情况下，`networkFirst` 策略可能更适合。
+
+# 构建时渲染
+
+构建时渲染（Build-time rendering，简称 BTR）在构建过程中将一个路由渲染为一个 HTML，并将在初始视图中显示的、关键的 CSS 和资源嵌入到页面中。Dojo 能预渲染路由使用的初始 HTML，并直接注入到页面中，这样会带来很多与服务器端渲染（SSR）相同的好处，如性能提升、搜索引擎优化且没有引入 SSR 的复杂性。
+
+## 使用 BTR
+
+首先确保 `index.html` 中包含一个拥有 `id` 属性的 DOM 节点。Dojo 的虚拟 DOM 会使用这个节点来比较和渲染应用程序的 HTML。BTR 需要此设置，这样它就能渲染在构建阶段生成的 HTML。这将会为路由创建一个响应非常快的初始渲染。
+
+> index.html
+
+```html
+<!DOCTYPE html>
+<html lang="en-us">
+	<head>
+		<title>sample-app</title>
+		<meta name="theme-color" content="#222127" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+	</head>
+	<body>
+		<div id="app"></div>
+	</body>
+</html>
+```
+
+然后将应用程序挂载到指定的 DOM 节点上：
+
+> main.ts
+
+```ts
+const r = renderer(() => w(App, {}));
+const domNode = document.getElementById('app') as HTMLElement;
+r.mount({ registry, domNode });
+```
+
+然后更新项目的 `.dojorc` 配置文件，设置根 DOM 节点的 `id` 和在构建时要渲染的路由。
+
+> .dojorc
+
+```json
+{
+	"build-app": {
+		"build-time-render": {
+			"root": "app",
+			"paths": [
+				"#home",
+				{
+					"path": "#comments/9999",
+					"match": ["#comments/.*"]
+				}
+			]
+		}
+	}
+}
+```
+
+此配置描述了两个路由。一个是 `home` 路由，一个是较复杂的 `comments` 路由。`comments` 是一个比较复杂的路由，需要传入参数。`match` 参数用于确保在构建时为此路由生成的 HTML 可以应用到与此正则表达式匹配的任何路由上。
+
+BTR 在构建时为每个渲染路径（path）生成一份屏幕快照，存在 `./output/info/screenshots` 文件夹中。
+
+### History 管理器
+
+构建时渲染支持使用 `@dojo/framework/routing/history/HashHistory` 或 `@dojo/framework/routing/history/StateHistory` history 管理器的应用程序。当使用 `HashHistory` 时，确保所有的路径都是以 `#` 字符开头。
+
+## `build-time-render` 功能标记
+
+运行时渲染公开了一个 `build-time-render` 功能标记，可用于跳过在构建时不能执行的功能。这样在创建一个初始渲染时，就可以避免对外部系统调用 `fetch`，而是提供静态数据。
+
+```ts
+if (!has('build-time-render')) {
+	const response = await fetch(/* remote JSON */);
+	return response.json();
+} else {
+	return Promise.resolve({
+		/* predefined Object */
+	});
+}
+```
+
+## Dojo Blocks
+
+Dojo 提供了一个 block 系统，在构建阶段的渲染过程中会执行 Node.js 代码。执行的结果会被写入到缓存中，然后在浏览器运行阶段会以相同的方式、透明的使用这些缓存。这就为使用一些浏览器中无法实现或者性能不佳的操作开辟了新的机会。
+
+例如，Dojo 的 block 模块可以读取一组 markdown 文件，将其转换为 VNode，并使它们可以在应用程序中渲染，所有这些都可在构建时执行。然后 Dojo block 模块的构建结果会缓存在应用程序的包中，以便在运行时在浏览器中使用。
+
+Dojo block 模块的用法与在 Dojo 部件中使用其它 meta 的用法类似。因此无需大量的配置或其他编写模式。
+
+例如，block 模块读取一个文本文件，然后将内容返回给应用程序。
+
+> src/blocks/read-file.ts
+
+```ts
+import * as fs from 'fs';
+import { resolve } from 'path';
+
+export default (path: string) => {
+	path = resolve(__dirname, path);
+	return fs.readFileSync(path, 'utf8');
+};
+```
+
+> src/widgets/MyBlockWidget.tsx
+
+```tsx
+import Block from '@dojo/framework/core/meta/Block';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v } from '@dojo/framework/core/vdom';
+
+import readFile from '../blocks/read-file';
+
+export default class MyBlockWidget extends WidgetBase {
+	protected render() {
+		const message = this.meta(Block).run(readFile)('../content/hello-dojo-blocks.txt');
+		return v('div', [message]);
+	}
+}
+```
+
+这个部件会在构建阶段运行 `src/blocks/read-file.ts` 模块来读取指定文件的内容。然后将内容作为文本节点，用作部件 VDOM 输出的子节点。
+
+# 按条件选取代码
+
+构建工具的静态代码分析工具能够从它创建的包中移除无用的代码。命名的条件块是使用 dojo 框架的 `has` 模块定义的，并且可以在 `.dojorc` 中静态设置为 true 或 false，然后在构建阶段移除。
+
+> main.ts
+
+```ts
+import has from '@dojo/framework/has';
+
+if (has('production')) {
+	console.log('Starting in production');
+} else {
+	console.log('Starting in dev mode');
+}
+
+export const mode = has('production') ? 'dist' : 'dev';
+```
+
+> .dojorc
+
+```json
+{
+	"build-app": {
+		"features": {
+			"production": true
+		}
+	}
+}
+```
+
+上述的 `production` 功能将**构建生产版本**（`dist` 模式）设置为 `true`。构建系统使用 `@dojo/framework/has` 将代码标记为无法访问，并在构建时移除这些无用的代码。
+
+比如，上述代码将重写为：
+
+> static-build-loader 输出
+
+```js
+import has from '@dojo/framework/has';
+
+if (true) {
+	console.log('Starting in production');
+} else {
+	console.log('Starting in dev mode');
+}
+
+export const mode = true ? 'dist' : 'dev';
+```
+
+然后，构建工具的无用分支移除工具将移除无用的代码。
+
+> Uglify 输出
+
+```js
+console.log('Starting in production');
+export const mode = 'dist';
+```
+
+任何没有被静态断言的功能都不会被重写。这就允许在运行时来确定是否存在这个功能。
+
+## 已提供的功能
+
+构建系统已提供以下功能（feature），用于帮助识别特定的环境或操作模式。
+
+| 功能标记            | 描述                                                                                                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `debug`             | 提供了一种为代码创建代码路径的方法，该代码路径仅在调试或者提供更强的诊断时有用，在为 _生产_ 构建时是不需要的。默认为 `true`，但在构建生产版本时应该静态地配置为 `false`。 |
+| `host-browser`      | 确定当前环境下 global 上下文中是否包含 `window` 和 `document` 对象，因此通常可以安全地假设代码运行在浏览器环境下。                                                        |
+| `host-node`         | 尝试检测当前环境是不是 node 环境。                                                                                                                                        |
+| `build-time-render` | 在构建期间渲染时由 BTR 系统静态定义。                                                                                                                                     |
+
+# 外部依赖
+
+通常不能被打包的非模块化库或者独立的应用程序，如果需要引入到 dojo 应用程序中，则可以通过提供一个 `require` 或 `define` 实现，并在项目的 `.dojorc` 文件中做一些配置。
+
+要配置外部依赖项，则需要为 `build-app` 配置对象设置 `externals` 属性。`externals` 是一个对象，包含以下两个属性：
+
+-   `outputPath`: 一个可选属性，指定一个将文件复制到何处的输出路径。
+-   `dependencies`: 一个必填的数组，定义哪些模块应该通过外部加载器加载，以及在构建时应该包含哪些文件。每个记录可以是以下两种类型之一：
+    -   一个字符串，表示应该使用外部加载器加载此路径及其所有子路径。
+    -   一个对象，为需要复制到构建版应用程序的依赖提供附加配置项。此对象具有以下属性：
+
+| 属性     | 类型                                                    | 可选 | 描述                                                                                                                                                                                                                                                                                                                                                                                         |
+| -------- | ------------------------------------------------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `string`                                                | 否   | 相对于项目根目录的路径，指定位于何处的文件夹或目录要复制到已构建应用程序中。                                                                                                                                                                                                                                                                                                                 |
+| `to`     | `string`                                                | 是   | 一个路径，表示将 `from` 路径下的依赖复制到何处的目标路径。默认情况下，依赖会被复制到 `${externalsOutputPath}/${to}`；如果没有设置 `to`，依赖会被复制到 `${externalsOutputPath}/${from}`。如果路径中包含 `.` 字符或者路径表示的是一个文件夹，则需要以正斜杠结尾。                                                                                                                             |
+| `name`   | `string`                                                | 是   | 在应用程序代码中引用的模块 id 或者全局变量名。                                                                                                                                                                                                                                                                                                                                               |
+| `inject` | `string, string[], or boolean`                          | 是   | 此属性表示这个依赖定义的（或者包含的），要在页面中加载的脚本或样式文件。如果 `inject` 的值为 `true`，那么就会在页面中加载 `to` 或 `from` 指定位置的文件。如果依赖的是文件夹，则 `inject` 可以被设置为一个或者一组字符串，来定义一个或多个要注入的文件。`inject` 中的每个路径都应该是相对于 `${externalsOutputPath}/${to}` 或 `${externalsOutputPath}/${from}`（具体取决于是否指定了 `to`）。 |
+| `type`   | `'root' or 'umd' or 'amd' or 'commonjs' or 'commonjs2'` | 是   | 强制模块用指定的方法解析。如果是 AMD 风格，则必须使用 `umd` 或 `amd`。如果是 node 风格则必须使用 `commonjs`，并且值为 `root` 时以全局的方式访问对象。                                                                                                                                                                                                                                        |
+
+例如，以下配置会将 `src/legacy/layer.js` 注入到应用程序页面中；注入定义了 `MyGlobal` 全局变量的文件；声明模块 `a` 和 `b` 为外部依赖，且要委托给外部层；然后复制 `node_modules/legacy-dep` 下的文件，并将其中的几个文件注入到页面中。所有文件都将被复制到 `externals` 文件夹中，也可以使用 `externals` 配置中的 `outputPath` 属性来重新指定文件夹。
+
+```json
+{
+	"build-app": {
+		"externals": {
+			"dependencies": [
+				"a",
+				"b",
+				{
+					"from": "node_modules/GlobalLibrary.js",
+					"to": "GlobalLibrary.js",
+					"name": "MyGlobal",
+					"inject": true
+				},
+				{ "from": "src/legacy/layer.js", "to": "legacy/layer.js", "inject": true },
+				{
+					"from": "node_modules/legacy-dep",
+					"to": "legacy-dep/",
+					"inject": ["moduleA/layer.js", "moduleA/layer.css", "moduleB/layer.js"]
+				}
+			]
+		}
+	}
+}
+```
+
+`externals` 中包含的依赖项的类型会被安装到 `node_modules/@types` 中，这跟其它依赖项是一样的。
+
+因为这些文件位于主构建（main build）之外，所以在生产构建中不会执行版本控制或哈希处理（在 `inject` 中指定资源的链接除外）。可以在 `to` 属性中指定版本号，将依赖复制到对应版本的文件夹下，这样就能避免缓存不同版本的文件。
+
+# 脱离 Dojo 构建管道
+
+<!-- TODO do we want to add any information from here: https://github.com/dojo/cli-build-app/blob/master/README.md#eject -->
+
+Dojo 的构建管道为项目提供了一个端到端的工具链，但是，在极少数情况下，可能需要自定义工具链。只要将项目脱离 Dojo 的构建管道，就可以自定义工具链。
+
+将项目脱离构建管道，是一个不可逆的、单向过程，它会导出 Webpack、Intern 以及 `dojo` 命令使用的其他项目的底层配置文件。如果提供的生成工具无法提供所需的功能或特性，推荐的方法是 fork 选定的构建命令，然后往工具中添加额外的功能。Dojo 的 CLI 本质上是专门按模块化设计的，考虑到了这个用例。
+
+要将一个项目脱离出 dojo 构建管道，请使用 `dojo eject` 命令，它将提示你确实已明白过程是不可逆的。这个导出过程将所有已安装的 dojo 命令中导出的配置信息存到 `config` 文件夹中。这个过程也会安装一些项目需要的附加依赖。
+
+现在项目已经是一个 webpack 项目。可以通过修改 `config/build-app/base.config.js` 来更改构建配置。
+
+然后，可以通过运行 webpack 的构建命令并提供配置项来触发一个构建。此外，使用 webpack 的 env 标记（例如 --env.mode=dev）来指定模式，默认为 dist。
+
+```bash
+./node_modules/.bin/webpack --config=config/build-app/ejected.config.js --env.mode=[mode]
+```

--- a/docs/zh-CN/creating-widgets/introduction.md
+++ b/docs/zh-CN/creating-widgets/introduction.md
@@ -21,8 +21,8 @@ Dojo 鼓励编写简单的、模块化组件，并称之为**部件**，它仅�
 
 ## 定义部件
 
--   使用 [内置的 `create()`](/learn/creating-widgets/widget-fundamentals#basic-widget-structure) 将部件定义为一个渲染函数 factory
--   返回定义了部件结构的 [虚拟 DOM 节点](/learn/creating-widgets/rendering-widgets/#working-with-the-vdom)，这里使用 [TSX 语法](/learn/creating-widgets/rendering-widgets#tsx-support)
+-   使用 [内置的 `create()`](/learn/creating-widgets/部件的基本原理#基本的部件结构) 将部件定义为一个渲染函数 factory
+-   返回定义了部件结构的 [虚拟 DOM 节点](/learn/creating-widgets/渲染部件/#使用-vdom)，这里使用 [TSX 语法](/learn/creating-widgets/渲染部件#支持-tsx)
 
 > src/widgets/MyWidget.tsx
 
@@ -38,9 +38,9 @@ export default factory(function MyWidget() {
 
 ## 设置部件属性
 
--   为了使部件能更好的复用，需要使用[类型化的属性接口](/learn/creating-widgets/managing-state#intermediate-passing-widget-properties)来抽象出 [state](/learn/creating-widgets/managing-state), 配置和[事件处理函数](/learn/creating-widgets/enabling-interactivity)
+-   为了使部件能更好的复用，需要使用[类型化的属性接口](/learn/creating-widgets/状态管理#中级传入部件属性)来抽象出 [state](/learn/creating-widgets/状态管理), 配置和[事件处理函数](/learn/creating-widgets/支持交互)
 -   使用 `create` 工厂为部件提供[中间件](/learn/middleware/introduction)
--   通过为节点指定 [`key` 属性](/learn/creating-widgets/configuring-widgets-through-properties#vdom-node-keys)，来区分同一类型的兄弟元素，此示例中是两个 `div` 元素。这样当应用程序中的状态发生变化，需要更新 DOM 节点时，框架就可以高效、准确地定位到相关元素
+-   通过为节点指定 [`key` 属性](/learn/creating-widgets/通过属性配置部件#vdom-节点的-key)，来区分同一类型的兄弟元素，此示例中是两个 `div` 元素。这样当应用程序中的状态发生变化，需要更新 DOM 节点时，框架就可以高效、准确地定位到相关元素
 
 > src/widgets/Greeter.tsx
 
@@ -85,8 +85,8 @@ export default factory(function Greeter({ middleware: { icache }, properties }) 
 ## 组合部件
 
 -   通过将部件组合在一起形成多层结构，以满足更复杂的应用程序需求
--   为子部件提供 state 和事件处理函数等[属性(properties)](/learn/creating-widgets/configuring-widgets-through-properties)
--   使用 [`icache` 中间件](/learn/middleware/available-middleware#icache)管理 state，并当状态变更时，失效或重新渲染受影响的部件
+-   为子部件提供 state 和事件处理函数等[属性(properties)](/learn/creating-widgets/通过属性配置部件)
+-   使用 [`icache` 中间件](/learn/middleware/可用的中间件#icache)管理 state，并当状态变更时，失效或重新渲染受影响的部件
 
 > src/widgets/NameHandler.tsx
 
@@ -114,7 +114,7 @@ export default factory(function NameHandler({ middleware: { icache } }) {
 ## 渲染到 DOM 中
 
 -   使用框架中的 `renderer` 函数将部件挂载到 DOM 中
--   也可以对 Dojo 应用程序在页面中呈现的位置[做更多控制](/learn/creating-widgets/rendering-widgets#mountoptions-properties)，以便稳步地采用较小的子组件，甚至支持一个页面中存在多个应用程序或框架
+-   也可以对 Dojo 应用程序在页面中呈现的位置[做更多控制](/learn/creating-widgets/渲染部件#mountoptions-属性)，以便稳步地采用较小的子组件，甚至支持一个页面中存在多个应用程序或框架
 
 > src/main.tsx
 

--- a/docs/zh-CN/creating-widgets/supplemental.md
+++ b/docs/zh-CN/creating-widgets/supplemental.md
@@ -59,9 +59,9 @@ export default class MyWidget extends WidgetBase {
 }
 ```
 
-因为此部件的渲染函数返回的是空数组，所以在应用程序的输出中没有任何内容。部件通常[返回一到多个虚拟 DOM 节点](/learn/creating-widgets/rendering-widgets#virtual-nodes-example)，以便在应用程序的 HTML 输出中包含有意义的结构。
+因为此部件的渲染函数返回的是空数组，所以在应用程序的输出中没有任何内容。部件通常[返回一到多个虚拟 DOM 节点](/learn/creating-widgets/渲染部件#虚拟节点示例)，以便在应用程序的 HTML 输出中包含有意义的结构。
 
-将虚拟 DOM 节点转换为网页中的输出是由 [Dojo 的渲染系统](/learn/creating-widgets/rendering-widgets)处理的。
+将虚拟 DOM 节点转换为网页中的输出是由 [Dojo 的渲染系统](/learn/creating-widgets/渲染部件)处理的。
 
 ## 部件样式
 
@@ -71,11 +71,11 @@ export default class MyWidget extends WidgetBase {
 
 Dojo 是一个响应式框架，负责处理数据变更的传播和相关的后台更新渲染。Dojo 采用虚拟 DOM(VDOM) 的概念来描述输出的元素，VDOM 中的节点是简单的 JavaScript 对象，旨在提高开发人员效率，而不用与实际的 DOM 元素交互。
 
-应用程序只需要关心，将它们的期望的输出结构声明为有层级的虚拟 DOM 节点即可，通常是作为[部件的渲染函数](/learn/creating-widgets/widget-fundamentals#basic-widget-structure)的返回值来完成的。然后，框架的 [`Renderer`](/learn/creating-widgets/rendering-widgets#rendering-to-the-dom) 组件会将期望的输出同步为 DOM 中的具体元素。也可以通过给虚拟 DOM 节点传入属性，从而配置部件和元素，以及为部件和元素提供状态。
+应用程序只需要关心，将它们的期望的输出结构声明为有层级的虚拟 DOM 节点即可，通常是作为[部件的渲染函数](/learn/creating-widgets/部件的基本原理#基本的部件结构)的返回值来完成的。然后，框架的 [`Renderer`](/learn/creating-widgets/渲染部件#渲染到-dom-中) 组件会将期望的输出同步为 DOM 中的具体元素。也可以通过给虚拟 DOM 节点传入属性，从而配置部件和元素，以及为部件和元素提供状态。
 
 Dojo 支持树的部分子节点渲染，这意味着当状态发生变化时，框架能够定位到受变化影响的 VDOM 节点的对应子集。然后，只更新 DOM 树中受影响的子树，从而响应变化、提高渲染性能并改善用户的交互体验。
 
-> **注意：** 部件渲染函数中返回的虚拟节点，是唯一影响应用程序渲染的因素。尝试使用任何其他实践，[在 Dojo 应用程序开发中是被视为反模式的](/learn/creating-widgets/best-practice-development)，应当避免。
+> **注意：** 部件渲染函数中返回的虚拟节点，是唯一影响应用程序渲染的因素。尝试使用任何其他实践，[在 Dojo 应用程序开发中是被视为反模式的](/learn/creating-widgets/最佳开发实践)，应当避免。
 
 ## 支持 TSX
 
@@ -160,11 +160,11 @@ Dojo 会在 VDOM 中识别出两类节点：
 -   `VNode`，或称为 _Virtual Nodes_，是具体 DOM 元素的虚拟表示，作为所有 Dojo 应用程序最底层的渲染输出。
 -   `WNode`，或称为 _Widget Nodes_，将 Dojo 部件关联到 VDOM 的层级结构上。
 
-Dojo 的虚拟节点中，`VNode` 和 `WNode` 都可看作 `DNode` 的子类型，但应用程序通常不处理抽象层面的 `DNode`。推荐使用 [TSX 语法](/learn/creating-widgets/rendering-widgets#tsx-support)，因为它能以统一的语法渲染两类虚拟节点。
+Dojo 的虚拟节点中，`VNode` 和 `WNode` 都可看作 `DNode` 的子类型，但应用程序通常不处理抽象层面的 `DNode`。推荐使用 [TSX 语法](/learn/creating-widgets/渲染部件#支持-tsx)，因为它能以统一的语法渲染两类虚拟节点。
 
 ### 实例化 VDOM 节点
 
-如果不想使用 TSX，在部件中可以导入 `@dojo/framework/core/vdom` 模块中的 `v()` 或 `w()` 函数。它们分别创建 `VNode` 和 `WNode`，并可作为[部件渲染函数](/learn/creating-widgets/widget-fundamentals#basic-widget-structure)返回值的一部分。它们的签名，抽象地说，如下：
+如果不想使用 TSX，在部件中可以导入 `@dojo/framework/core/vdom` 模块中的 `v()` 或 `w()` 函数。它们分别创建 `VNode` 和 `WNode`，并可作为[部件渲染函数](/learn/creating-widgets/部件的基本原理#基本的部件结构)返回值的一部分。它们的签名，抽象地说，如下：
 
 -   `v(tagName | VNode, properties?, children?)`:
 -   `w(Widget | constructor, properties, children?)`
@@ -173,7 +173,7 @@ Dojo 的虚拟节点中，`VNode` 和 `WNode` 都可看作 `DNode` 的子类型�
 | ---------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tagName | VNode`      | 否               | 通常，会以字符串的形式传入 `tagName`，该字符串对应 `VNode` 将要渲染的相应 DOM 元素的标签名。如果传入的是 `VNode`，新创建的 `VNode` 将是原始 `VNode` 的副本。如果传入了 `properties` 参数，则会合并 `properties` 中重复的属性，并应用到副本 `VNode` 中。如果传入了 `children` 参数，将在新的副本中完全覆盖原始 `VNode` 中的所有子节点。 |
 | `Widget | constructor` | 否               | 通常，会传入 `Widget`，它将导入部件当作泛型类型引用。还可以传入几种类型的 `constructor`，它允许 Dojo 以各种不同的方式实例化部件。它们支持延迟加载等高级功能。                                                                                                                                                                          |
-| `properties`           | `v`: 是, `w`: 否 | [用于配置新创建的 VDOM 节点的属性集](/learn/creating-widgets/configuring-widgets-through-properties)。它们还允许框架检测节点是否已更新，从而重新渲染。                                                                                                                                                                                 |
+| `properties`           | `v`: 是, `w`: 否 | [用于配置新创建的 VDOM 节点的属性集](/learn/creating-widgets/通过属性配置部件)。它们还允许框架检测节点是否已更新，从而重新渲染。                                                                                                                                                                                                       |
 | `children`             | 是               | 一组节点，会渲染为新创建节点的子节点。如果需要，还可以使用字符串字面值表示任何文本节点。部件通常会封装自己的子节点，因此此参数更可能会与 `v()` 一起使用，而不是 `w()`。                                                                                                                                                                |
 
 ### 虚拟节点示例
@@ -299,7 +299,7 @@ r.mount({ domNode: dojoAppRootElement });
 
 ## 向 VDOM 中加入外部的 DOM 节点
 
-Dojo 可以包装外部的 DOM 元素，有效地将它们引入到应用程序的 VDOM 中，用作渲染输出的一部分。这是通过 `@dojo/framework/core/vdom` 模块中的 `dom()` 工具方法完成的。它的工作原理与 [`v()`](/learn/creating-widgets/rendering-widgets#instantiating-vdom-nodes) 类似，但它的主参数使用的是现有的 DOM 节点而不是元素标记字符串。在返回 `VNode` 时，它会引用传递给它的 DOM 节点，而不是使用 `v()` 新创建的元素。
+Dojo 可以包装外部的 DOM 元素，有效地将它们引入到应用程序的 VDOM 中，用作渲染输出的一部分。这是通过 `@dojo/framework/core/vdom` 模块中的 `dom()` 工具方法完成的。它的工作原理与 [`v()`](/learn/creating-widgets/渲染部件#实例化-vdom-节点) 类似，但它的主参数使用的是现有的 DOM 节点而不是元素标记字符串。在返回 `VNode` 时，它会引用传递给它的 DOM 节点，而不是使用 `v()` 新创建的元素。
 
 一旦 `dom()` 返回的 `VNode` 添加到应用程序的 VDOM 中，Dojo 应用程序就实际获得了被包装 DOM 节点的所有权。请注意，此过程仅适用于 Dojo 应用程序的外部节点，如挂载应用程序元素的兄弟节点，或与主网页的 DOM 断开连接的新创建的节点。如果包装的节点是挂载了应用程序的元素的祖先或子孙节点，将无效。
 
@@ -307,14 +307,14 @@ Dojo 可以包装外部的 DOM 元素，有效地将它们引入到应用程序�
 
 -   `dom({ node, attrs = {}, props = {}, on = {}, diffType = 'none', onAttach })`
 
-| 参数       | 可选 | 描述                                                                                                                                                        |
-| ---------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `node`     | 否   | 添加到 Dojo VDOM 中的外部 DOM 节点                                                                                                                          |
-| `attrs`    | 是   | 应用到外部 DOM 节点上的 HTML 属性(attributes)                                                                                                               |
-| `props`    | 是   | 附加到 DOM 节点上的属性(properties)                                                                                                                         |
-| `on`       | 是   | 应用到外部 DOM 节点上的事件集合                                                                                                                             |
-| `diffType` | 是   | 默认为: `none`。[更改检测策略](/learn/creating-widgets/rendering-widgets#external-dom-node-change-detection)，确定 Dojo 应用程序是否需要更新外部的 DOM 节点 |
-| `onAttach` | 是   | 一个可选的回调函数，在节点追加到 DOM 后执行                                                                                                                 |
+| 参数       | 可选 | 描述                                                                                                                                    |
+| ---------- | ---- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `node`     | 否   | 添加到 Dojo VDOM 中的外部 DOM 节点                                                                                                      |
+| `attrs`    | 是   | 应用到外部 DOM 节点上的 HTML 属性(attributes)                                                                                           |
+| `props`    | 是   | 附加到 DOM 节点上的属性(properties)                                                                                                     |
+| `on`       | 是   | 应用到外部 DOM 节点上的事件集合                                                                                                         |
+| `diffType` | 是   | 默认为: `none`。[更改检测策略](/learn/creating-widgets/渲染部件#检测外部-dom-节点的变化)，确定 Dojo 应用程序是否需要更新外部的 DOM 节点 |
+| `onAttach` | 是   | 一个可选的回调函数，在节点追加到 DOM 后执行                                                                                             |
 
 ### 检测外部 DOM 节点的变化
 
@@ -346,25 +346,25 @@ Dojo 可以包装外部的 DOM 元素，有效地将它们引入到应用程序�
 
 当重新渲染 VDOM 中受影响部分时，Dojo 使用虚拟节点的 key 来唯一标识特定实例。如果没有使用 key 在 VDOM 中区分开同一层级中的相同类型的多个节点，则 Dojo 就无法准确地确定哪些子节点受到了失效更改(invalidating change)的影响。
 
-> **注意：** 虚拟节点的 `key` 应在多次渲染函数的调用中保持一致。在每一次的渲染调用中，为相同的输出节点生成不同的 key，[在 Dojo 应用程序开发中被认为是反模式的](/learn/creating-widgets/best-practice-development#the-virtual-dom)，应当避免。
+> **注意：** 虚拟节点的 `key` 应在多次渲染函数的调用中保持一致。在每一次的渲染调用中，为相同的输出节点生成不同的 key，[在 Dojo 应用程序开发中被认为是反模式的](/learn/creating-widgets/最佳开发实践#虚拟-dom)，应当避免。
 
 ## 配置 `VNode`
 
 `VNodeProperties` 包含很多字段，是与 DOM 中的元素交互的重要 API。其中很多属性镜像了 [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) 中的可用属性，包括指定各种 `oneventname` 的事件处理器。
 
-应用程序的这些属性是单向的，因为 Dojo 将给定的属性集应用到具体的 DOM 元素上，但不会将相应的 DOM 属性后续的任何更改同步到 `VNodeProperties`。任何此类更改都应该通过事件处理器回传给 Dojo 应用程序。当调用事件处理程序时，应用程序可以处理事件所需的任何状态更改，在输出 VDOM 结构进行渲染时，更新对应的 `VNodeProperties` 视图，然后 Dojo 的 [`Renderer` 会同步所有相关的 DOM 更新](/learn/creating-widgets/rendering-widgets#rendering-to-the-dom)。
+应用程序的这些属性是单向的，因为 Dojo 将给定的属性集应用到具体的 DOM 元素上，但不会将相应的 DOM 属性后续的任何更改同步到 `VNodeProperties`。任何此类更改都应该通过事件处理器回传给 Dojo 应用程序。当调用事件处理程序时，应用程序可以处理事件所需的任何状态更改，在输出 VDOM 结构进行渲染时，更新对应的 `VNodeProperties` 视图，然后 Dojo 的 [`Renderer` 会同步所有相关的 DOM 更新](/learn/creating-widgets/渲染部件#渲染到-dom-中)。
 
 ## 修改属性和差异检测
 
 Dojo 使用虚拟节点的属性来确定给定节点是否已更新，从而是否需要重新渲染。具体来说，它使用差异检测策略来比较前一次和当前渲染帧的属性集。如果在节点接收的最新属性集中检测到差异，则该节点将失效，并在下一个绘制周期中重新渲染。
 
-> **注意：** 属性更改检测是由框架内部管理的，依赖于在部件的渲染函数中声明的 VDOM 输出结构。试图保留属性的引用，并在正常的部件渲染周期之外对其进行修改，[在 Dojo 应用程序开发中被视为反模式的](/learn/creating-widgets/best-practice-development)，应当避免。
+> **注意：** 属性更改检测是由框架内部管理的，依赖于在部件的渲染函数中声明的 VDOM 输出结构。试图保留属性的引用，并在正常的部件渲染周期之外对其进行修改，[在 Dojo 应用程序开发中被视为反模式的](/learn/creating-widgets/最佳开发实践)，应当避免。
 
 # 支持交互
 
 ## 事件监听器
 
-在实例化节点时，为虚拟节点指定事件监听器的方法与指定[任何其他属性](/learn/creating-widgets/configuring-widgets-through-properties)的方法相同。当输出 `VNode` 时，`VNodeProperties` 上事件监听器的名字会镜像到 [`HTMLElement` 的等价事件上](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement)。虽然自定义部件的作者可以根据自己的选择命名事件，但通常也遵循类似的 `onEventName` 的命名约定。
+在实例化节点时，为虚拟节点指定事件监听器的方法与指定[任何其他属性](/learn/creating-widgets/通过属性配置部件)的方法相同。当输出 `VNode` 时，`VNodeProperties` 上事件监听器的名字会镜像到 [`HTMLElement` 的等价事件上](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement)。虽然自定义部件的作者可以根据自己的选择命名事件，但通常也遵循类似的 `onEventName` 的命名约定。
 
 函数属性（如事件处理程序）会自动绑定到实例化此虚拟节点的部件的 `this` 上下文。但是，如果将已绑定的函数传给属性值，将不会重复绑定给 `this`。
 
@@ -372,7 +372,7 @@ Dojo 使用虚拟节点的属性来确定给定节点是否已更新，从而是
 
 输出 `VNode` 时，部件可以使用 `VNodeProperties` 的 `focus` 属性来控制生成的 DOM 元素在渲染时是否获取焦点。这是一个特殊属性，它可接收一个 `boolean` 类型的对象或者是返回一个 `boolean` 类型的函数。
 
-当直接传入 `true` 时，只有上一次的值不是 `true` 时，元素才会获取焦点（类似于[常规属性变更检测](/learn/creating-widgets/configuring-widgets-through-properties#changing-properties-and-diff-detection)）。而传入函数时，只要函数返回 `true`，元素就会获取焦点，而不管上一次返回值。
+当直接传入 `true` 时，只有上一次的值不是 `true` 时，元素才会获取焦点（类似于[常规属性变更检测](/learn/creating-widgets/通过属性配置部件#修改属性和差异检测)）。而传入函数时，只要函数返回 `true`，元素就会获取焦点，而不管上一次返回值。
 
 例如：
 
@@ -419,13 +419,13 @@ export default class FocusExample extends WidgetBase {
 
 ### 委托 focus
 
-基于函数的部件可使用 [`focus` 中间件](/learn/middleware/available-middleware#focus)为其子部件设置焦点，或者接受来自父部件的焦点。基于类的部件可使用 `FocusMixin`(来自 `@dojo/framework/core/mixins/Focus`)以相同的方式委托 focus。
+基于函数的部件可使用 [`focus` 中间件](/learn/middleware/可用的中间件#focus)为其子部件设置焦点，或者接受来自父部件的焦点。基于类的部件可使用 `FocusMixin`(来自 `@dojo/framework/core/mixins/Focus`)以相同的方式委托 focus。
 
 `FocusMixin` 会给部件的类中添加一个 `this.shouldFocus()` 方法，而基于函数的部件使用 `focus.shouldFocus()` 中间件方法实现相同的目的。此方法会检查部件是否处于执行了获取焦点的状态（译注：即调用了 `this.focus()`），并且仅对单个调用返回 `true`，直到再次调用部件的 `this.focus()` 方法（基于函数的部件使用等价的 `focus.focus()`）。
 
 `FocusMixin` 或者 `focus` 中间件也会为部件的 API 添加一个 `focus` 函数属性。框架使用此属性的布尔结果来确定渲染时，部件（或其一个子部件）是否应获得焦点。通常，部件通过其 `focus` 属性将 `shouldFocus` 方法传递给特定的子部件或输出的节点上，从而允许父部件将焦点委托给其子部件。
 
-基于函数的部件的示例，请参阅 Dojo 中间件参考指南中的 [`focus` 中间件委派示例](/learn/middleware/available-middleware#focus-delegation-example)
+基于函数的部件的示例，请参阅 Dojo 中间件参考指南中的 [`focus` 中间件委派示例](/learn/middleware/可用的中间件#focus-委托示例)
 
 下面基于类的部件示例，显示了在部件层次结构内和输出的 VNode 之间委托和控制焦点：
 
@@ -528,15 +528,15 @@ export default class FocusableWidget extends Focus(WidgetBase) {
 
 # 状态管理
 
-在数据不需要在多个组件之间流动的简单应用程序中，状态管理是非常简单的。可将部件需要的数据封装在部件内，这是 Dojo 应用程序中[状态管理的最基本形式](/learn/creating-widgets/managing-state#basic-self-encapsulated-widget-state)。
+在数据不需要在多个组件之间流动的简单应用程序中，状态管理是非常简单的。可将部件需要的数据封装在部件内，这是 Dojo 应用程序中[状态管理的最基本形式](/learn/creating-widgets/状态管理#基础自封装的部件状态)。
 
-随着应用程序变得越来越复杂，并且开始要求在多个部件之间共享和传输数据，就需要一种更健壮的状态管理形式。在这里，Dojo 开始展现出其响应式框架的价值，允许应用程序定义数据如何在组件之间流动，然后由框架管理变更检测和重新渲染。这是通过在部件的渲染函数中声明 VDOM 输出时[将部件和属性连接在一起](/learn/creating-widgets/managing-state#intermediate-passing-widget-properties)而做到的。
+随着应用程序变得越来越复杂，并且开始要求在多个部件之间共享和传输数据，就需要一种更健壮的状态管理形式。在这里，Dojo 开始展现出其响应式框架的价值，允许应用程序定义数据如何在组件之间流动，然后由框架管理变更检测和重新渲染。这是通过在部件的渲染函数中声明 VDOM 输出时[将部件和属性连接在一起](/learn/creating-widgets/状态管理#中级传入部件属性)而做到的。
 
 对于大型应用程序，状态管理可能是最具挑战性的工作之一，需要开发人员在数据一致性、可用性和容错性之间进行平衡。虽然这种复杂性大多超出了 web 应用程序层的范围，但 Dojo 提供了更进一步的解决方案，以确保数据的一致性。[Dojo Store](/learn/stores/introduction) 组件提供了一个集中式的状态存储，它提供一致的 API，用于访问和管理应用程序中多个位置的数据。
 
 ## 基础：自封装的部件状态
 
-部件可以通过多种方式维护其内部状态。基于函数的部件可以使用 [`cache`](/learn/middleware/available-middleware#cache) 或 [`icache`](/learn/middleware/available-middleware#icache) 中间件来存储部件的本地状态，而基于类的部件可以使用内部的类字段。
+部件可以通过多种方式维护其内部状态。基于函数的部件可以使用 [`cache`](/learn/middleware/可用的中间件#cache) 或 [`icache`](/learn/middleware/可用的中间件#icache) 中间件来存储部件的本地状态，而基于类的部件可以使用内部的类字段。
 
 内部状态数据可能直接影响部件的渲染输出，也可能作为属性传递给子部件，而它们继而又直接影响了子部件的渲染输出。部件还可能允许更改其内部状态，例如响应用户交互事件。
 
@@ -600,13 +600,13 @@ export default class MyEncapsulatedStateWidget extends WidgetBase {
 }
 ```
 
-注意，这个示例是不完整的，在正在运行的应用程序中，单击“Change State”按钮不会对部件的渲染输出产生任何影响。这是因为状态完全封装在 `MyEncapsulatedStateWidget` 部件中，而 Dojo [无从得知对部件的任何更改](/learn/creating-widgets/best-practice-development#widget-properties)。框架只处理了部件的初始渲染。
+注意，这个示例是不完整的，在正在运行的应用程序中，单击“Change State”按钮不会对部件的渲染输出产生任何影响。这是因为状态完全封装在 `MyEncapsulatedStateWidget` 部件中，而 Dojo [无从得知对部件的任何更改](/learn/creating-widgets/最佳开发实践#部件属性)。框架只处理了部件的初始渲染。
 
 要通知 Dojo 重新渲染，则需要封装渲染状态的部件自行失效。
 
 ### 让部件失效
 
-基于函数的部件可以使用 [`icache` 中间件](/learn/middleware/available-middleware#icache)处理本地的状态管理，当状态更新时会自动失效部件。`icache` 组合了 [`cache`](/learn/middleware/available-middleware#cache) 和 [`invalidator`](/learn/middleware/available-middleware#invalidator) 中间件，拥有 `cache` 的处理部件状态管理的功能，和 `invalidator` 的当状态变化时让部件失效的功能。如果需要，基于函数的部件也可以直接使用 `invalidator`。
+基于函数的部件可以使用 [`icache` 中间件](/learn/middleware/可用的中间件#icache)处理本地的状态管理，当状态更新时会自动失效部件。`icache` 组合了 [`cache`](/learn/middleware/可用的中间件#cache) 和 [`invalidator`](/learn/middleware/可用的中间件#invalidator) 中间件，拥有 `cache` 的处理部件状态管理的功能，和 `invalidator` 的当状态变化时让部件失效的功能。如果需要，基于函数的部件也可以直接使用 `invalidator`。
 
 基于类的部件，则有两种失效的方法：
 
@@ -682,7 +682,7 @@ export default class MyEncapsulatedStateWidget extends WidgetBase {
 
 ## 中级：传入部件属性
 
-通过虚拟节点的 [`properties`](/learn/creating-widgets/configuring-widgets-through-properties) 将状态传入部件是 Dojo 应用程序中连接响应式数据流最有效的方法。
+通过虚拟节点的 [`properties`](/learn/creating-widgets/通过属性配置部件) 将状态传入部件是 Dojo 应用程序中连接响应式数据流最有效的方法。
 
 部件指定自己的属性[接口](https://www.typescriptlang.org/docs/handbook/interfaces.html)，该接口包含部件希望向使用者公开的任何字段，包括配置选项、表示注入状态的字段以及任何事件处理函数。
 
@@ -848,7 +848,7 @@ Dojo 提供的 [Store 组件](/learn/stores/introduction) 解决了这些问题�
 
 ## 虚拟 DOM
 
--   虚拟节点的 [`key`](/learn/creating-widgets/configuring-widgets-through-properties#vdom-node-keys) 应在多次渲染调用中保持一致。
+-   虚拟节点的 [`key`](/learn/creating-widgets/通过属性配置部件#vdom-节点的-key) 应在多次渲染调用中保持一致。
     -   如果在每次渲染调用中都指定一个不同的 `key`，则 Dojo 无法有效地将前一次渲染和本次渲染中的相同节点关联上。Dojo 会将上一次渲染中没有看到的新 `key` 当作新元素，这会导致从 DOM 中删除之前的节点并重新添加一套，即使属性没有发生变化，不需要重新更新 DOM。
     -   一个常见的反模式是在部件的渲染函数中为节点的 `key` 分配一个随机生成的 ID（如 GUID 或 UUID）。除非生成策略是等幂的，否则不应在渲染函数中生成节点的 `key` 值。
 -   应用程序不应存储虚拟节点的引用，以便从部件的渲染函数返回它们后，进行后续操作；也不应尝试通过使用单个实例跨多个渲染调用来优化内存分配。

--- a/docs/zh-CN/middleware/introduction.md
+++ b/docs/zh-CN/middleware/introduction.md
@@ -43,7 +43,7 @@ export default myMiddleware;
 ## 组合中间件
 
 -   组合中间件并返回一个对象以公开更复杂的 API
--   使用核心的 [`invalidator`](/learn/middleware/core-render-middleware#invalidator) 中间件将组合部件标记为需要重新渲染
+-   使用核心的 [`invalidator`](/learn/middleware/核心渲染中间件#invalidator) 中间件将组合部件标记为需要重新渲染
 
 > src/middleware/myComposingMiddleware.ts
 

--- a/docs/zh-CN/middleware/supplemental.md
+++ b/docs/zh-CN/middleware/supplemental.md
@@ -189,7 +189,7 @@ import cache from '@dojo/framework/core/middleware/cache';
 
 ## `icache`
 
-组合了 [`cache`](/learn/middleware/available-middleware#cache) 和 [`invalidator`](/learn/middleware/core-render-middleware#invalidator) 中间件功能，以提供一个缓存，支持延迟值的解析，并在值可用时自动让部件失效。
+组合了 [`cache`](/learn/middleware/可用的中间件#cache) 和 [`invalidator`](/learn/middleware/核心渲染中间件#invalidator) 中间件功能，以提供一个缓存，支持延迟值的解析，并在值可用时自动让部件失效。
 
 **API:**
 
@@ -376,7 +376,7 @@ import resize from '@dojo/framework/core/middleware/resize';
 
 允许部件确定一个指定的宽度断点，该断点与其中一个虚拟节点的当前宽度匹配。此中间件在创建能够适配各种显示宽度的部件时非常有用，比如在移动端和桌面分辨率下同时使用的部件。
 
-与 [`resize`](/learn/middleware/available-middleware#resize) 中间件组合使用，以获取元素的宽度，并在调整宽度时自动让部件失效。
+与 [`resize`](/learn/middleware/可用的中间件#resize) 中间件组合使用，以获取元素的宽度，并在调整宽度时自动让部件失效。
 
 **注意：** 如果没有设置自定义的宽度断点，Dojo 将默认使用以下集合：
 
@@ -435,7 +435,7 @@ import store from '@dojo/framework/core/middleware/store';
 
 ## `focus`
 
-组合使用 [VDOM focus 原生方法](/learn/creating-widgets/enabling-interactivity#handling-focus) ，允许部件检查和控制输出的 DOM 间的焦点。
+组合使用 [VDOM focus 原生方法](/learn/creating-widgets/支持交互#处理-focus) ，允许部件检查和控制输出的 DOM 间的焦点。
 
 **API:**
 
@@ -547,7 +547,7 @@ import injector from '@dojo/framework/core/middleware/injector';
 ```
 
 -   `injector.subscribe(label: RegistryLabel, callback: Function = invalidator)`
-    -   为注册表 `label` 指定的注入器（如果存在的话）订阅给定的 `callback` 失效函数。如果未指定 `callback`，则默认使用 [`invalidator`](/learn/middleware/core-render-middleware#invalidator) 中间件，以便当注入器使其数据可用时，将当前部件标记为失效并重新渲染。
+    -   为注册表 `label` 指定的注入器（如果存在的话）订阅给定的 `callback` 失效函数。如果未指定 `callback`，则默认使用 [`invalidator`](/learn/middleware/核心渲染中间件#invalidator) 中间件，以便当注入器使其数据可用时，将当前部件标记为失效并重新渲染。
 -   `injector.get<T>(label: RegistryLabel): T | null`
     -   获取当前与给定的注册表 `label` 关联的注册器，如果注册器不存在则返回 `null`。
 
@@ -568,7 +568,7 @@ import block from '@dojo/framework/core/middleware/block';
 
 # 核心渲染中间件
 
-`@dojo/framework/core/vdom` 模块中包含基础中间件，大多数 Dojo 应用程序都会用到。这些主要用于构建其他自定义中间件（框架提供的[附加中间件](/learn/middleware/available-middleware)就是由他们构成的），但在一般的部件开发中也偶尔会用到。
+`@dojo/framework/core/vdom` 模块中包含基础中间件，大多数 Dojo 应用程序都会用到。这些主要用于构建其他自定义中间件（框架提供的[附加中间件](/learn/middleware/可用的中间件)就是由他们构成的），但在一般的部件开发中也偶尔会用到。
 
 ## `invalidator`
 
@@ -600,7 +600,7 @@ import node from '@dojo/framework/core/vdom';
 
 通过为指定的属性注册自己的 diff 函数，以允许部件对差异检测进行细粒度控制。当尝试重新渲染部件时，框架将调用该函数，以确定是否发生了变化，从而需要进行完全的重新渲染。如果在部件的属性集中没有检测到差异，将跳过更新，并且现有的所有 DOM 节点都保持原样。
 
-编写自定义的 diff 函数时，通常需要与 [`invalidator`](/learn/middleware/core-render-middleware#invalidator) 中间件组合使用，以便需要更新部件的 DOM 节点时，将当前部件标记为无效。
+编写自定义的 diff 函数时，通常需要与 [`invalidator`](/learn/middleware/核心渲染中间件#invalidator) 中间件组合使用，以便需要更新部件的 DOM 节点时，将当前部件标记为无效。
 
 **注意：** 在组合部件或中间件的生命周期中，只能为指定的属性注册一个 diff 函数，后续的调用将被忽略。渲染引擎有一套默认算法，该算法对对象和数组进行 shallow 对比，忽略函数，而对其他所有属性进行相等检查。为属性设置了自定义的 diff 函数后，将会覆盖 Dojo 默认的差异检测策略。
 

--- a/docs/zh-CN/outline/introduction.md
+++ b/docs/zh-CN/outline/introduction.md
@@ -11,15 +11,15 @@ Dojo 提供了各种各样的框架组件、工具以及构建管道，它们协
 
 ## 管理复杂的应用程序
 
--   开发[称为 **Widget** 的简单且模块化的组件](/learn/creating-widgets/widget-fundamentals#basic-widget-structure)，这些组件可通过多种方式组装，以实现日益复杂的需求。
--   使用[响应式的状态管理和数据流](/learn/creating-widgets/managing-state)来连接部件，当应用程序的状态更改时，Dojo 框架就可以高效地渲染更新。
+-   开发[称为 **Widget** 的简单且模块化的组件](/learn/creating-widgets/部件的基本原理#基本的部件结构)，这些组件可通过多种方式组装，以实现日益复杂的需求。
+-   使用[响应式的状态管理和数据流](/learn/creating-widgets/状态管理)来连接部件，当应用程序的状态更改时，Dojo 框架就可以高效地渲染更新。
 -   使用[集中的、面向命令的数据存储](/learn/stores/introduction)来管理高级的应用程序状态。
 -   允许用户使用[声明式路由](/learn/routing/route-configuration)在单页面应用程序（SPA）内导航，并支持跟踪历史记录。
 -   通过功能切换检测来禁用处于开发阶段的功能——甚至在构建时删除未使用的模块，缩减应用程序的交付大小。编写适合在浏览器或服务器上运行的程序。
 
 ## 创建高效的应用程序
 
--   通过[虚拟化 DOM（VDOM）](/learn/creating-widgets/rendering-widgets#working-with-the-vdom)声明部件结构，避免高昂的 DOM 操作和布局抖动。
+-   通过[虚拟化 DOM（VDOM）](/learn/creating-widgets/渲染部件#使用-vdom)声明部件结构，避免高昂的 DOM 操作和布局抖动。
 -   简化[资源分层和绑定](/learn/building/creating-bundles)，缩减用户实际需要的应用程序交互时间（Time-to-Interactive）。当模块及其依赖跨多个绑定时，Dojo 框架能自动将 import 转换为延迟加载。
 
 ## 创建全面的应用程序
@@ -32,7 +32,7 @@ Dojo 提供了各种各样的框架组件、工具以及构建管道，它们协
 
 -   开发[渐进式 web 应用程序（PWA）](/learn/building/progressive-web-applications)，支持与本地设备 APP 类似的功能，如离线使用、后台数据同步和推送通知。
 -   使用[构建时渲染（BTR）](/learn/building/buildtime-rendering)，提供可以与服务器端渲染（SSR）的应用程序媲美的预渲染功能，并且不需要托管到动态的 web 服务器上。创建完全不使用 JavaScript 的、真正的静态站点；或者借助 BTR 让应用程序实现更好的首次加载体验。
--   利用先进的 web 技术，如 [Web Animations](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)、[Intersection Observers](/learn/middleware/available-middleware#intersection) 和 [Resize Observers](/learn/middleware/available-middleware#resize)。Dojo 框架为用户在多种运行环境上使用最新功能提供了一致的应用程序体验。
+-   利用先进的 web 技术，如 [Web Animations](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)、[Intersection Observers](/learn/middleware/可用的中间件#intersection) 和 [Resize Observers](/learn/middleware/可用的中间件#resize)。Dojo 框架为用户在多种运行环境上使用最新功能提供了一致的应用程序体验。
 -   如果需要的话，需要定制的应用程序可以[脱离 Dojo 的构建管道](/learn/building/ejecting)，转而使用自己的解决方案，并只使用框架提供的部分功能。
 
 ## 加快开发

--- a/docs/zh-CN/outline/supplemental.md
+++ b/docs/zh-CN/outline/supplemental.md
@@ -53,13 +53,13 @@ Dojo 中的部件与 DOM 元素类似，是 Dojo 应用程序中封装的核心�
 
 类似地，并非 DOM 中的所有元素都对用户可见，Dojo 部件不仅提供用户界面，也可以实现应用程序的所有幕后需求。
 
-详见[创建 Dojo 部件参考文档](/learn/creating-widgets/widget-fundamentals)，了解如何在应用程序中创建部件。
+详见[创建 Dojo 部件参考文档](/learn/creating-widgets/部件的基本原理)，了解如何在应用程序中创建部件。
 
 ## TypeScript 模块
 
-Dojo 部件可以是一个渲染函数工厂或者 TypeScript 类，通常包含在单个 TypeScript 模块中。该模块封装了组成部件的大部分内容，包括它的行为以及[虚拟 DOM](/learn/creating-widgets/rendering-widgets#working-with-the-vdom) 的语义化表示。
+Dojo 部件可以是一个渲染函数工厂或者 TypeScript 类，通常包含在单个 TypeScript 模块中。该模块封装了组成部件的大部分内容，包括它的行为以及[虚拟 DOM](/learn/creating-widgets/渲染部件#使用-vdom) 的语义化表示。
 
-部件通过[属性](/learn/creating-widgets/configuring-widgets-through-properties)接口向外部消费者提供 API。这个接口既可包含状态字段列表，在渲染时注入到部件中；也可以包含函数，当事件发生时，部件需要通知应用程序的其他部分时调用，比如部件状态的变更。
+部件通过[属性](/learn/creating-widgets/通过属性配置部件)接口向外部消费者提供 API。这个接口既可包含状态字段列表，在渲染时注入到部件中；也可以包含函数，当事件发生时，部件需要通知应用程序的其他部分时调用，比如部件状态的变更。
 
 ## CSS 模块
 
@@ -69,7 +69,7 @@ Dojo 部件可以是一个渲染函数工厂或者 TypeScript 类，通常包含
 
 虽然部件的 CSS 模块可以完全封装自身的样式，但通常也需要一些灵活性。部件可以在应用程序的不同配置下使用，每个配置都有自己独特的外观需求。Dojo 提供了覆盖特定样式的能力以满足这个需求。
 
-为了支持应用程序层面外观的一致性，可以通过[主题](/learn/overview/user-experience#theming)进一步控制部件的样式。
+为了支持应用程序层面外观的一致性，可以通过[主题](/learn/overview/用户体验#主题)进一步控制部件的样式。
 
 详见 [Dojo 样式和主题参考文档](/learn/styling/introduction)，了解如何为单个部件设置样式。
 
@@ -108,9 +108,9 @@ Dojo 部件可以是一个渲染函数工厂或者 TypeScript 类，通常包含
 
 ## Dojo 的状态管理
 
-对于最[基本的状态管理](/learn/creating-widgets/managing-state#basic-self-encapsulated-widget-state)需求，部件可以使用本地变量管理自身的状态。虽然这种方法有助于隔离和封装，但它只适用于非常简单的用例，如只在应用程序中出现一次的部件，或者与应用程序处理的所有其他状态都断开了连接的部件。
+对于最[基本的状态管理](/learn/creating-widgets/状态管理#基础自封装的部件状态)需求，部件可以使用本地变量管理自身的状态。虽然这种方法有助于隔离和封装，但它只适用于非常简单的用例，如只在应用程序中出现一次的部件，或者与应用程序处理的所有其他状态都断开了连接的部件。
 
-随着在部件间共享状态的需求增加，Dojo 支持响应式的控制反转。将状态提升到父容器部件中，然后使用子部件的 [properties 接口](/learn/creating-widgets/managing-state#intermediate-passing-widget-properties)注入到子部件中。如果需要，这种状态提升可以横穿整个部件层级，将状态集中在应用程序根部件中，然后将部分状态注入到相关的子分支中。
+随着在部件间共享状态的需求增加，Dojo 支持响应式的控制反转。将状态提升到父容器部件中，然后使用子部件的 [properties 接口](/learn/creating-widgets/状态管理#中级传入部件属性)注入到子部件中。如果需要，这种状态提升可以横穿整个部件层级，将状态集中在应用程序根部件中，然后将部分状态注入到相关的子分支中。
 
 对于更复杂的需求，或者对于较深的部件层级且不希望在不相关的中间层传递状态，则外部的数据存储可能是最好的方法。集中的数据存储能够帮助应用程序处理大量的状态，允许复杂的状态编辑操作，或者在多处请求相同的状态子集。
 
@@ -139,7 +139,7 @@ Dojo 的样式管道使用 CSS 模块将样式规则封装到特定的部件中�
 
 通过[部件套件](https://github.com/dojo/widgets/blob/master/README.md)，Dojo 提供了一些现成的 UI 组件。开发人员可以立即使用这些部件制作许多常见的页面，如 combobox、button、list、tab、text input 和 calendar 等部件。
 
-Dojo 的部件支持[国际化、可访问性](/learn/overview/accessibility-and-internationalization)和[主题](/learn/overview/user-experience#theming)，让开发人员在无需自定义 UI 组件的情况下，能够灵活的交付应用程序专有的用户体验。
+Dojo 的部件支持[国际化、可访问性](/learn/overview/可访问性与国际化)和[主题](/learn/overview/用户体验#主题)，让开发人员在无需自定义 UI 组件的情况下，能够灵活的交付应用程序专有的用户体验。
 
 ## 导航路由
 
@@ -161,7 +161,7 @@ Dojo 的路由系统允许将 URL 的子路径注册为路由，以链接到某�
 
 类似于在传统 HTML 页面中使用的锚点，应用程序可以使用与 Outlet 关联的 Link 部件向用户提供导航选项。
 
-当使用路由时，Dojo 的构建系统能为应用程序中的所有顶级路由[自动生成单独的包](/learn/overview/efficiency-and-performance#automated-layering)。然后可以根据需要将每个包独立的交付给用户。
+当使用路由时，Dojo 的构建系统能为应用程序中的所有顶级路由[自动生成单独的包](/learn/overview/效率和性能#自动分层)。然后可以根据需要将每个包独立的交付给用户。
 
 详见 [Dojo 路由参考指南](/learn/routing/introduction)，了解如何在自己的应用程序中实现路由。
 
@@ -173,7 +173,7 @@ Dojo 的路由系统允许将 URL 的子路径注册为路由，以链接到某�
 
 近年来，随着 web 应用程序越来越复杂，浏览器已通过 DOM 性能优化做出了回应，针对动态内容作了优化。然而，为了渲染用户界面，web 应用程序仍然需要与一套几十年不变的命令式 API 交互。围绕响应式数据传播而设计的现代 web 应用程序需要一种更高效的方式，将用户界面转换为网页的 DOM。
 
-Dojo 将 DOM 从应用程序中抽象出来，推荐使用响应式状态流来最小化应用程序的样板文件，同时提高了渲染性能。部件会在渲染函数中输出虚拟节点，这些渲染函数使用[虚拟 DOM](/learn/creating-widgets/rendering-widgets#working-with-the-vdom) 描述部件的结构层级。然后，框架以尽可能高效的方式处理 VDOM 的[渲染](/learn/creating-widgets/rendering-widgets#rendering-to-the-dom)，只会影响实际需要修改的 DOM 元素。
+Dojo 将 DOM 从应用程序中抽象出来，推荐使用响应式状态流来最小化应用程序的样板文件，同时提高了渲染性能。部件会在渲染函数中输出虚拟节点，这些渲染函数使用[虚拟 DOM](/learn/creating-widgets/渲染部件#使用-vdom) 描述部件的结构层级。然后，框架以尽可能高效的方式处理 VDOM 的[渲染](/learn/creating-widgets/渲染部件#渲染到-dom-中)，只会影响实际需要修改的 DOM 元素。
 
 需要从 DOM 中获取具体信息来实现其需求的应用程序，Dojo 通过[中间件](/learn/middleware/introduction)系统提供了另一种 DOM 抽象层。Dojo 中间件以一致的方式解决了这些问题，并仍然支持横跨应用程序的响应式数据流。
 
@@ -191,7 +191,7 @@ Dojo 将 DOM 从应用程序中抽象出来，推荐使用响应式状态流来�
 
 ### 自动分层
 
-当使用 Dojo 的[路由系统](/learn/overview/user-experience#navigational-routing)时，应用程序可以从自动分层和打包中获益。应用程序中的每个顶级路由都成为一个单独的层，Dojo 的构建系统会自动打包每层内容。这样就可以对层分离，以及打包资源，而不需要配置额外的工具链。这种自动化方案有一处折衷，即在每个包中都内联和复制了跨多个层的公共依赖项。
+当使用 Dojo 的[路由系统](/learn/overview/用户体验#导航路由)时，应用程序可以从自动分层和打包中获益。应用程序中的每个顶级路由都成为一个单独的层，Dojo 的构建系统会自动打包每层内容。这样就可以对层分离，以及打包资源，而不需要配置额外的工具链。这种自动化方案有一处折衷，即在每个包中都内联和复制了跨多个层的公共依赖项。
 
 ### 声明分层
 
@@ -219,7 +219,7 @@ Dojo 允许轻松使用消息包将文本消息从应用程序逻辑中分离出
 
 渐进式 web 应用程序（[PWA](/learn/building/progressive-web-applications)）有助于提供与本地设备 App 接近的体验，同时依然能从 web 支持的可移植性和易交付等功能中受益。Dojo 通过简单的构建配置就能帮助创建 [PWA](/learn/building/progressive-web-applications)，开发人员可以在应用程序中添加离线使用、后台数据同步和推送通知等。
 
-Dojo 允许开发人员通过[中间件](/learn/middleware/introduction)系统，在所有的交付目标上以一致的方式使用几个即将可用的 web API。[Intersection observer](/learn/middleware/available-middleware#intersection) API 用于更好的控制渲染，仅渲染用户可见的部件，例如支持无线滚动列表。[Resize observer](/learn/middleware/available-middleware#resize) API 能够让应用程序动态响应视窗大小的变化，允许界面在桌面和移动视窗的所有分辨率间逐步适应。
+Dojo 允许开发人员通过[中间件](/learn/middleware/introduction)系统，在所有的交付目标上以一致的方式使用几个即将可用的 web API。[Intersection observer](/learn/middleware/可用的中间件#intersection) API 用于更好的控制渲染，仅渲染用户可见的部件，例如支持无线滚动列表。[Resize observer](/learn/middleware/可用的中间件#resize) API 能够让应用程序动态响应视窗大小的变化，允许界面在桌面和移动视窗的所有分辨率间逐步适应。
 
 # 应用程序的开发生命周期
 

--- a/docs/zh-CN/stores/introduction.md
+++ b/docs/zh-CN/stores/introduction.md
@@ -300,7 +300,7 @@ process(store)({ one: 'one', two: 'two' });
 
 有两个状态容器可用于部件：`StoreContainer` 和 `StoreProvider`。这些容器将应用程序的 store 与部件关联起来。当使用函数部件时，也可以创建类型化的 store 中间件。
 
-注意，本节旨在介绍部件和状态（通过 store 提供的）是如何关联起来的。有关部件状态管理的更多信息，请参阅[创建部件参考指南](/learn/creating-widgets/managing-state)。
+注意，本节旨在介绍部件和状态（通过 store 提供的）是如何关联起来的。有关部件状态管理的更多信息，请参阅[创建部件参考指南](/learn/creating-widgets/状态管理)。
 
 ### Store 中间件
 

--- a/docs/zh-CN/testing/supplemental.md
+++ b/docs/zh-CN/testing/supplemental.md
@@ -20,7 +20,7 @@ harness(renderFunction: () => WNode, options?: HarnessOptions): Harness;
 ```
 
 -   `renderFunction`: 返回被测部件 WNode 的函数
--   [`customComparators`](/learn/testing/dojo-test-harness#custom-comparators): 一组自定义的比较器描述符。每个描述符提供一个比较器函数，用于比较通过 `selector` 和 `property` 定位到的 `properties`
+-   [`customComparators`](/learn/testing/dojo-test-harness#自定义比较): 一组自定义的比较器描述符。每个描述符提供一个比较器函数，用于比较通过 `selector` 和 `property` 定位到的 `properties`
 -   `options`: harness 的扩展选项，包括 `customComparators` 和一组 middleware/mocks 元组。
 
 harness 函数返回一个 `Harness` 对象，该对象提供了几个与被测部件交互的 API：


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

A couple of back ports for the translated doc content.