### PR TITLE
Ensure the rendering flag is reset correctly

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1390,6 +1390,9 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		_cleanUpMergedNodes();
 		_insertBeforeMap = undefined;
 		_runDeferredRenderCallbacks();
+		if (!_renderScheduled) {
+			setRendering(false);
+		}
 	}
 
 	function invalidate() {
@@ -1473,7 +1476,9 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		_runDomInstructionQueue();
 		_cleanUpMergedNodes();
 		_runDeferredRenderCallbacks();
-		setRendering(false);
+		if (!_renderScheduled) {
+			setRendering(false);
+		}
 	}
 
 	function _cleanUpMergedNodes() {

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -6501,6 +6501,32 @@ jsdomDescribe('vdom', () => {
 			decrementBlockCount();
 			assert.strictEqual(global.dojo_scope.blocksPending, 0);
 		});
+
+		it('should not set rendering to false if a render has been scheduled', () => {
+			const factory = create({ icache }).properties<any>();
+			let key = 0;
+			const Foo = factory(function App({ properties }) {
+				properties().doSomething();
+				return <div></div>;
+			});
+			const App = factory(function App({ middleware: { icache }}) {
+				return <Foo key={key} doSomething={() => {
+					icache.set('key', key);
+				}}></Foo>
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App/>);
+			r.mount({ domNode });
+			assert.strictEqual(global.dojo_scope.rendering, true);
+			key++;
+			resolvers.resolve();
+			assert.strictEqual(global.dojo_scope.rendering, true);
+			key++;
+			resolvers.resolve();
+			assert.strictEqual(global.dojo_scope.rendering, true);
+			resolvers.resolve();
+			assert.strictEqual(global.dojo_scope.rendering, false);
+		});
 	});
 
 	describe('focus', () => {

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -6507,15 +6507,20 @@ jsdomDescribe('vdom', () => {
 			let key = 0;
 			const Foo = factory(function App({ properties }) {
 				properties().doSomething();
-				return <div></div>;
+				return <div />;
 			});
-			const App = factory(function App({ middleware: { icache }}) {
-				return <Foo key={key} doSomething={() => {
-					icache.set('key', key);
-				}}></Foo>
+			const App = factory(function App({ middleware: { icache } }) {
+				return (
+					<Foo
+						key={key}
+						doSomething={() => {
+							icache.set('key', key);
+						}}
+					/>
+				);
 			});
 			const domNode = document.createElement('div');
-			const r = renderer(() => <App/>);
+			const r = renderer(() => <App />);
 			r.mount({ domNode });
 			assert.strictEqual(global.dojo_scope.rendering, true);
 			key++;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure the rendering flag is set correctly based on the _renderScheduled flag.
