### PR TITLE
Ensure that diff property call backs are called immediately when registered

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -878,6 +878,7 @@ export const diffProperty = factory(({ id }) => {
 			widgetMeta.customDiffProperties = widgetMeta.customDiffProperties || new Set();
 			const propertyDiffMap = widgetMeta.customDiffMap.get(id) || new Map();
 			if (!propertyDiffMap.has(propertyName)) {
+				diff({}, widgetMeta.properties);
 				propertyDiffMap.set(propertyName, diff);
 				widgetMeta.customDiffProperties.add(propertyName);
 			}

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -3851,11 +3851,7 @@ jsdomDescribe('vdom', () => {
 							return v('div', [`${counter}`]);
 						});
 						const App = createWidget(() => {
-							return v('div', [
-								v('button', {
-								}),
-								Foo({ key: 'foo' })
-							]);
+							return v('div', [v('button', {}), Foo({ key: 'foo' })]);
 						});
 						const r = renderer(() => App({}));
 						const root = document.createElement('div');

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -3790,7 +3790,6 @@ jsdomDescribe('vdom', () => {
 						let counter = 0;
 						const Foo = createWidget(({ middleware }) => {
 							middleware.diffProperty('key', (current: any, properties: any) => {
-								assert.deepEqual(current, { key: 'foo' });
 								assert.deepEqual(properties, { key: 'foo' });
 								middleware.invalidator();
 							});

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -3841,6 +3841,29 @@ jsdomDescribe('vdom', () => {
 						resolvers.resolve();
 						assert.strictEqual(root.outerHTML, '<div><div><button></button><div>first</div></div></div>');
 					});
+
+					it('should call diff property for the first render', () => {
+						const createWidget = create({ diffProperty });
+						let counter = 0;
+						const Foo = createWidget(({ middleware }) => {
+							middleware.diffProperty('key', () => {
+								counter++;
+							});
+							return v('div', [`${counter}`]);
+						});
+						const App = createWidget(() => {
+							return v('div', [
+								v('button', {
+								}),
+								Foo({ key: 'foo' })
+							]);
+						});
+						const r = renderer(() => App({}));
+						const root = document.createElement('div');
+						r.mount({ domNode: root });
+						assert.strictEqual(root.outerHTML, '<div><div><button></button><div>1</div></div></div>');
+						sendEvent(root.childNodes[0].childNodes[0] as HTMLButtonElement, 'click');
+					});
 				});
 			});
 		});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

`diffProperty` callbacks are not called for the first render which could mean that logic the user requires to run _every_ render. This changes ensures that the diff properties are executed immediately when registered, subsequently they will be executed as they are currently.
