### PR TITLE
Ensure that diff property call backs are called immediately when registered (#572)

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -763,6 +763,7 @@ export const diffProperty = factory(({ id }) => {
 			widgetMeta.customDiffProperties = widgetMeta.customDiffProperties || new Set();
 			const propertyDiffMap = widgetMeta.customDiffMap.get(id) || new Map();
 			if (!propertyDiffMap.has(propertyName)) {
+				diff({}, widgetMeta.properties);
 				propertyDiffMap.set(propertyName, diff);
 				widgetMeta.customDiffProperties.add(propertyName);
 			}

--- a/tests/core/unit/vdom.ts
+++ b/tests/core/unit/vdom.ts
@@ -3672,7 +3672,6 @@ jsdomDescribe('vdom', () => {
 						let counter = 0;
 						const Foo = createWidget(({ middleware }) => {
 							middleware.diffProperty('key', (current: any, properties: any) => {
-								assert.deepEqual(current, { key: 'foo' });
 								assert.deepEqual(properties, { key: 'foo' });
 								middleware.invalidator();
 							});
@@ -3722,6 +3721,25 @@ jsdomDescribe('vdom', () => {
 						sendEvent(root.childNodes[0].childNodes[0] as HTMLButtonElement, 'click');
 						resolvers.resolve();
 						assert.strictEqual(root.outerHTML, '<div><div><button></button><div>first</div></div></div>');
+					});
+
+					it('should call diff property for the first render', () => {
+						const createWidget = create({ diffProperty });
+						let counter = 0;
+						const Foo = createWidget(({ middleware }) => {
+							middleware.diffProperty('key', () => {
+								counter++;
+							});
+							return v('div', [`${counter}`]);
+						});
+						const App = createWidget(() => {
+							return v('div', [v('button', {}), Foo({ key: 'foo' })]);
+						});
+						const r = renderer(() => App({}));
+						const root = document.createElement('div');
+						r.mount({ domNode: root });
+						assert.strictEqual(root.outerHTML, '<div><div><button></button><div>1</div></div></div>');
+						sendEvent(root.childNodes[0].childNodes[0] as HTMLButtonElement, 'click');
 					});
 				});
 			});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Backport of #572 

* failing unit test for diff property on the first render
* Call diff properties immediately when they are registered
* prettier
