### PR TITLE
update zh-CN building doc links

### DIFF
--- a/docs/zh-CN/middleware/supplemental.md
+++ b/docs/zh-CN/middleware/supplemental.md
@@ -555,7 +555,7 @@ import injector from '@dojo/framework/core/middleware/injector';
 
 在构建时，允许部件在 Node.js 中执行称为 **blocks** 的模块。通常用于构建时渲染。
 
-在[构建(build)参考指南](/learn/building/buildtime-rendering)中有详细说明。
+在[构建(build)参考指南](/learn/building/构建时渲染)中有详细说明。
 
 **API:**
 

--- a/docs/zh-CN/outline/introduction.md
+++ b/docs/zh-CN/outline/introduction.md
@@ -20,7 +20,7 @@ Dojo 提供了各种各样的框架组件、工具以及构建管道，它们协
 ## 创建高效的应用程序
 
 -   通过[虚拟化 DOM（VDOM）](/learn/creating-widgets/渲染部件#使用-vdom)声明部件结构，避免高昂的 DOM 操作和布局抖动。
--   简化[资源分层和绑定](/learn/building/creating-bundles)，缩减用户实际需要的应用程序交互时间（Time-to-Interactive）。当模块及其依赖跨多个绑定时，Dojo 框架能自动将 import 转换为延迟加载。
+-   简化[资源分层和绑定](/learn/building/创建包)，缩减用户实际需要的应用程序交互时间（Time-to-Interactive）。当模块及其依赖跨多个绑定时，Dojo 框架能自动将 import 转换为延迟加载。
 
 ## 创建全面的应用程序
 
@@ -30,10 +30,10 @@ Dojo 提供了各种各样的框架组件、工具以及构建管道，它们协
 
 ## 创建可适配的应用程序
 
--   开发[渐进式 web 应用程序（PWA）](/learn/building/progressive-web-applications)，支持与本地设备 APP 类似的功能，如离线使用、后台数据同步和推送通知。
--   使用[构建时渲染（BTR）](/learn/building/buildtime-rendering)，提供可以与服务器端渲染（SSR）的应用程序媲美的预渲染功能，并且不需要托管到动态的 web 服务器上。创建完全不使用 JavaScript 的、真正的静态站点；或者借助 BTR 让应用程序实现更好的首次加载体验。
+-   开发[渐进式 web 应用程序（PWA）](/learn/building/渐进式-web-应用程序)，支持与本地设备 APP 类似的功能，如离线使用、后台数据同步和推送通知。
+-   使用[构建时渲染（BTR）](/learn/building/构建时渲染)，提供可以与服务器端渲染（SSR）的应用程序媲美的预渲染功能，并且不需要托管到动态的 web 服务器上。创建完全不使用 JavaScript 的、真正的静态站点；或者借助 BTR 让应用程序实现更好的首次加载体验。
 -   利用先进的 web 技术，如 [Web Animations](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)、[Intersection Observers](/learn/middleware/可用的中间件#intersection) 和 [Resize Observers](/learn/middleware/可用的中间件#resize)。Dojo 框架为用户在多种运行环境上使用最新功能提供了一致的应用程序体验。
--   如果需要的话，需要定制的应用程序可以[脱离 Dojo 的构建管道](/learn/building/ejecting)，转而使用自己的解决方案，并只使用框架提供的部分功能。
+-   如果需要的话，需要定制的应用程序可以[脱离 Dojo 的构建管道](/learn/building/脱离-dojo-构建管道)，转而使用自己的解决方案，并只使用框架提供的部分功能。
 
 ## 加快开发
 

--- a/docs/zh-CN/outline/supplemental.md
+++ b/docs/zh-CN/outline/supplemental.md
@@ -197,7 +197,7 @@ Dojo 将 DOM 从应用程序中抽象出来，推荐使用响应式状态流来�
 
 复杂的应用程序可能需要对层或包的定义做更细粒度的控制。例如，如果应用程序有一组横跨多个路由的公共依赖项，不要在每个包中内联或复制这些依赖，则需要将公共依赖提取到自己的包中，然后在第一次引用时延迟加载。
 
-Dojo 的构建管道允许在应用程序的 `.dojorc` 构建配置文件中指定资源[包](/learn/building/creating-bundles)，然后能自动将横跨多个包的模块依赖项转换为延迟加载的引用。
+Dojo 的构建管道允许在应用程序的 `.dojorc` 构建配置文件中指定资源[包](/learn/building/介绍)，然后能自动将横跨多个包的模块依赖项转换为延迟加载的引用。
 
 # 可访问性与国际化
 
@@ -215,9 +215,9 @@ Dojo 允许轻松使用消息包将文本消息从应用程序逻辑中分离出
 
 当前社会，Internet 的重要性与日俱增，应用程序被要求能适应用户访问 web 的各种方式。较小尺寸的移动体验已经超过了桌面，但较大的外观仍然可以满足复杂的应用程序需求。Dojo 提供了多种解决方案，帮助开发人员创建适应用户访问需求的应用程序。
 
-当需要预渲染内容时（如开发静态站点时），Dojo 应用程序可以利用构建时渲染（[BTR](/learn/building/buildtime-rendering)），应用程序结构的一部分或全部都是在构建时计算的，而不是在用户浏览器中运行时计算的。Dojo 提供了一个灵活的基于块 [BTR](/learn/building/buildtime-rendering) 的解决方案，当构建应用程序时能运行 Node.js 脚本，支持读取文件来获取内容等功能。Dojo 的 BTR 解决方案也支持渐进式融合，以在预渲染内容之上支持动态行为。
+当需要预渲染内容时（如开发静态站点时），Dojo 应用程序可以利用构建时渲染（[BTR](/learn/building/构建时渲染)），应用程序结构的一部分或全部都是在构建时计算的，而不是在用户浏览器中运行时计算的。Dojo 提供了一个灵活的基于块 [BTR](/learn/building/构建时渲染) 的解决方案，当构建应用程序时能运行 Node.js 脚本，支持读取文件来获取内容等功能。Dojo 的 BTR 解决方案也支持渐进式融合，以在预渲染内容之上支持动态行为。
 
-渐进式 web 应用程序（[PWA](/learn/building/progressive-web-applications)）有助于提供与本地设备 App 接近的体验，同时依然能从 web 支持的可移植性和易交付等功能中受益。Dojo 通过简单的构建配置就能帮助创建 [PWA](/learn/building/progressive-web-applications)，开发人员可以在应用程序中添加离线使用、后台数据同步和推送通知等。
+渐进式 web 应用程序（[PWA](/learn/building/渐进式-web-应用程序)）有助于提供与本地设备 App 接近的体验，同时依然能从 web 支持的可移植性和易交付等功能中受益。Dojo 通过简单的构建配置就能帮助创建 [PWA](/learn/building/渐进式-web-应用程序)，开发人员可以在应用程序中添加离线使用、后台数据同步和推送通知等。
 
 Dojo 允许开发人员通过[中间件](/learn/middleware/introduction)系统，在所有的交付目标上以一致的方式使用几个即将可用的 web API。[Intersection observer](/learn/middleware/可用的中间件#intersection) API 用于更好的控制渲染，仅渲染用户可见的部件，例如支持无线滚动列表。[Resize observer](/learn/middleware/可用的中间件#resize) API 能够让应用程序动态响应视窗大小的变化，允许界面在桌面和移动视窗的所有分辨率间逐步适应。
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Change inter-docs links for building docs.