### PR TITLE
Fix state in focus middleware

### DIFF
--- a/tests/core/unit/middleware/focus.ts
+++ b/tests/core/unit/middleware/focus.ts
@@ -57,6 +57,10 @@ describe('focus middleware', () => {
 		assert.isFalse(focus.shouldFocus());
 		focus.focus();
 		assert.isTrue(focus.shouldFocus());
+		assert.isFalse(focus.shouldFocus());
+		focus.focus();
+		assert.isTrue(focus.shouldFocus());
+		assert.isFalse(focus.shouldFocus());
 	});
 
 	it('`shouldFocus` returns true when focus property returns true', () => {

--- a/tests/core/unit/middleware/focus.ts
+++ b/tests/core/unit/middleware/focus.ts
@@ -45,7 +45,6 @@ describe('focus middleware', () => {
 			id: 'test',
 			middleware: {
 				diffProperty: diffPropertyStub,
-				cache: cacheFactory(),
 				icache: icacheFactory(),
 				destroy: destroyStub,
 				node: nodeStub,
@@ -69,7 +68,6 @@ describe('focus middleware', () => {
 			id: 'test',
 			middleware: {
 				diffProperty: diffPropertyStub,
-				cache: cacheFactory(),
 				icache: icacheFactory(),
 				destroy: destroyStub,
 				node: nodeStub,
@@ -88,7 +86,6 @@ describe('focus middleware', () => {
 			id: 'test',
 			middleware: {
 				diffProperty: diffPropertyStub,
-				cache: cacheFactory(),
 				icache: icacheFactory(),
 				destroy: destroyStub,
 				node: nodeStub,
@@ -107,7 +104,6 @@ describe('focus middleware', () => {
 			id: 'test',
 			middleware: {
 				diffProperty: diffPropertyStub,
-				cache: cacheFactory(),
 				icache: icacheFactory(),
 				destroy: destroyStub,
 				node: nodeStub,
@@ -125,7 +121,6 @@ describe('focus middleware', () => {
 			id: 'test',
 			middleware: {
 				diffProperty: diffPropertyStub,
-				cache: cacheFactory(),
 				icache: icacheFactory(),
 				destroy: destroyStub,
 				node: nodeStub,


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The state in the focus middleware was incorrectly getting the current value from the cache, but setting it in the icache. This means that after the first focus call, `shouldFocus` would always be `false`. This highlights just one of the issues with mixing icache and cache.

This changes the logic to use icache for everything except the active element which is simply kept in the scope of the middlware.
