### PR TITLE
Ensure assertion template children are immutable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4624,18 +4624,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.42.0"
       }
     },
     "mimic-fn": {
@@ -6953,9 +6953,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/src/testing/assertionTemplate.ts
+++ b/src/testing/assertionTemplate.ts
@@ -121,18 +121,19 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 			const render = renderFunc();
 			const node = findOne(render, selector);
 			node.children = node.children || [];
-			if (typeof children === 'function') {
-				children = children();
+			let childrenResult = children;
+			if (typeof childrenResult === 'function') {
+				childrenResult = childrenResult();
 			}
 			switch (type) {
 				case 'prepend':
-					node.children = [...children, ...node.children];
+					node.children = [...childrenResult, ...node.children];
 					break;
 				case 'append':
-					node.children = [...node.children, ...children];
+					node.children = [...node.children, ...childrenResult];
 					break;
 				case 'replace':
-					node.children = [...children];
+					node.children = [...childrenResult];
 					break;
 			}
 			return render;
@@ -156,7 +157,7 @@ export function assertionTemplate(renderFunc: () => DNode | DNode[]) {
 		}
 		return assertionTemplate(() => {
 			const render = renderFunc();
-			const insertedChildren = typeof children === 'function' ? (children = children()) : children;
+			const insertedChildren = typeof children === 'function' ? children() : children;
 			return replaceChildren(selector, render, (index, children) => {
 				if (type === 'after') {
 					children.splice(index + 1, 0, ...insertedChildren);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that children set on assertion templates are always immutable.

Resolves #586 
