### PR TITLE
Type i18n format function using the passed bundle message keys

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -680,7 +680,7 @@ export type LocalizedMessages<T extends Messages> = {
 	 * @return
 	 * The formatted string.
 	 */
-	format(key: string, options?: any): string;
+	format(key: keyof T, options?: any): string;
 
 	/**
 	 * The localized messages if available, or either the default messages or a blank bundle depending on the

--- a/src/core/middleware/i18n.ts
+++ b/src/core/middleware/i18n.ts
@@ -91,7 +91,7 @@ export const i18n = factory(({ properties, middleware: { invalidator, injector, 
 			const format =
 				isPlaceholder && !useDefaults
 					? () => ''
-					: (key: string, options?: any) => formatMessage(bundle, key, options, locale);
+					: (key: keyof T, options?: any) => formatMessage(bundle, key as string, options, locale);
 
 			return Object.create({
 				format,


### PR DESCRIPTION
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR prevents i18n middleware users from passing keys that aren't part of the bundle messages to the `format` function.

![i18nformat](https://user-images.githubusercontent.com/8822075/69875487-2e191e00-12b5-11ea-8af2-8c9e97de7b9e.png)


Resolves #591 
