### PR TITLE
Ensure mixins properties are inferred when using tsx

### DIFF
--- a/src/core/WidgetBase.ts
+++ b/src/core/WidgetBase.ts
@@ -93,7 +93,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	 * property specifically for typing when using tsx
 	 */
 	/* tslint:disable-next-line:variable-name */
-	public __properties__!: P & WidgetProperties & { __children__?: DNode[] | DNode };
+	public __properties__!: this['properties'] & WidgetProperties & { __children__?: DNode[] | DNode };
 
 	/**
 	 * children array

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -569,7 +569,7 @@ export interface WidgetBaseInterface<P = WidgetProperties, C extends DNode = DNo
 	/**
 	 * property used for typing with tsx
 	 */
-	__properties__: P & { __children__?: DNode[] | DNode };
+	__properties__: this['properties'] & { __children__?: DNode[] | DNode };
 }
 
 /**

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -7071,6 +7071,9 @@ jsdomDescribe('vdom', () => {
 		const root: any = document.createElement('div');
 		const r = renderer(() => <MyWidget theme={{}} classes={{}} locale="en" rtl={true} />);
 		r.mount({ domNode: root });
-		assert.strictEqual(root.innerHTML, '<div lang="en" dir="rtl">hello dojo</div>');
+
+		assert.strictEqual(root.children[0].getAttribute('lang'), 'en');
+		assert.strictEqual(root.children[0].getAttribute('dir'), 'rtl');
+		assert.strictEqual(root.children[0].innerHTML, 'hello dojo');
 	});
 });

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -28,6 +28,7 @@ import { VNode, DNode, DomVNode, RenderResult } from '../../../src/core/interfac
 import { WidgetBase } from '../../../src/core/WidgetBase';
 import Registry from '../../../src/core/Registry';
 import { I18nMixin } from '../../../src/core/mixins/I18n';
+import { ThemedMixin } from '../../../src/core/mixins/Themed';
 import icache from '../../../src/core/middleware/icache';
 import registry from '../../../src/core/decorators/registry';
 import { alwaysRender } from '../../../src/core/decorators/alwaysRender';
@@ -7059,5 +7060,17 @@ jsdomDescribe('vdom', () => {
 		const root: any = document.createElement('div');
 		r.mount({ domNode: root });
 		assert.isTrue(stubby.calledOnce);
+	});
+
+	it('infer mixin typings correctly', () => {
+		class MyWidget extends ThemedMixin(I18nMixin(WidgetBase)) {
+			render() {
+				return <div>hello dojo</div>;
+			}
+		}
+		const root: any = document.createElement('div');
+		const r = renderer(() => <MyWidget theme={{}} classes={{}} locale="en" rtl={true} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, '<div dir="rtl" lang="en">hello dojo</div>');
 	});
 });

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -7071,6 +7071,6 @@ jsdomDescribe('vdom', () => {
 		const root: any = document.createElement('div');
 		const r = renderer(() => <MyWidget theme={{}} classes={{}} locale="en" rtl={true} />);
 		r.mount({ domNode: root });
-		assert.strictEqual(root.innerHTML, '<div dir="rtl" lang="en">hello dojo</div>');
+		assert.strictEqual(root.innerHTML, '<div lang="en" dir="rtl">hello dojo</div>');
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fix property interference when using a widget with mixins via tsx.

Resolves #592 