### PR TITLE
Run comparators when using expect with an actual render argument

### DIFF
--- a/src/testing/harness.ts
+++ b/src/testing/harness.ts
@@ -223,6 +223,7 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 			renderResult = _getRender();
 		} else {
 			renderResult = actualRenderFunc();
+			_runCompares(renderResult);
 		}
 
 		const { nodes: expectedRenderResult } = decorateNodes(expectedRenderFunc());

--- a/tests/testing/unit/harness.tsx
+++ b/tests/testing/unit/harness.tsx
@@ -47,6 +47,17 @@ class MyWidget extends WidgetBase {
 	}
 }
 
+class MyWidgetWithRenderProp extends WidgetBase {
+	protected render() {
+		return v('div', {
+			key: 'root',
+			renderProp: () => {
+				return v('div', { id: 'not-going-to-match' });
+			}
+		});
+	}
+}
+
 class MyDeferredWidget extends WidgetBase {
 	// prettier-ignore
 	protected render() {
@@ -370,6 +381,19 @@ describe('harness', () => {
 					w<ChildWidget>('registry-item', { key: 'registry', id: 'random-id' })
 				])
 			);
+		});
+
+		it('custom compare for VNode returned from render prop', () => {
+			const h = harness(() => w(MyWidgetWithRenderProp, {}), [
+				{
+					selector: '*',
+					property: 'id',
+					comparator: (property: any) => typeof property === 'string'
+				}
+			]);
+			const renderResult = h.trigger('@root', 'renderProp');
+
+			h.expect(() => <div id="" />, () => renderResult);
 		});
 
 		it('custom compare for constructor WNode', () => {

--- a/tests/testing/unit/harness.tsx
+++ b/tests/testing/unit/harness.tsx
@@ -47,17 +47,6 @@ class MyWidget extends WidgetBase {
 	}
 }
 
-class MyWidgetWithRenderProp extends WidgetBase {
-	protected render() {
-		return v('div', {
-			key: 'root',
-			renderProp: () => {
-				return v('div', { id: 'not-going-to-match' });
-			}
-		});
-	}
-}
-
 class MyDeferredWidget extends WidgetBase {
 	// prettier-ignore
 	protected render() {
@@ -383,17 +372,15 @@ describe('harness', () => {
 			);
 		});
 
-		it('custom compare for VNode returned from render prop', () => {
-			const h = harness(() => w(MyWidgetWithRenderProp, {}), [
+		it('custom compare used when actual render function passed to expect', () => {
+			const h = harness(() => w(WidgetBase, {}), [
 				{
 					selector: '*',
 					property: 'id',
 					comparator: (property: any) => typeof property === 'string'
 				}
 			]);
-			const renderResult = h.trigger('@root', 'renderProp');
-
-			h.expect(() => <div id="" />, () => renderResult);
+			h.expect(() => <div id="" />, () => <div id="foo" />);
 		});
 
 		it('custom compare for constructor WNode', () => {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Runs compares for actual result on each call to `expect`

Resolves #600 
