### PR TITLE
Enable cache eviction with icache

### DIFF
--- a/docs/en/middleware/supplemental.md
+++ b/docs/en/middleware/supplemental.md
@@ -198,6 +198,10 @@ import icache from '@dojo/framework/core/middleware/icache';
     -   Retrieves the cached value for the given `key`, or `undefined` if either no value has been set, or if the value is still pending resolution.
 -   `icache.set(key: any, value: any)`
     -   Sets the provided `value` for the given `key`. If `value` is a function, it will be invoked in order to obtain the actual value to cache. If the function returns a promise, a 'pending' value will be cached until the final value is fully resolved. In all scenarios, once a value is available and has been stored in the cache, the widget will be marked as invalid so it can be re-rendered with the final value available.
+-   `icache.has(key: any): boolean`
+    -   Returns `true` or `false` based in whether the key is set in the cache.
+-   `icache.delete(key: any): void`
+    -   Remove the item from the cache.
 -   `clear()`
     -   Clears all values currently stored in the widget's local cache.
 

--- a/src/core/middleware/cache.ts
+++ b/src/core/middleware/cache.ts
@@ -15,6 +15,12 @@ export const cache = factory(({ middleware: { destroy } }) => {
 		set<T = any>(key: any, value: T): void {
 			cacheMap.set(key, value);
 		},
+		has(key: any): boolean {
+			return cacheMap.has(key);
+		},
+		delete(key: any): void {
+			cacheMap.delete(key);
+		},
 		clear(): void {
 			cacheMap.clear();
 		}

--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -31,6 +31,8 @@ export interface ICacheResult<S = void> {
 		key: void extends S ? any : T,
 		value: void extends S ? T : S[T]
 	): void;
+	has<T extends void extends S ? any : keyof S>(key: void extends S ? any : T): boolean;
+	delete<T extends void extends S ? any : keyof S>(key: void extends S ? any : T): void;
 	clear(): void;
 }
 
@@ -82,6 +84,12 @@ export function createICacheMiddleware<S = void>() {
 						value
 					});
 					invalidator();
+				},
+				has(key: any) {
+					return cache.has(key);
+				},
+				delete(key: any) {
+					cache.delete(key);
 				},
 				clear(): void {
 					cache.clear();

--- a/tests/core/unit/middleware/cache.ts
+++ b/tests/core/unit/middleware/cache.ts
@@ -42,6 +42,34 @@ describe('cache middleware', () => {
 		assert.isUndefined(cache.get('test'));
 	});
 
+	it('should return true if the key exists', () => {
+		const cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: destroyStub },
+			properties: () => ({}),
+			children: () => []
+		});
+		cache.set('test', 'value');
+		assert.isTrue(cache.has('test'));
+	});
+
+	it('should remove value for the specified key from the cache', () => {
+		const cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: destroyStub },
+			properties: () => ({}),
+			children: () => []
+		});
+		assert.isUndefined(cache.get('test'));
+		cache.set('test', 'value');
+		cache.set('test-two', 'value');
+		assert.strictEqual(cache.get('test'), 'value');
+		assert.strictEqual(cache.get('test-two'), 'value');
+		cache.delete('test');
+		assert.isUndefined(cache.get('test'));
+		assert.strictEqual(cache.get('test-two'), 'value');
+	});
+
 	it('should be able to clear the cache', () => {
 		const { callback } = cacheMiddleware();
 		const cache = callback({

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -113,6 +113,52 @@ describe('icache middleware', () => {
 		});
 	});
 
+	it('should return true if the key exists', () => {
+		const cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: sb.stub() },
+			properties: () => ({}),
+			children: () => []
+		});
+		const icache = callback({
+			id: 'test',
+			middleware: {
+				cache,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+		icache.set('test', 'value');
+		assert.isTrue(icache.has('test'));
+	});
+
+	it('should remove value for the specified key from the cache', () => {
+		const cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: sb.stub() },
+			properties: () => ({}),
+			children: () => []
+		});
+		const icache = callback({
+			id: 'test',
+			middleware: {
+				cache,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+		assert.isUndefined(icache.get('test'));
+		icache.set('test', 'value');
+		icache.set('test-two', 'value');
+		assert.strictEqual(icache.get('test'), 'value');
+		assert.strictEqual(icache.get('test-two'), 'value');
+		icache.delete('test');
+		assert.isUndefined(icache.get('test'));
+		assert.strictEqual(icache.get('test-two'), 'value');
+	});
+
 	it('should be able to clear the cache', () => {
 		const cache = cacheMiddleware().callback({
 			id: 'cache-test',


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Two new APIs for dealing with cache eviction from the `icache`.

```ts
console.log(icache.getOrSet('key', 'foo')); // logs `foo`
if (icache.has('key')) {
    icache.delete('key');
}
console.log(icache.getOrSet('key', 'bar')); // logs `bar`
```

Resolves #604 
