### PR TITLE
Fix typed icache set interface

### DIFF
--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -27,10 +27,20 @@ export interface ICacheResult<S = void> {
 	get<T extends void extends S ? any : keyof S>(
 		key: void extends S ? any : T
 	): void extends S ? T | undefined : S[T] | undefined;
-	set<T extends void extends S ? any : keyof S>(
-		key: void extends S ? any : T,
-		value: void extends S ? T : S[T]
-	): void;
+	set: {
+		<T extends void extends S ? any : keyof S>(
+			key: void extends S ? any : T,
+			value: void extends S ? () => Promise<T> : () => Promise<S[T]>
+		): void;
+		<T extends void extends S ? any : keyof S>(
+			key: void extends S ? any : T,
+			value: void extends S ? () => T : () => S[T]
+		): void;
+		<T extends void extends S ? any : keyof S>(
+			key: void extends S ? any : T,
+			value: void extends S ? T : S[T]
+		): void;
+	};
 	has<T extends void extends S ? any : keyof S>(key: void extends S ? any : T): boolean;
 	delete<T extends void extends S ? any : keyof S>(key: void extends S ? any : T): void;
 	clear(): void;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure the typings are correct for `icache.set` when working with functions or promise factories.

Resolves #606 
