### PR TITLE
Deprecate cache middleware and add optional flag to skip invalidation with the icache

### DIFF
--- a/docs/en/middleware/supplemental.md
+++ b/docs/en/middleware/supplemental.md
@@ -165,26 +165,9 @@ r.mount();
 
 Dojo provides a variety of optional middleware that widgets can include when needing to implement specific requirements.
 
-## `cache`
-
-Provides a simple widget-scoped cache that can persist small amounts of data between widget renders.
-
-**API:**
-
-```ts
-import cache from '@dojo/framework/core/middleware/cache';
-```
-
--   `cache.get<T = any>(key: any): T | null`
-    -   Retrieves the currently cached value for the specified `key`, or `null` on a cache miss.
--   `cache.set<T = any>(key: any, value: T)`
-    -   Stores the provided `value` in the cache against the specified `key`.
--   `cache.clear()`
-    -   Clears all values currently stored in the widget's local cache.
-
 ## `icache`
 
-Composes [`cache`](/learn/middleware/available-middleware#cache) and [`invalidator`](/learn/middleware/core-render-middleware#invalidator) middleware functionality to provide a cache that supports lazy value resolution and automatic widget invalidation once a value becomes available.
+A middleware that uses the [`invalidator`](/learn/middleware/core-render-middleware#invalidator) middleware functionality to provide a cache that supports lazy value resolution and automatic widget invalidation once a value becomes available. By default the cache will invalidate when a value is set in the cache, however there is an optional third argument on the set APIs that can be used to skip the invalidation when required.
 
 **API:**
 
@@ -192,11 +175,11 @@ Composes [`cache`](/learn/middleware/available-middleware#cache) and [`invalidat
 import icache from '@dojo/framework/core/middleware/icache';
 ```
 
--   `icache.getOrSet<T = any>(key: any, value: any): T | undefined`
+-   `icache.getOrSet<T = any>(key: any, value: any, invalidate: boolean = true): T | undefined`
     -   Retrieves the cached value for the given `key`, if one exists, otherwise `value` is set. In both instances, `undefined` is returned if the cached value has not yet been resolved.
 -   `icache.get<T = any>(key: any): T | undefined`
     -   Retrieves the cached value for the given `key`, or `undefined` if either no value has been set, or if the value is still pending resolution.
--   `icache.set(key: any, value: any)`
+-   `icache.set(key: any, value: any, invalidate: boolean = true)`
     -   Sets the provided `value` for the given `key`. If `value` is a function, it will be invoked in order to obtain the actual value to cache. If the function returns a promise, a 'pending' value will be cached until the final value is fully resolved. In all scenarios, once a value is available and has been stored in the cache, the widget will be marked as invalid so it can be re-rendered with the final value available.
 -   `icache.has(key: any): boolean`
     -   Returns `true` or `false` based in whether the key is set in the cache.

--- a/docs/zh-CN/middleware/supplemental.md
+++ b/docs/zh-CN/middleware/supplemental.md
@@ -170,23 +170,6 @@ r.mount();
 
 Dojo 提供了多种可选的中间件，当部件需要实现特定需求时，可以包含这些中间件。
 
-## `cache`
-
-提供了一个简单的、部件内的缓存，可以在部件的多次渲染间保留少量数据。
-
-**API:**
-
-```ts
-import cache from '@dojo/framework/core/middleware/cache';
-```
-
--   `cache.get<T = any>(key: any): T | null`
-    -   根据指定的 `key` 获取当前缓存值，如果缓存未命中则返回 `null`。
--   `cache.set<T = any>(key: any, value: T)`
-    -   将提供的 `value` 存储在缓存中，并与指定的 `key` 关联。
--   `cache.clear()`
-    -   清除当前在部件本地缓存中存储的所有值。
-
 ## `icache`
 
 组合了 [`cache`](/learn/middleware/可用的中间件#cache) 和 [`invalidator`](/learn/middleware/核心渲染中间件#invalidator) 中间件功能，以提供一个缓存，支持延迟值的解析，并在值可用时自动让部件失效。
@@ -197,11 +180,11 @@ import cache from '@dojo/framework/core/middleware/cache';
 import icache from '@dojo/framework/core/middleware/icache';
 ```
 
--   `icache.getOrSet<T = any>(key: any, value: any): T | undefined`
+-   `icache.getOrSet<T = any>(key: any, value: any, invalidate: boolean = true): T | undefined`
     -   如果存在的话，则返回根据 `key` 获取的值，否则就将 `key` 值设置为 `value`。在这两种情况下，如果缓存值尚未解析，则返回 `undefined`。
 -   `icache.get<T = any>(key: any): T | undefined`
     -   根据 `key` 获取缓存值，如果未设置值或者该值处在挂起状态，则返回 `undefined`。
--   `icache.set(key: any, value: any)`
+-   `icache.set(key: any, value: any, invalidate: boolean = true)`
     -   将提供的 `value` 设置给指定的 `key`。如果 `value` 是一个函数，则将调用它以获取要缓存的实际值。如果函数返回的是 promise，则会先缓存一个“pending”值，直到解析出最终的值。在所有场景中，一旦一个值可用并存储到缓存中，该部件将被标记为无效，这样就可以使用最终的值重新渲染。
 -   `clear()`
     -   清除当前在部件本地缓存中存储的所有值。

--- a/src/core/middleware/block.ts
+++ b/src/core/middleware/block.ts
@@ -1,16 +1,15 @@
 import { create, defer, decrementBlockCount, incrementBlockCount } from '../vdom';
-import cache from './cache';
 import icache from './icache';
 
-const blockFactory = create({ defer, cache, icache });
+const blockFactory = create({ defer, icache });
 
-export const block = blockFactory(({ middleware: { cache, icache, defer } }) => {
+export const block = blockFactory(({ middleware: { icache, defer } }) => {
 	let id = 1;
 	return <T extends (...args: any[]) => any>(module: T) => {
 		return (...args: Parameters<T>): (ReturnType<T> extends Promise<infer U> ? U : ReturnType<T>) | null => {
 			const argsString = JSON.stringify(args);
-			const moduleId = cache.get(module) || id++;
-			cache.set(module, moduleId);
+			const moduleId = icache.get(module) || id++;
+			icache.set(module, moduleId, false);
 			const cachedValue = icache.getOrSet(`${moduleId}-${argsString}`, async () => {
 				incrementBlockCount();
 				const run = module(...args);

--- a/src/core/middleware/cache.ts
+++ b/src/core/middleware/cache.ts
@@ -1,9 +1,15 @@
+import has from './../has';
 import { create } from '../vdom';
 import icache from './icache';
 
 const factory = create({ icache });
 
 export const cache = factory(({ middleware: { icache } }) => {
+	if (has('dojo-debug')) {
+		console.warn(
+			'The cache middleware has been deprecated. Please use the icache middleware instead, for details please see the documentation https://dojo.io/learn/middleware/available-middleware#icache'
+		);
+	}
 	return {
 		get<T = any>(key: any): T | undefined {
 			return icache.get(key);

--- a/src/core/middleware/cache.ts
+++ b/src/core/middleware/cache.ts
@@ -1,28 +1,24 @@
-import { create, destroy } from '../vdom';
-import Map from '../../shim/Map';
+import { create } from '../vdom';
+import icache from './icache';
 
-const factory = create({ destroy });
+const factory = create({ icache });
 
-export const cache = factory(({ middleware: { destroy } }) => {
-	const cacheMap = new Map<string, any>();
-	destroy(() => {
-		cacheMap.clear();
-	});
+export const cache = factory(({ middleware: { icache } }) => {
 	return {
 		get<T = any>(key: any): T | undefined {
-			return cacheMap.get(key);
+			return icache.get(key);
 		},
 		set<T = any>(key: any, value: T): void {
-			cacheMap.set(key, value);
+			icache.set(key, value, false);
 		},
 		has(key: any): boolean {
-			return cacheMap.has(key);
+			return icache.has(key);
 		},
 		delete(key: any): void {
-			cacheMap.delete(key);
+			icache.delete(key);
 		},
 		clear(): void {
-			cacheMap.clear();
+			icache.clear();
 		}
 	};
 });

--- a/src/core/middleware/intersection.ts
+++ b/src/core/middleware/intersection.ts
@@ -1,7 +1,7 @@
 import WeakMap from '../../shim/WeakMap';
 import IntersectionObserver from '../../shim/IntersectionObserver';
 import { create, node, invalidator, destroy } from '../vdom';
-import cache from './cache';
+import icache from './icache';
 import {
 	IntersectionResult,
 	IntersectionGetOptions,
@@ -14,9 +14,9 @@ const defaultIntersection: IntersectionResult = Object.freeze({
 	isIntersecting: false
 });
 
-const factory = create({ cache, node, invalidator, destroy });
+const factory = create({ icache, node, invalidator, destroy });
 
-export const intersection = factory(({ middleware: { cache, node, invalidator, destroy } }) => {
+export const intersection = factory(({ middleware: { icache, node, invalidator, destroy } }) => {
 	const handles: Function[] = [];
 	destroy(() => {
 		let handle: any;
@@ -32,13 +32,13 @@ export const intersection = factory(({ middleware: { cache, node, invalidator, d
 			root: rootNode
 		});
 		const details = { observer, entries, ...options };
-		cache.set(JSON.stringify(options), details);
+		icache.set(JSON.stringify(options), details, false);
 		handles.push(() => observer.disconnect());
 		return details;
 	}
 
 	function _getDetails(options: IntersectionGetOptions = {}): IntersectionDetail | undefined {
-		return cache.get(JSON.stringify(options));
+		return icache.get(JSON.stringify(options));
 	}
 
 	function _onIntersect(detailEntries: WeakMap<Element, IntersectionResult>) {

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -1,6 +1,6 @@
 import { Theme, Classes, ClassNames } from './../interfaces';
 import { create, invalidator, diffProperty, getRegistry } from '../vdom';
-import cache from './cache';
+import icache from './icache';
 import injector from './injector';
 import Injector from '../Injector';
 import Set from '../../shim/Set';
@@ -27,14 +27,14 @@ function registerThemeInjector(theme: any, themeRegistry: Registry): Injector {
 	return themeInjector;
 }
 
-const factory = create({ invalidator, cache, diffProperty, injector, getRegistry }).properties<ThemeProperties>();
+const factory = create({ invalidator, icache, diffProperty, injector, getRegistry }).properties<ThemeProperties>();
 
 export const theme = factory(
-	({ middleware: { invalidator, cache, diffProperty, injector, getRegistry }, properties }) => {
+	({ middleware: { invalidator, icache, diffProperty, injector, getRegistry }, properties }) => {
 		let themeKeys = new Set();
 		diffProperty('theme', (current: ThemeProperties, next: ThemeProperties) => {
 			if (current.theme !== next.theme) {
-				cache.clear();
+				icache.clear();
 				invalidator();
 			}
 		});
@@ -53,7 +53,7 @@ export const theme = factory(
 				}
 			}
 			if (result) {
-				cache.clear();
+				icache.clear();
 				invalidator();
 			}
 		});
@@ -66,12 +66,12 @@ export const theme = factory(
 			}
 		}
 		injector.subscribe(INJECTED_THEME_KEY, () => {
-			cache.clear();
+			icache.clear();
 			invalidator();
 		});
 		return {
 			classes<T extends ClassNames>(css: T): T {
-				let theme = cache.get(css);
+				let theme = icache.get<T>(css);
 				if (theme) {
 					return theme;
 				}
@@ -95,7 +95,7 @@ export const theme = factory(
 						}
 					}
 				}
-				cache.set(css, theme);
+				icache.set(css, theme, false);
 				return theme;
 			},
 			set(css: Theme): void {

--- a/src/testing/mocks/middleware/icache.ts
+++ b/src/testing/mocks/middleware/icache.ts
@@ -1,17 +1,16 @@
-import { create, invalidator } from '../../../core/vdom';
+import { create, invalidator, destroy } from '../../../core/vdom';
 import { DefaultMiddlewareResult } from '../../../core/interfaces';
-import { cache } from '../../../core/middleware/cache';
 import { icache } from '../../../core/middleware/icache';
 import Map from '../../../shim/Map';
 
 export function createICacheMock() {
 	const map = new Map<string, any>();
-	const factory = create({ cache, invalidator });
+	const factory = create({ destroy, invalidator });
 	const mockICacheFactory = factory(({ id, middleware, properties, children }) => {
 		const { callback } = icache();
 		const icacheMiddleware = callback({
 			id,
-			middleware: { invalidator: middleware.invalidator, cache: middleware.cache },
+			middleware: { invalidator: middleware.invalidator, destroy: middleware.destroy },
 			properties,
 			children
 		});

--- a/src/testing/mocks/middleware/intersection.ts
+++ b/src/testing/mocks/middleware/intersection.ts
@@ -1,6 +1,6 @@
 import global from '../../../shim/global';
 import { create, destroy, invalidator } from '../../../core/vdom';
-import cache from '../../../core/middleware/cache';
+import icache from '../../../core/middleware/icache';
 import intersection from '../../../core/middleware/intersection';
 import { ExtendedIntersectionObserverEntry, IntersectionResult } from '../../../core/meta/Intersection';
 import { DefaultMiddlewareResult } from '../../../core/interfaces';
@@ -15,7 +15,7 @@ export function createIntersectionMock() {
 	};
 	let invalidate: () => void | undefined;
 
-	const factory = create({ destroy, cache, invalidator });
+	const factory = create({ destroy, icache, invalidator });
 
 	const mockIntersectionFactory = factory(({ id, middleware, properties, children }) => {
 		const { callback } = intersection();

--- a/tests/core/unit/middleware/block.ts
+++ b/tests/core/unit/middleware/block.ts
@@ -3,7 +3,6 @@ const { assert } = intern.getPlugin('chai');
 import { sandbox, SinonStub } from 'sinon';
 
 import blockMiddleware from '../../../../src/core/middleware/block';
-import cacheMiddleware from '../../../../src/core/middleware/cache';
 import icacheMiddleware from '../../../../src/core/middleware/icache';
 
 const sb = sandbox.create();
@@ -13,7 +12,6 @@ const deferStub = {
 	resume: sb.stub()
 };
 const { callback } = blockMiddleware();
-let cache: any;
 let icache: any;
 
 function waitForCall(calls = 1, stub: SinonStub) {
@@ -22,15 +20,9 @@ function waitForCall(calls = 1, stub: SinonStub) {
 
 describe('block middleware', () => {
 	beforeEach(() => {
-		cache = cacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { destroy: sb.stub() },
-			properties: () => ({}),
-			children: () => []
-		});
 		icache = icacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { cache, invalidator: invalidatorStub },
+			id: 'icache-test',
+			middleware: { destroy: sb.stub(), invalidator: invalidatorStub },
 			properties: () => ({}),
 			children: () => []
 		});
@@ -43,7 +35,6 @@ describe('block middleware', () => {
 		const block = callback({
 			id: 'test',
 			middleware: {
-				cache,
 				icache,
 				defer: deferStub
 			},

--- a/tests/core/unit/middleware/cache.ts
+++ b/tests/core/unit/middleware/cache.ts
@@ -3,6 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import { stub } from 'sinon';
 
 import cacheMiddleware from '../../../../src/core/middleware/cache';
+import icacheMiddleware from '../../../../src/core/middleware/icache';
 
 const destroyStub = stub();
 
@@ -12,11 +13,17 @@ describe('cache middleware', () => {
 	});
 
 	it('should be able to store and retrieve values from the cache', () => {
+		const icache = icacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: stub(), invalidator: stub() },
+			properties: () => ({}),
+			children: () => []
+		});
 		const { callback } = cacheMiddleware();
 		const cache = callback({
 			id: 'test',
 			middleware: {
-				destroy: destroyStub
+				icache
 			},
 			properties: () => ({}),
 			children: () => []
@@ -26,26 +33,16 @@ describe('cache middleware', () => {
 		assert.strictEqual(cache.get('test'), 'value');
 	});
 
-	it('should register destroy to clear the map', () => {
-		const { callback } = cacheMiddleware();
-		const cache = callback({
-			id: 'test',
-			middleware: {
-				destroy: destroyStub
-			},
+	it('should return true if the key exists', () => {
+		const icache = icacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: stub(), invalidator: stub() },
 			properties: () => ({}),
 			children: () => []
 		});
-		cache.set('test', 'value');
-		assert.isTrue(destroyStub.calledOnce);
-		destroyStub.getCall(0).callArg(0);
-		assert.isUndefined(cache.get('test'));
-	});
-
-	it('should return true if the key exists', () => {
 		const cache = cacheMiddleware().callback({
 			id: 'cache-test',
-			middleware: { destroy: destroyStub },
+			middleware: { icache },
 			properties: () => ({}),
 			children: () => []
 		});
@@ -54,9 +51,15 @@ describe('cache middleware', () => {
 	});
 
 	it('should remove value for the specified key from the cache', () => {
+		const icache = icacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: stub(), invalidator: stub() },
+			properties: () => ({}),
+			children: () => []
+		});
 		const cache = cacheMiddleware().callback({
 			id: 'cache-test',
-			middleware: { destroy: destroyStub },
+			middleware: { icache },
 			properties: () => ({}),
 			children: () => []
 		});
@@ -71,11 +74,17 @@ describe('cache middleware', () => {
 	});
 
 	it('should be able to clear the cache', () => {
+		const icache = icacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: stub(), invalidator: stub() },
+			properties: () => ({}),
+			children: () => []
+		});
 		const { callback } = cacheMiddleware();
 		const cache = callback({
 			id: 'test',
 			middleware: {
-				destroy: destroyStub
+				icache
 			},
 			properties: () => ({}),
 			children: () => []

--- a/tests/core/unit/middleware/focus.ts
+++ b/tests/core/unit/middleware/focus.ts
@@ -5,7 +5,6 @@ const { assert } = intern.getPlugin('chai');
 import { sandbox } from 'sinon';
 
 import focusMiddleware from '../../../../src/core/middleware/focus';
-import cacheMiddleware from '../../../../src/core/middleware/cache';
 import icacheMiddleware from '../../../../src/core/middleware/icache';
 
 const sb = sandbox.create();
@@ -17,21 +16,12 @@ const nodeStub = {
 const invalidatorStub = sb.stub();
 const icacheInvalidatorStub = sb.stub();
 
-function cacheFactory() {
-	return cacheMiddleware().callback({
-		id: 'test-cache',
-		properties: () => ({}),
-		children: () => [],
-		middleware: { destroy: sb.stub() }
-	});
-}
-
 function icacheFactory() {
 	return icacheMiddleware().callback({
 		id: 'test-cache',
 		properties: () => ({}),
 		children: () => [],
-		middleware: { cache: cacheFactory(), invalidator: icacheInvalidatorStub }
+		middleware: { destroy: sb.stub(), invalidator: icacheInvalidatorStub }
 	});
 }
 

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -113,6 +113,28 @@ describe('icache middleware', () => {
 		});
 	});
 
+	it('should not invalidate on set when invalidate option is set to false', () => {
+		const cache = cacheMiddleware().callback({
+			id: 'cache-test',
+			middleware: { destroy: sb.stub() },
+			properties: () => ({}),
+			children: () => []
+		});
+		const icache = callback({
+			id: 'test',
+			middleware: {
+				cache,
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+
+		icache.set('test', 'value');
+		assert.strictEqual(icache.get('test'), 'value');
+		assert.isTrue(invalidatorStub.calledOnce);
+	});
+
 	it('should support passing a promise factory to set and invalidate once resolved', async () => {
 		const cache = cacheMiddleware().callback({
 			id: 'cache-test',

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -3,7 +3,6 @@ const { assert } = intern.getPlugin('chai');
 import { sandbox } from 'sinon';
 
 import iCacheMiddleware, { createICacheMiddleware } from '../../../../src/core/middleware/icache';
-import cacheMiddleware from '../../../../src/core/middleware/cache';
 
 const sb = sandbox.create();
 const invalidatorStub = sb.stub();
@@ -15,16 +14,10 @@ describe('icache middleware', () => {
 	});
 
 	it('should invalidate when value is set to the cache', () => {
-		const cache = cacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { destroy: sb.stub() },
-			properties: () => ({}),
-			children: () => []
-		});
 		const icache = callback({
 			id: 'test',
 			middleware: {
-				cache,
+				destroy: sb.stub(),
 				invalidator: invalidatorStub
 			},
 			properties: () => ({}),
@@ -38,16 +31,10 @@ describe('icache middleware', () => {
 	});
 
 	it('should invalidate when cache value is resolved and set resolved value as result', () => {
-		const cache = cacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { destroy: sb.stub() },
-			properties: () => ({}),
-			children: () => []
-		});
 		const icache = callback({
 			id: 'test',
 			middleware: {
-				cache,
+				destroy: sb.stub(),
 				invalidator: invalidatorStub
 			},
 			properties: () => ({}),
@@ -75,16 +62,10 @@ describe('icache middleware', () => {
 	});
 
 	it('should invalidate allow cache value to replaced when calling set directly', () => {
-		const cache = cacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { destroy: sb.stub() },
-			properties: () => ({}),
-			children: () => []
-		});
 		const icache = callback({
 			id: 'test',
 			middleware: {
-				cache,
+				destroy: sb.stub(),
 				invalidator: invalidatorStub
 			},
 			properties: () => ({}),
@@ -114,16 +95,10 @@ describe('icache middleware', () => {
 	});
 
 	it('should not invalidate on set when invalidate option is set to false', () => {
-		const cache = cacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { destroy: sb.stub() },
-			properties: () => ({}),
-			children: () => []
-		});
 		const icache = callback({
 			id: 'test',
 			middleware: {
-				cache,
+				destroy: sb.stub(),
 				invalidator: invalidatorStub
 			},
 			properties: () => ({}),
@@ -136,16 +111,10 @@ describe('icache middleware', () => {
 	});
 
 	it('should support passing a promise factory to set and invalidate once resolved', async () => {
-		const cache = cacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { destroy: sb.stub() },
-			properties: () => ({}),
-			children: () => []
-		});
 		const icache = callback({
 			id: 'test',
 			middleware: {
-				cache,
+				destroy: sb.stub(),
 				invalidator: invalidatorStub
 			},
 			properties: () => ({}),
@@ -166,16 +135,10 @@ describe('icache middleware', () => {
 	});
 
 	it('should return true if the key exists', () => {
-		const cache = cacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { destroy: sb.stub() },
-			properties: () => ({}),
-			children: () => []
-		});
 		const icache = callback({
 			id: 'test',
 			middleware: {
-				cache,
+				destroy: sb.stub(),
 				invalidator: invalidatorStub
 			},
 			properties: () => ({}),
@@ -186,16 +149,10 @@ describe('icache middleware', () => {
 	});
 
 	it('should remove value for the specified key from the cache', () => {
-		const cache = cacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { destroy: sb.stub() },
-			properties: () => ({}),
-			children: () => []
-		});
 		const icache = callback({
 			id: 'test',
 			middleware: {
-				cache,
+				destroy: sb.stub(),
 				invalidator: invalidatorStub
 			},
 			properties: () => ({}),
@@ -212,16 +169,10 @@ describe('icache middleware', () => {
 	});
 
 	it('should be able to clear the cache', () => {
-		const cache = cacheMiddleware().callback({
-			id: 'cache-test',
-			middleware: { destroy: sb.stub() },
-			properties: () => ({}),
-			children: () => []
-		});
 		const icache = callback({
 			id: 'test',
 			middleware: {
-				cache,
+				destroy: sb.stub(),
 				invalidator: invalidatorStub
 			},
 			properties: () => ({}),
@@ -242,16 +193,10 @@ describe('icache middleware', () => {
 
 		it('should support setting the cache with a value, function or promise factory', async () => {
 			const typedICache = createICacheMiddleware<CacheContents>();
-			const cache = cacheMiddleware().callback({
-				id: 'cache-test',
-				middleware: { destroy: sb.stub() },
-				properties: () => ({}),
-				children: () => []
-			});
 			const icache = typedICache().callback({
 				id: 'test',
 				middleware: {
-					cache,
+					destroy: sb.stub(),
 					invalidator: invalidatorStub
 				},
 				properties: () => ({}),

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -105,9 +105,9 @@ describe('icache middleware', () => {
 			children: () => []
 		});
 
-		icache.set('test', 'value');
+		icache.set('test', 'value', false);
 		assert.strictEqual(icache.get('test'), 'value');
-		assert.isTrue(invalidatorStub.calledOnce);
+		assert.isTrue(invalidatorStub.notCalled);
 	});
 
 	it('should support passing a promise factory to set and invalidate once resolved', async () => {

--- a/tests/core/unit/middleware/intersection.ts
+++ b/tests/core/unit/middleware/intersection.ts
@@ -3,7 +3,7 @@ const { describe } = intern.getPlugin('jsdom');
 const { assert } = intern.getPlugin('chai');
 import { sandbox, SinonStub, SinonSpy, stub } from 'sinon';
 import global from '../../../../src/shim/global';
-import cacheMiddleware from '../../../../src/core/middleware/cache';
+import icacheMiddleware from '../../../../src/core/middleware/icache';
 import intersectionMiddleware from '../../../../src/core/middleware/intersection';
 
 const sb = sandbox.create();
@@ -51,17 +51,17 @@ describe('intersection middleware', () => {
 	});
 
 	it('no intersection', () => {
-		const cache = cacheMiddleware().callback({
+		const icache = icacheMiddleware().callback({
 			properties: () => ({}),
 			children: () => [],
 			id: 'test-cache',
-			middleware: { destroy: destroyStub }
+			middleware: { invalidator: invalidatorStub, destroy: sb.stub() }
 		});
 		const intersection = intersectionMiddleware().callback({
 			id: 'test',
 			middleware: {
 				destroy: destroyStub,
-				cache,
+				icache,
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},
@@ -77,17 +77,17 @@ describe('intersection middleware', () => {
 	});
 
 	it('no intersection with options', () => {
-		const cache = cacheMiddleware().callback({
+		const icache = icacheMiddleware().callback({
 			properties: () => ({}),
 			children: () => [],
 			id: 'test-cache',
-			middleware: { destroy: destroyStub }
+			middleware: { invalidator: invalidatorStub, destroy: sb.stub() }
 		});
 		const intersection = intersectionMiddleware().callback({
 			id: 'test',
 			middleware: {
 				destroy: destroyStub,
-				cache,
+				icache,
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},
@@ -103,17 +103,17 @@ describe('intersection middleware', () => {
 	});
 
 	it('Should return the registered intersection', () => {
-		const cache = cacheMiddleware().callback({
+		const icache = icacheMiddleware().callback({
 			properties: () => ({}),
 			children: () => [],
 			id: 'test-cache',
-			middleware: { destroy: destroyStub }
+			middleware: { invalidator: invalidatorStub, destroy: sb.stub() }
 		});
 		const intersection = intersectionMiddleware().callback({
 			id: 'test',
 			middleware: {
 				destroy: destroyStub,
-				cache,
+				icache,
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},
@@ -147,17 +147,17 @@ describe('intersection middleware', () => {
 	});
 
 	it('intersections calls waits for root node before invalidating', () => {
-		const cache = cacheMiddleware().callback({
+		const icache = icacheMiddleware().callback({
 			properties: () => ({}),
 			children: () => [],
 			id: 'test-cache',
-			middleware: { destroy: destroyStub }
+			middleware: { invalidator: invalidatorStub, destroy: sb.stub() }
 		});
 		const intersection = intersectionMiddleware().callback({
 			id: 'test',
 			middleware: {
 				destroy: destroyStub,
-				cache,
+				icache,
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},
@@ -212,17 +212,17 @@ describe('intersection middleware', () => {
 	});
 
 	it('Should register disconnect with destroy', () => {
-		const cache = cacheMiddleware().callback({
+		const icache = icacheMiddleware().callback({
 			properties: () => ({}),
 			children: () => [],
 			id: 'test-cache',
-			middleware: { destroy: sb.stub() }
+			middleware: { invalidator: invalidatorStub, destroy: sb.stub() }
 		});
 		const intersection = intersectionMiddleware().callback({
 			id: 'test',
 			middleware: {
 				destroy: destroyStub,
-				cache,
+				icache,
 				invalidator: invalidatorStub,
 				node: nodeStub
 			},

--- a/tests/core/unit/middleware/resize.ts
+++ b/tests/core/unit/middleware/resize.ts
@@ -5,7 +5,6 @@ import { sandbox, SinonStub } from 'sinon';
 
 import resizeMiddleware from '../../../../src/core/middleware/resize';
 import icacheMiddleware from '../../../../src/core/middleware/icache';
-import cacheMiddleware from '../../../../src/core/middleware/cache';
 
 const sb = sandbox.create();
 let resizeObserver: any;
@@ -50,17 +49,11 @@ describe('resize middleware', () => {
 	});
 
 	it('Should observe node with with resize and invalidate when the resize callback is called ', () => {
-		const cache = cacheMiddleware().callback({
-			properties: () => ({}),
-			children: () => [],
-			id: 'test-cache',
-			middleware: { destroy: destroyStub }
-		});
 		const icache = icacheMiddleware().callback({
 			properties: () => ({}),
 			children: () => [],
 			id: 'test-cache',
-			middleware: { invalidator: invalidatorStub, cache }
+			middleware: { invalidator: invalidatorStub, destroy: sb.stub() }
 		});
 		const { callback } = resizeMiddleware();
 		const resize = callback({
@@ -96,17 +89,11 @@ describe('resize middleware', () => {
 	});
 
 	it('Should register disconnect with destroy', () => {
-		const cache = cacheMiddleware().callback({
-			properties: () => ({}),
-			children: () => [],
-			id: 'test-cache',
-			middleware: { destroy: sb.stub() }
-		});
 		const icache = icacheMiddleware().callback({
 			properties: () => ({}),
 			children: () => [],
 			id: 'test-cache',
-			middleware: { invalidator: invalidatorStub, cache }
+			middleware: { invalidator: invalidatorStub, destroy: sb.stub() }
 		});
 		const { callback } = resizeMiddleware();
 		const resize = callback({

--- a/tests/core/unit/middleware/theme.ts
+++ b/tests/core/unit/middleware/theme.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import { sandbox } from 'sinon';
 
 import themeMiddleware from '../../../../src/core/middleware/theme';
-import cacheMiddleware from '../../../../src/core/middleware/cache';
+import icacheMiddleware from '../../../../src/core/middleware/icache';
 import Injector from '../../../../src/core/Injector';
 
 const sb = sandbox.create();
@@ -28,8 +28,8 @@ describe('theme middleware', () => {
 	});
 
 	it('Should register injector and allow theme to be set', () => {
-		const cache = cacheMiddleware().callback({
-			middleware: { destroy: sb.stub() },
+		const icache = icacheMiddleware().callback({
+			middleware: { destroy: sb.stub(), invalidator: sb.stub() },
 			properties: () => ({}),
 			children: () => [],
 			id: 'blah'
@@ -42,7 +42,7 @@ describe('theme middleware', () => {
 			id: 'test',
 			middleware: {
 				invalidator,
-				cache,
+				icache,
 				diffProperty,
 				injector,
 				getRegistry
@@ -81,8 +81,8 @@ describe('theme middleware', () => {
 	});
 
 	it('Should give precedence to theme from properties over an injected theme', () => {
-		const cache = cacheMiddleware().callback({
-			middleware: { destroy: sb.stub() },
+		const icache = icacheMiddleware().callback({
+			middleware: { destroy: sb.stub(), invalidator: sb.stub() },
 			properties: () => ({}),
 			children: () => [],
 			id: 'blah'
@@ -100,7 +100,7 @@ describe('theme middleware', () => {
 			id: 'test',
 			middleware: {
 				invalidator,
-				cache,
+				icache,
 				diffProperty,
 				injector,
 				getRegistry
@@ -139,8 +139,8 @@ describe('theme middleware', () => {
 	});
 
 	it('Should support classes property for adding additional classes', () => {
-		const cache = cacheMiddleware().callback({
-			middleware: { destroy: sb.stub() },
+		const icache = icacheMiddleware().callback({
+			middleware: { destroy: sb.stub(), invalidator: sb.stub() },
 			properties: () => ({}),
 			children: () => [],
 			id: 'blah'
@@ -153,7 +153,7 @@ describe('theme middleware', () => {
 			id: 'test',
 			middleware: {
 				invalidator,
-				cache,
+				icache,
 				diffProperty,
 				injector,
 				getRegistry


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add optional parameter to the `icache` middleware set APIs to skip invalidation. Invert the dependency between the `cache` and `icache` so the `cache` can be deprecated. Includes a deprecation message on use of the `cache` middleware

Updates the documentation to reflect the changes made.

Resolves #616 
Resolves #617 
