### PR TITLE
WIP: Set document title on route change

### DIFF
--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -22,6 +22,7 @@ export interface Route {
 	fullQueryParams: string[];
 	defaultParams: Params;
 	score: number;
+	title?: string;
 }
 
 /**
@@ -33,6 +34,7 @@ export interface RouteConfig {
 	children?: RouteConfig[];
 	defaultParams?: Params;
 	defaultRoute?: boolean;
+	title?: string;
 }
 
 /**
@@ -160,6 +162,20 @@ export interface OnChangeFunction {
 }
 
 /**
+ * Document title option
+ */
+export interface DocumentTitleOptions {
+	title?: string;
+	outlet: string;
+	params: Params;
+	queryParams: Params;
+}
+
+export interface SetDocumentTitle {
+	(options: DocumentTitleOptions): string | undefined;
+}
+
+/**
  * Options for a history provider
  */
 export interface HistoryOptions {
@@ -200,4 +216,5 @@ export interface RouterOptions {
 	window?: Window;
 	base?: string;
 	HistoryManager?: HistoryConstructor;
+	setDocumentTitle?: SetDocumentTitle;
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for setting the `document.title` on route change. This can be done either statically in the route configuration, a callback passed to the router to dynamically set the title or a combination of the two.

#### Statically:

> routes.ts

```ts
export default [
    {
        path: 'foo/{param}?{queryParam}'
        outlet: 'foo',
        title: 'Foo Title'
    }
];
```

#### Dynamically on Router initialisation using the `setDocumentTitle` callback (using the injector registration as an example, but the same can be passed when instantiating a new `Router` directly):

```ts
registerRouterInjector(routes, registry, {
    setDocumentTitle: ({ title, outlet, params, queryParams }) => {
        if (outlet === 'dynamic-title-outlet') {
            return `${outlet}-${params.id}-${queryParams.bar}`;
        }
        return title;
    }
});
```

Currently the options interface for the `setDocumentTitle` look like:

```ts
export interface DocumentTitleOptions {
	title?: string;
	outlet: string;
	params: Params;
	queryParams: Params;
}
```

Resolves #601 
