### PR TITLE
Convert cache usages to icache

### DIFF
--- a/docs/en/creating-widgets/supplemental.md
+++ b/docs/en/creating-widgets/supplemental.md
@@ -531,7 +531,7 @@ For large applications, state management can be one of the most challenging aspe
 
 ## Basic: self-encapsulated widget state
 
-Widgets can maintain their own internal state in a variety of ways. Function-based widgets can use the [`cache`](/learn/middleware/available-middleware#cache) or [`icache`](/learn/middleware/available-middleware#icache) middleware to store widget-local state, and class-based widgets can use internal class fields.
+Widgets can maintain their own internal state in a variety of ways. Function-based widgets can use the [`icache`](/learn/middleware/available-middleware#icache) middleware to store widget-local state, and class-based widgets can use internal class fields.
 
 Internal state data may directly affect the widget's render output, or may be passed as properties to any child widgets where they in turn directly affect the children's render output. Widgets may also allow their internal state to be changed, for example in response to a user interaction event.
 
@@ -543,21 +543,21 @@ The following example illustrates these patterns:
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-import cache from '@dojo/framework/core/middleware/cache';
+import icache from '@dojo/framework/core/middleware/icache';
 
-const factory = create({ cache });
+const factory = create({ icache });
 
-export default factory(function MyEncapsulatedStateWidget({ middleware: { cache } }) {
+export default factory(function MyEncapsulatedStateWidget({ middleware: { icache } }) {
 	return (
 		<div>
-			Current widget state: {cache.get<string>('myState') || 'Hello from a stateful widget!'}
+			Current widget state: {icache.get<string>('myState') || 'Hello from a stateful widget!'}
 			<br />
 			<button
 				onclick={() => {
-					let counter = cache.get<number>('counter') || 0;
+					let counter = icache.get<number>('counter') || 0;
 					let myState = 'State change iteration #' + ++counter;
-					cache.set('myState', myState);
-					cache.set('counter', counter);
+					icache.set('myState', myState);
+					icache.set('counter', counter);
 				}}
 			>
 				Change State

--- a/docs/en/middleware/supplemental.md
+++ b/docs/en/middleware/supplemental.md
@@ -74,14 +74,14 @@ The following example shows middleware composing other middleware to implement m
 > src/middleware/ValueCachingMiddleware.ts
 
 ```ts
-import { create, defer, invalidator } from '@dojo/framework/core/vdom';
-import { cache } from '@dojo/framework/core/middleware/cache';
+import { create, defer } from '@dojo/framework/core/vdom';
+import { icache } from '@dojo/framework/core/middleware/icache';
 
-const factory = create({ defer, cache });
+const factory = create({ defer, icache });
 
-export const ValueCachingMiddleware = factory(({ middleware: { defer, cache, invalidator }}) => {
+export const ValueCachingMiddleware = factory(({ middleware: { defer, icache }}) => {
 	get(key: string) {
-		const cachedValue = cache.get(key);
+		const cachedValue = icache.get(key);
 		if (cachedValue) {
 			return cachedValue;
 		}
@@ -91,11 +91,9 @@ export const ValueCachingMiddleware = factory(({ middleware: { defer, cache, inv
 		defer.pause();
 		promise.then((result) => {
 			// Cache the value for subsequent renderings
-			cache.set(key, result);
+			icache.set(key, result);
 			// Resume widget rendering once the value is available
 			defer.resume();
-			// Invalidate the widget for a re-render
-			invalidator();
 		});
 		return null;
 	}

--- a/docs/zh-CN/creating-widgets/supplemental.md
+++ b/docs/zh-CN/creating-widgets/supplemental.md
@@ -536,7 +536,7 @@ export default class FocusableWidget extends Focus(WidgetBase) {
 
 ## 基础：自封装的部件状态
 
-部件可以通过多种方式维护其内部状态。基于函数的部件可以使用 [`cache`](/learn/middleware/可用的中间件#cache) 或 [`icache`](/learn/middleware/可用的中间件#icache) 中间件来存储部件的本地状态，而基于类的部件可以使用内部的类字段。
+部件可以通过多种方式维护其内部状态。基于函数的部件可以使用 [`icache`](/learn/middleware/可用的中间件#icache) 中间件来存储部件的本地状态，而基于类的部件可以使用内部的类字段。
 
 内部状态数据可能直接影响部件的渲染输出，也可能作为属性传递给子部件，而它们继而又直接影响了子部件的渲染输出。部件还可能允许更改其内部状态，例如响应用户交互事件。
 
@@ -548,21 +548,21 @@ export default class FocusableWidget extends Focus(WidgetBase) {
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-import cache from '@dojo/framework/core/middleware/cache';
+import icache from '@dojo/framework/core/middleware/icache';
 
-const factory = create({ cache });
+const factory = create({ icache });
 
-export default factory(function MyEncapsulatedStateWidget({ middleware: { cache } }) {
+export default factory(function MyEncapsulatedStateWidget({ middleware: { icache } }) {
 	return (
 		<div>
-			Current widget state: {cache.get<string>('myState') || 'Hello from a stateful widget!'}
+			Current widget state: {icache.get<string>('myState') || 'Hello from a stateful widget!'}
 			<br />
 			<button
 				onclick={() => {
-					let counter = cache.get<number>('counter') || 0;
+					let counter = icache.get<number>('counter') || 0;
 					let myState = 'State change iteration #' + ++counter;
-					cache.set('myState', myState);
-					cache.set('counter', counter);
+					icache.set('myState', myState);
+					icache.set('counter', counter);
 				}}
 			>
 				Change State

--- a/docs/zh-CN/middleware/supplemental.md
+++ b/docs/zh-CN/middleware/supplemental.md
@@ -79,14 +79,14 @@ export default MiddlewareConsumerWidget;
 > src/middleware/ValueCachingMiddleware.ts
 
 ```ts
-import { create, defer, invalidator } from '@dojo/framework/core/vdom';
-import { cache } from '@dojo/framework/core/middleware/cache';
+import { create, defer } from '@dojo/framework/core/vdom';
+import { icache } from '@dojo/framework/core/middleware/icache';
 
-const factory = create({ defer, cache });
+const factory = create({ defer, icache });
 
-export const ValueCachingMiddleware = factory(({ middleware: { defer, cache, invalidator }}) => {
+export const ValueCachingMiddleware = factory(({ middleware: { defer, icache }}) => {
 	get(key: string) {
-		const cachedValue = cache.get(key);
+		const cachedValue = icache.get(key);
 		if (cachedValue) {
 			return cachedValue;
 		}
@@ -96,11 +96,9 @@ export const ValueCachingMiddleware = factory(({ middleware: { defer, cache, inv
 		defer.pause();
 		promise.then((result) => {
 			// Cache the value for subsequent renderings
-			cache.set(key, result);
+			icache.set(key, result);
 			// Resume widget rendering once the value is available
 			defer.resume();
-			// Invalidate the widget for a re-render
-			invalidator();
 		});
 		return null;
 	}

--- a/src/routing/Outlet.ts
+++ b/src/routing/Outlet.ts
@@ -1,6 +1,6 @@
 import { create, diffProperty, invalidator } from '../core/vdom';
 import injector from '../core/middleware/injector';
-import cache from '../core/middleware/cache';
+import icache from '../core/middleware/icache';
 import { DNode } from '../core/interfaces';
 import { MatchDetails } from './interfaces';
 import Router from './Router';
@@ -11,31 +11,31 @@ export interface OutletProperties {
 	routerKey?: string;
 }
 
-const factory = create({ cache, injector, diffProperty, invalidator }).properties<OutletProperties>();
+const factory = create({ icache, injector, diffProperty, invalidator }).properties<OutletProperties>();
 
 export const Outlet = factory(function Outlet({
-	middleware: { cache, injector, diffProperty, invalidator },
+	middleware: { icache, injector, diffProperty, invalidator },
 	properties
 }) {
 	const { renderer, id, routerKey = 'router' } = properties();
-	const currentHandle = cache.get<Function>('handle');
+	const currentHandle = icache.get<Function>('handle');
 	if (!currentHandle) {
 		const handle = injector.subscribe(routerKey);
 		if (handle) {
-			cache.set('handle', handle);
+			icache.set('handle', () => handle);
 		}
 	}
 	diffProperty('routerKey', (current: OutletProperties, next: OutletProperties) => {
 		const { routerKey: currentRouterKey = 'router' } = current;
 		const { routerKey = 'router' } = next;
 		if (routerKey !== currentRouterKey) {
-			const currentHandle = cache.get<Function>('handle');
+			const currentHandle = icache.get<Function>('handle');
 			if (currentHandle) {
 				currentHandle();
 			}
 			const handle = injector.subscribe(routerKey);
 			if (handle) {
-				cache.set('handle', handle);
+				icache.set('handle', () => handle);
 			}
 		}
 		invalidator();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

`cache` middleware has been deprecated, this converts all existing usages of `cache` to `icache`.