### PR TITLE
Fix: reset `setLocaleMessages` calls after tests

### DIFF
--- a/tests/i18n/unit/i18n.ts
+++ b/tests/i18n/unit/i18n.ts
@@ -177,15 +177,19 @@ registerSuite('i18n', {
 			},
 
 			'assert unsupported locale added with `setLocaleMessages`'() {
-				const messages = { hello: 'Oy' };
-				setLocaleMessages(bundle, messages, 'en-GB');
+				try {
+					const messages = { hello: 'Oy' };
+					setLocaleMessages(bundle, messages, 'en-GB');
 
-				const cached = getCachedMessages(bundle, 'en-GB');
-				assert.deepEqual(
-					cached,
-					{ ...bundle.messages, ...messages },
-					'Messages added with `setLocaleMessages` are returned.'
-				);
+					const cached = getCachedMessages(bundle, 'en-GB');
+					assert.deepEqual(
+						cached,
+						{ ...bundle.messages, ...messages },
+						'Messages added with `setLocaleMessages` are returned.'
+					);
+				} finally {
+					setLocaleMessages(bundle, {}, 'en-GB');
+				}
 			},
 
 			async 'assert most specific supported locale returned'() {
@@ -258,7 +262,7 @@ registerSuite('i18n', {
 
 					async 'assert unsupported locale'() {
 						await i18n(bundle, 'en-GB');
-						const formatter = getMessageFormatter(bundle, 'hello');
+						const formatter = getMessageFormatter(bundle, 'hello', 'en-GB');
 						assert.strictEqual(formatter(), 'Hello');
 					},
 
@@ -446,32 +450,36 @@ registerSuite('i18n', {
 		},
 
 		setLocaleMessages() {
-			sinon.stub(Globalize, 'loadMessages');
-			const french = { hello: 'Bonjour', goodbye: 'Au revoir' };
-			const czech = { hello: 'Ahoj', goodbye: 'Ahoj' };
+			try {
+				sinon.stub(Globalize, 'loadMessages');
+				const french = { hello: 'Bonjour', goodbye: 'Au revoir' };
+				const czech = { hello: 'Ahoj', goodbye: 'Ahoj' };
 
-			setLocaleMessages(bundle, french, 'fr');
-			setLocaleMessages(bundle, czech, 'cz');
+				setLocaleMessages(bundle, french, 'fr');
+				setLocaleMessages(bundle, czech, 'cz');
 
-			const path = '..-_build-tests-support-mocks-common-main';
-			const first = (<any>Globalize).loadMessages.args[0][0].fr[path];
-			const second = (<any>Globalize).loadMessages.args[1][0].cz[path];
+				const path = '..-_build-tests-support-mocks-common-main';
+				const first = (<any>Globalize).loadMessages.args[0][0].fr[path];
+				const second = (<any>Globalize).loadMessages.args[1][0].cz[path];
 
-			assert.isFrozen(first, 'locale messages should be frozen');
-			assert.isFrozen(second, 'locale messages should be frozen');
+				assert.isFrozen(first, 'locale messages should be frozen');
+				assert.isFrozen(second, 'locale messages should be frozen');
 
-			assert.deepEqual(
-				getCachedMessages(bundle, 'fr'),
-				{ ...french, helloReply: 'Hello' },
-				'Default messages should be included where not overridden'
-			);
-			assert.deepEqual(
-				getCachedMessages(bundle, 'cz'),
-				{ ...czech, helloReply: 'Hello' },
-				'Default messages should be included where not overridden'
-			);
-
-			(<any>Globalize).loadMessages.restore();
+				assert.deepEqual(
+					getCachedMessages(bundle, 'fr'),
+					{ ...french, helloReply: 'Hello' },
+					'Default messages should be included where not overridden'
+				);
+				assert.deepEqual(
+					getCachedMessages(bundle, 'cz'),
+					{ ...czech, helloReply: 'Hello' },
+					'Default messages should be included where not overridden'
+				);
+			} finally {
+				setLocaleMessages(bundle, {}, 'fr');
+				setLocaleMessages(bundle, {}, 'cz');
+				(<any>Globalize).loadMessages.restore();
+			}
 		},
 
 		switchLocale: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #603 

Update the `i18n#setLocaleMessages` tests to reset any custom locale messages to avoid failures in subsequent tests. For example, while `en-GB` is not explicitly supported by the test message bundle, one of the `setLocaleMessages` tests adds support for `en-GB`, resulting in test failures when the suite is run on a machine with `en-GB` set as the primary language.