### PR TITLE
Add validity middleware mock and tests

### DIFF
--- a/src/testing/mocks/middleware/validity.ts
+++ b/src/testing/mocks/middleware/validity.ts
@@ -1,0 +1,39 @@
+import { create, invalidator } from '../../../core/vdom';
+import { DefaultMiddlewareResult } from '../../../core/interfaces';
+
+interface ValidityResult {
+	valid?: boolean;
+	message?: string;
+}
+
+export function createValidityMock() {
+	const values: { [key: string]: ValidityResult } = {};
+	let invalidate: () => void | undefined;
+
+	const factory = create({ invalidator });
+
+	const mockValidityFactory = factory(({ middleware: { invalidator } }) => {
+		invalidate = invalidator;
+		return {
+			get(key: string | number, value: string) {
+				value;
+				return values[key] || { valid: undefined, message: '' };
+			}
+		};
+	});
+
+	function mockValidity(): DefaultMiddlewareResult;
+	function mockValidity(key: string, value: ValidityResult): void;
+	function mockValidity(key?: string, value?: ValidityResult): void | DefaultMiddlewareResult {
+		if (key && value) {
+			values[key] = value;
+			invalidate && invalidate();
+		} else {
+			return mockValidityFactory();
+		}
+	}
+
+	return mockValidity;
+}
+
+export default createValidityMock;

--- a/src/testing/mocks/middleware/validity.ts
+++ b/src/testing/mocks/middleware/validity.ts
@@ -15,8 +15,7 @@ export function createValidityMock() {
 	const mockValidityFactory = factory(({ middleware: { invalidator } }) => {
 		invalidate = invalidator;
 		return {
-			get(key: string | number, value: string) {
-				value;
+			get(key: string | number, _value: string) {
 				return values[key] || { valid: undefined, message: '' };
 			}
 		};

--- a/tests/testing/unit/mocks/middleware/all.ts
+++ b/tests/testing/unit/mocks/middleware/all.ts
@@ -5,3 +5,4 @@ import './resize';
 import './store';
 import './breakpoint';
 import './icache';
+import './validity';

--- a/tests/testing/unit/mocks/middleware/validity.tsx
+++ b/tests/testing/unit/mocks/middleware/validity.tsx
@@ -1,0 +1,41 @@
+const { it } = intern.getInterface('bdd');
+const { describe } = intern.getPlugin('jsdom');
+const { assert } = intern.getPlugin('chai');
+
+import { tsx, create } from '../../../../../src/core/vdom';
+import validity from '../../../../../src/core/middleware/validity';
+import createValidityMock from '../../../../../src/testing/mocks/middleware/validity';
+import harness from '../../../../../src/testing/harness';
+
+describe('validity mock', () => {
+	it('should mock validity', () => {
+		const factory = create({ validity });
+		const validityMock = createValidityMock();
+		const App = factory(({ middleware: { validity } }) => {
+			const { valid, message } = validity.get('test', 'test value');
+			return !valid ? <div>{message}</div> : <div>valid</div>;
+		});
+
+		validityMock('test', { valid: false, message: 'test message' });
+		let h = harness(() => <App />, { middleware: [[validity, validityMock]] });
+		h.expect(() => <div>test message</div>);
+
+		validityMock('test', { valid: true, message: '' });
+		h = harness(() => <App />, { middleware: [[validity, validityMock]] });
+		h.expect(() => <div>valid</div>);
+	});
+
+	it('defaults to a default return value', () => {
+		const factory = create({ validity });
+		const validityMock = createValidityMock();
+		const App = factory(({ middleware: { validity } }) => {
+			const { valid, message } = validity.get('test', 'test value');
+			assert.isUndefined(valid);
+			assert.strictEqual(message, '');
+			return !valid ? <div>{message}</div> : <div>valid</div>;
+		});
+
+		let h = harness(() => <App />, { middleware: [[validity, validityMock]] });
+		h.expect(() => <div />);
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This adds a validity middleware mock and tests for it.

```tsx
const App = factory(({ middleware: { validity } }) => {
	const { valid, message } = validity.get('test', 'test value');
	return !valid ? <div>{message}</div> : <div>valid</div>;
});

validityMock('test', { valid: false, message: 'test message' });
let h = harness(() => <App />, { middleware: [[validity, validityMock]] });
h.expect(() => <div>test message</div>);
```

Resolves #630 