### PR TITLE
Use MessageFormat.js; deprecate Globalize wrappers

### DIFF
--- a/docs/en/i18n/supplemental.md
+++ b/docs/en/i18n/supplemental.md
@@ -705,7 +705,9 @@ i18n(bundle, 'en').then((messages) => {
 });
 ```
 
-## Date and number formatting.
+## Date, number, and unit formatting. (Deprecated)
+
+**Note**: This feature has been deprecated in favor of using [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) or the relevant [`Globalize.js`](https://github.com/globalizejs/globalize) methods directly.
 
 **Note**: This feature requires appropriate [CLDR data](#loading-cldr-data) to have been loaded into the application.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4561,6 +4561,22 @@
         }
       }
     },
+    "make-plural": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
+      "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "optional": true
+        }
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -4608,6 +4624,26 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "messageformat": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
+      "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
+      "requires": {
+        "make-plural": "^4.3.0",
+        "messageformat-formatters": "^2.0.1",
+        "messageformat-parser": "^4.1.2"
+      }
+    },
+    "messageformat-formatters": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
+      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg=="
+    },
+    "messageformat-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.2.tgz",
+      "integrity": "sha512-7dWuifeyldz7vhEuL96Kwq1fhZXBW+TUfbnHN4UCrCxoXQTYjHnR78eI66Gk9LaLLsAvzPNVJBaa66DRfFNaiA=="
     },
     "methods": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "globalize": "1.4.0",
     "immutable": "3.8.2",
     "intersection-observer": "0.4.2",
+    "messageformat": "2.3.0",
     "pepjs": "0.4.2",
     "resize-observer-polyfill": "1.5.0",
     "tslib": "1.9.3",

--- a/src/i18n/date.ts
+++ b/src/i18n/date.ts
@@ -1,6 +1,7 @@
 import 'globalize/dist/globalize/number';
 import 'globalize/dist/globalize/date';
 import 'globalize/dist/globalize/relative-time';
+import has from '../core/has';
 import { NumberFormatter } from './number';
 import { globalizeDelegator } from './util/globalize';
 
@@ -70,6 +71,10 @@ export type RelativeTimeFormatterOptions = {
 export function formatDate(value: Date, options?: DateFormatterOptions, locale?: string): string;
 export function formatDate(value: Date, locale?: string): string;
 export function formatDate(value: Date, optionsOrLocale?: DateFormatterOptions | string, locale?: string): string {
+	if (has('dojo-debug')) {
+		console.warn('formatDate has been deprecated. Please use Globalize.formatDate or Intl.DateTimeFormat.');
+	}
+
 	return globalizeDelegator<Date, DateFormatterOptions, string>('formatDate', {
 		locale,
 		optionsOrLocale,
@@ -107,6 +112,12 @@ export function formatRelativeTime(
 	optionsOrLocale?: RelativeTimeFormatterOptions | string,
 	locale?: string
 ): string {
+	if (has('dojo-debug')) {
+		console.warn(
+			'formatRelativeTime has been deprecated. Please use Globalize.formatRelativeTime or Intl.RelativeTimeFormat.'
+		);
+	}
+
 	return globalizeDelegator<number, RelativeTimeFormatterOptions, string>('formatRelativeTime', {
 		locale,
 		optionsOrLocale,
@@ -131,6 +142,10 @@ export function formatRelativeTime(
 export function getDateFormatter(options?: DateFormatterOptions, locale?: string): DateFormatter;
 export function getDateFormatter(locale?: string): DateFormatter;
 export function getDateFormatter(optionsOrLocale?: DateFormatterOptions | string, locale?: string): DateFormatter {
+	if (has('dojo-debug')) {
+		console.warn('getDateFormatter has been deprecated. Please use Globalize.dateFormatter.');
+	}
+
 	return globalizeDelegator<DateFormatterOptions, DateFormatter>('dateFormatter', {
 		locale,
 		optionsOrLocale
@@ -152,6 +167,10 @@ export function getDateFormatter(optionsOrLocale?: DateFormatterOptions | string
 export function getDateParser(options?: DateFormatterOptions, locale?: string): DateParser;
 export function getDateParser(locale?: string): DateParser;
 export function getDateParser(optionsOrLocale?: DateFormatterOptions | string, locale?: string): DateParser {
+	if (has('dojo-debug')) {
+		console.warn('getDateParser has been deprecated. Please use Globalize.dateParser.');
+	}
+
 	return globalizeDelegator<DateFormatterOptions, DateParser>('dateParser', {
 		locale,
 		optionsOrLocale
@@ -186,6 +205,10 @@ export function getRelativeTimeFormatter(
 	optionsOrLocale?: RelativeTimeFormatterOptions | string,
 	locale?: string
 ): NumberFormatter {
+	if (has('dojo-debug')) {
+		console.warn('getRelativeTimeFormatter has been deprecated. Please use Globalize.relativeTimeFormatter.');
+	}
+
 	return globalizeDelegator<string, RelativeTimeFormatterOptions, NumberFormatter>('relativeTimeFormatter', {
 		locale,
 		optionsOrLocale,
@@ -211,6 +234,10 @@ export function getRelativeTimeFormatter(
 export function parseDate(value: string, options?: DateFormatterOptions, locale?: string): Date;
 export function parseDate(value: string, locale?: string): Date;
 export function parseDate(value: string, optionsOrLocale?: DateFormatterOptions | string, locale?: string): Date {
+	if (has('dojo-debug')) {
+		console.warn('parseDate has been deprecated. Please use Globalize.parseDate.');
+	}
+
 	return globalizeDelegator<string, DateFormatterOptions, Date>('parseDate', {
 		locale,
 		optionsOrLocale,

--- a/src/i18n/number.ts
+++ b/src/i18n/number.ts
@@ -1,6 +1,7 @@
 import 'globalize/dist/globalize/number';
 import 'globalize/dist/globalize/plural';
 import 'globalize/dist/globalize/currency';
+import has from '../core/has';
 import { globalizeDelegator } from './util/globalize';
 
 export type CurrencyStyleOption = 'accounting' | 'code' | 'name' | 'symbol';
@@ -134,6 +135,10 @@ export function formatCurrency(
 	optionsOrLocale?: CurrencyFormatterOptions | string,
 	locale?: string
 ): string {
+	if (has('dojo-debug')) {
+		console.warn('formatCurrency has been deprecated. Please use Globalize.formatCurrency or Intl.NumberFormat.');
+	}
+
 	return globalizeDelegator<number, CurrencyFormatterOptions, string>('formatCurrency', {
 		locale,
 		optionsOrLocale,
@@ -164,6 +169,10 @@ export function formatNumber(
 	optionsOrLocale?: NumberFormatterOptions | string,
 	locale?: string
 ): string {
+	if (has('dojo-debug')) {
+		console.warn('formatNumber has been deprecated. Please use Globalize.formatNumber or Intl.NumberFormat.');
+	}
+
 	return globalizeDelegator<number, NumberFormatterOptions, string>('formatNumber', {
 		locale,
 		optionsOrLocale,
@@ -198,6 +207,10 @@ export function getCurrencyFormatter(
 	optionsOrLocale?: CurrencyFormatterOptions | string,
 	locale?: string
 ): NumberFormatter {
+	if (has('dojo-debug')) {
+		console.warn('getCurrencyFormatter has been deprecated. Please use Globalize.currencyFormatter.');
+	}
+
 	return globalizeDelegator<string, CurrencyFormatterOptions, NumberFormatter>('currencyFormatter', {
 		locale,
 		optionsOrLocale,
@@ -223,6 +236,10 @@ export function getNumberFormatter(
 	optionsOrLocale?: NumberFormatterOptions | string,
 	locale?: string
 ): NumberFormatter {
+	if (has('dojo-debug')) {
+		console.warn('getNumberFormatter has been deprecated. Please use Globalize.numberFormatter.');
+	}
+
 	return globalizeDelegator<NumberFormatterOptions, NumberFormatter>('numberFormatter', {
 		locale,
 		optionsOrLocale
@@ -244,6 +261,10 @@ export function getNumberFormatter(
 export function getNumberParser(options?: NumberFormatterOptions, locale?: string): NumberParser;
 export function getNumberParser(locale?: string): NumberParser;
 export function getNumberParser(optionsOrLocale?: NumberFormatterOptions | string, locale?: string): NumberParser {
+	if (has('dojo-debug')) {
+		console.warn('getNumberParser has been deprecated. Please use Globalize.numberParser.');
+	}
+
 	return globalizeDelegator<NumberFormatterOptions, NumberParser>('numberParser', {
 		locale,
 		optionsOrLocale
@@ -269,6 +290,10 @@ export function getPluralGenerator(
 	optionsOrLocale?: PluralGeneratorOptions | string,
 	locale?: string
 ): NumberFormatter {
+	if (has('dojo-debug')) {
+		console.warn('getPluralGenerator has been deprecated. Please use Globalize.pluralGenerator.');
+	}
+
 	return globalizeDelegator<PluralGeneratorOptions, NumberFormatter>('pluralGenerator', {
 		locale,
 		optionsOrLocale
@@ -293,6 +318,10 @@ export function getPluralGenerator(
 export function parseNumber(value: string, options?: NumberFormatterOptions, locale?: string): number;
 export function parseNumber(value: string, locale?: string): number;
 export function parseNumber(value: string, optionsOrLocale?: NumberFormatterOptions | string, locale?: string): number {
+	if (has('dojo-debug')) {
+		console.warn('parseNumber has been deprecated. Please use Globalize.parseNumber.');
+	}
+
 	return globalizeDelegator<string, NumberFormatterOptions, number>('parseNumber', {
 		locale,
 		optionsOrLocale,
@@ -319,6 +348,10 @@ export function parseNumber(value: string, optionsOrLocale?: NumberFormatterOpti
 export function pluralize(value: number, options?: PluralGeneratorOptions, locale?: string): string;
 export function pluralize(value: number, locale?: string): string;
 export function pluralize(value: number, optionsOrLocale?: PluralGeneratorOptions | string, locale?: string): string {
+	if (has('dojo-debug')) {
+		console.warn('plural has been deprecated. Please use Globalize.plural.');
+	}
+
 	return globalizeDelegator<number, PluralGeneratorOptions, string>('plural', {
 		locale,
 		optionsOrLocale,

--- a/src/i18n/unit.ts
+++ b/src/i18n/unit.ts
@@ -1,6 +1,7 @@
 import 'globalize/dist/globalize/number';
 import 'globalize/dist/globalize/plural';
 import 'globalize/dist/globalize/unit';
+import has from '../core/has';
 import { NumberFormatter } from './number';
 import { globalizeDelegator } from './util/globalize';
 
@@ -44,6 +45,10 @@ export function formatUnit(
 	optionsOrLocale?: UnitFormatterOptions | string,
 	locale?: string
 ): string {
+	if (has('dojo-debug')) {
+		console.warn('formatUnit has been deprecated. Please use Globalize.formatUnit.');
+	}
+
 	return globalizeDelegator<number, UnitFormatterOptions, string>('formatUnit', {
 		locale,
 		optionsOrLocale,
@@ -74,6 +79,10 @@ export function getUnitFormatter(
 	optionsOrLocale?: UnitFormatterOptions | string,
 	locale?: string
 ): NumberFormatter {
+	if (has('dojo-debug')) {
+		console.warn('getUnitFormatter has been deprecated. Please use Globalize.unitFormatter.');
+	}
+
 	return globalizeDelegator<string, UnitFormatterOptions, NumberFormatter>('unitFormatter', {
 		locale,
 		optionsOrLocale,

--- a/src/i18n/util/globalize.ts
+++ b/src/i18n/util/globalize.ts
@@ -1,5 +1,18 @@
 import * as Globalize from 'globalize/dist/globalize';
-import i18n from '../i18n';
+import { isLoaded } from '../cldr/load';
+import i18n, { observeLocale } from '../i18n';
+
+// Globalize.js needs to be notified when the system locale is changed
+observeLocale((locale) => {
+	if (isLoaded('supplemental', 'likelySubtags')) {
+		Globalize.load({
+			main: {
+				[locale]: {}
+			}
+		});
+		Globalize.locale(locale);
+	}
+});
 
 /**
  * @private

--- a/tests/i18n/unit/i18n.ts
+++ b/tests/i18n/unit/i18n.ts
@@ -38,19 +38,17 @@ registerSuite('i18n', {
 		},
 
 		formatMessage: {
-			'assert without loaded messages'() {
-				assert.throws(
-					() => {
-						formatMessage({ messages: {} }, 'messageKey');
-					},
-					Error,
-					'The bundle has not been registered.'
-				);
-			},
-
 			async 'assert tokens replaced'() {
 				await i18n(partyBundle);
 				const formatted = formatMessage(partyBundle, 'simpleGuestInfo', {
+					host: 'Nita',
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
+			},
+
+			async 'assert tokens replaced with message argument'() {
+				const formatted = formatMessage('{host} invites {guest} to a party.', {
 					host: 'Nita',
 					guest: 'Bryan'
 				});
@@ -175,19 +173,18 @@ registerSuite('i18n', {
 		},
 
 		getMessageFormatter: {
-			'assert without loaded messages'() {
-				assert.throws(
-					() => {
-						getMessageFormatter({ messages: {} }, 'messageKey')();
-					},
-					Error,
-					'The bundle has not been registered.'
-				);
-			},
-
 			async 'assert tokens replaced'() {
 				await i18n(partyBundle);
 				const formatter = getMessageFormatter(partyBundle, 'simpleGuestInfo');
+				const formatted = formatter({
+					host: 'Nita',
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
+			},
+
+			async 'assert tokens replaced with message argument'() {
+				const formatter = getMessageFormatter('{host} invites {guest} to a party.');
 				const formatted = formatter({
 					host: 'Nita',
 					guest: 'Bryan'

--- a/tests/i18n/unit/i18n.ts
+++ b/tests/i18n/unit/i18n.ts
@@ -1,11 +1,8 @@
 import has from '../../../src/core/has';
 import global from '../../../src/shim/global';
-import * as Globalize from 'globalize';
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
-import { fetchCldrData } from '../support/util';
-import * as cldrLoad from '../../../src/i18n/cldr/load';
 import i18n, {
 	formatMessage,
 	getCachedMessages,
@@ -21,19 +18,7 @@ import bundle from '../support/mocks/common/main';
 import partyBundle from '../support/mocks/common/party';
 
 registerSuite('i18n', {
-	before() {
-		// Load the CLDR data for the locales used in the tests ('en' and 'fr');
-		return fetchCldrData(['en', 'fr']).then(() => {
-			switchLocale('en');
-		});
-	},
-
 	afterEach() {
-		const loadCldrData = cldrLoad.default as any;
-		if (typeof loadCldrData.restore === 'function') {
-			loadCldrData.restore();
-		}
-
 		invalidate();
 		switchLocale(systemLocale);
 	},
@@ -53,103 +38,79 @@ registerSuite('i18n', {
 		},
 
 		formatMessage: {
-			'without CLDR data': {
-				before() {
-					cldrLoad.reset();
-				},
-
-				after() {
-					return fetchCldrData(['en', 'fr']);
-				},
-
-				tests: {
-					'assert without loaded messages'() {
-						assert.throws(
-							() => {
-								formatMessage({ messages: {} }, 'messageKey');
-							},
-							Error,
-							'The bundle has not been registered.'
-						);
+			'assert without loaded messages'() {
+				assert.throws(
+					() => {
+						formatMessage({ messages: {} }, 'messageKey');
 					},
-
-					async 'assert tokens replaced'() {
-						await i18n(partyBundle);
-						const formatted = formatMessage(partyBundle, 'simpleGuestInfo', {
-							host: 'Nita',
-							guest: 'Bryan'
-						});
-						assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
-
-						assert.throws(
-							() => {
-								formatMessage(partyBundle, 'simpleGuestInfo', {
-									host: 'Nita'
-								});
-							},
-							Error,
-							'Missing property guest'
-						);
-					},
-
-					async 'assert message without tokens'() {
-						await i18n(bundle);
-						const formatted = formatMessage(bundle, 'hello');
-						assert.strictEqual(formatted, 'Hello');
-					},
-
-					async 'assert default locale used'() {
-						switchLocale('ar');
-						await i18n(bundle, 'ar');
-						const formatted = formatMessage(bundle, 'hello');
-						assert.strictEqual(formatted, 'السلام عليكم');
-					}
-				}
+					Error,
+					'The bundle has not been registered.'
+				);
 			},
 
-			'with CLDR data': {
-				async 'assert without a locale'() {
-					await i18n(partyBundle);
-					let formatted = formatMessage(partyBundle, 'guestInfo', {
-						host: 'Nita',
-						guestCount: 0
-					});
-					assert.strictEqual(formatted, 'Nita does not host a party.');
+			async 'assert tokens replaced'() {
+				await i18n(partyBundle);
+				const formatted = formatMessage(partyBundle, 'simpleGuestInfo', {
+					host: 'Nita',
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
+			},
 
-					formatted = formatMessage(partyBundle, 'guestInfo', {
-						host: 'Nita',
-						gender: 'female',
-						guestCount: 1,
-						guest: 'Bryan'
-					});
-					assert.strictEqual(formatted, 'Nita invites Bryan to her party.');
+			async 'assert message without tokens'() {
+				await i18n(bundle);
+				const formatted = formatMessage(bundle, 'hello');
+				assert.strictEqual(formatted, 'Hello');
+			},
 
-					formatted = formatMessage(partyBundle, 'guestInfo', {
-						host: 'Nita',
-						gender: 'female',
-						guestCount: 2,
-						guest: 'Bryan'
-					});
-					assert.strictEqual(formatted, 'Nita invites Bryan and one other person to her party.');
+			async 'assert default locale used'() {
+				switchLocale('ar');
+				await i18n(bundle, 'ar');
+				const formatted = formatMessage(bundle, 'hello');
+				assert.strictEqual(formatted, 'السلام عليكم');
+			},
 
-					formatted = formatMessage(partyBundle, 'guestInfo', {
-						host: 'Nita',
-						gender: 'female',
-						guestCount: 42,
-						guest: 'Bryan'
-					});
-					assert.strictEqual(formatted, 'Nita invites Bryan and 41 other people to her party.');
-				},
+			async 'assert without a locale'() {
+				await i18n(partyBundle);
+				let formatted = formatMessage(partyBundle, 'guestInfo', {
+					host: 'Nita',
+					guestCount: 0
+				});
+				assert.strictEqual(formatted, 'Nita does not host a party.');
 
-				async 'assert supported locale'() {
-					await i18n(bundle, 'ar');
-					assert.strictEqual(formatMessage(bundle, 'hello', {}, 'ar'), 'السلام عليكم');
-				},
+				formatted = formatMessage(partyBundle, 'guestInfo', {
+					host: 'Nita',
+					gender: 'female',
+					guestCount: 1,
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan to her party.');
 
-				async 'assert unsupported locale'() {
-					await i18n(bundle, 'fr');
-					assert.strictEqual(formatMessage(bundle, 'hello', {}, 'fr'), 'Hello');
-				}
+				formatted = formatMessage(partyBundle, 'guestInfo', {
+					host: 'Nita',
+					gender: 'female',
+					guestCount: 2,
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan and one other person to her party.');
+
+				formatted = formatMessage(partyBundle, 'guestInfo', {
+					host: 'Nita',
+					gender: 'female',
+					guestCount: 42,
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan and 41 other people to her party.');
+			},
+
+			async 'assert supported locale'() {
+				await i18n(bundle, 'ar');
+				assert.strictEqual(formatMessage(bundle, 'hello', {}, 'ar'), 'السلام عليكم');
+			},
+
+			async 'assert unsupported locale'() {
+				await i18n(bundle, 'fr');
+				assert.strictEqual(formatMessage(bundle, 'hello', {}, 'fr'), 'Hello');
 			}
 		},
 
@@ -214,118 +175,82 @@ registerSuite('i18n', {
 		},
 
 		getMessageFormatter: {
-			'without CLDR data': {
-				before() {
-					cldrLoad.reset();
-				},
-
-				after() {
-					return fetchCldrData(['en', 'fr']);
-				},
-
-				tests: {
-					'assert without loaded messages'() {
-						assert.throws(
-							() => {
-								getMessageFormatter({ messages: {} }, 'messageKey')();
-							},
-							Error,
-							'The bundle has not been registered.'
-						);
+			'assert without loaded messages'() {
+				assert.throws(
+					() => {
+						getMessageFormatter({ messages: {} }, 'messageKey')();
 					},
-
-					async 'assert tokens replaced'() {
-						await i18n(partyBundle);
-						const formatter = getMessageFormatter(partyBundle, 'simpleGuestInfo');
-						const formatted = formatter({
-							host: 'Nita',
-							guest: 'Bryan'
-						});
-						assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
-
-						assert.throws(
-							() => {
-								formatter({
-									host: 'Nita'
-								});
-							},
-							Error,
-							'Missing property guest'
-						);
-					},
-
-					async 'assert message without tokens'() {
-						await i18n(bundle);
-						const formatter = getMessageFormatter(bundle, 'hello');
-						assert.strictEqual(formatter(), 'Hello');
-					},
-
-					async 'assert unsupported locale'() {
-						await i18n(bundle, 'en-GB');
-						const formatter = getMessageFormatter(bundle, 'hello', 'en-GB');
-						assert.strictEqual(formatter(), 'Hello');
-					},
-
-					async 'assert partially-supported locale'() {
-						await i18n(bundle, 'ar-IR');
-						const formatter = getMessageFormatter(bundle, 'hello', 'ar-IR');
-						assert.strictEqual(formatter(), 'السلام عليكم');
-					}
-				}
+					Error,
+					'The bundle has not been registered.'
+				);
 			},
 
-			'with CLDR data': {
-				async 'assert without a locale'() {
-					await i18n(partyBundle);
-					const formatter = getMessageFormatter(partyBundle, 'guestInfo');
-					let formatted = formatter({
-						host: 'Nita',
-						guestCount: 0
-					});
-					assert.strictEqual(formatted, 'Nita does not host a party.');
+			async 'assert tokens replaced'() {
+				await i18n(partyBundle);
+				const formatter = getMessageFormatter(partyBundle, 'simpleGuestInfo');
+				const formatted = formatter({
+					host: 'Nita',
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
+			},
 
-					formatted = formatter({
-						host: 'Nita',
-						gender: 'female',
-						guestCount: 1,
-						guest: 'Bryan'
-					});
-					assert.strictEqual(formatted, 'Nita invites Bryan to her party.');
+			async 'assert message without tokens'() {
+				await i18n(bundle);
+				const formatter = getMessageFormatter(bundle, 'hello');
+				assert.strictEqual(formatter(), 'Hello');
+			},
 
-					formatted = formatter({
-						host: 'Nita',
-						gender: 'female',
-						guestCount: 2,
-						guest: 'Bryan'
-					});
-					assert.strictEqual(formatted, 'Nita invites Bryan and one other person to her party.');
+			async 'assert without a locale'() {
+				await i18n(partyBundle);
+				const formatter = getMessageFormatter(partyBundle, 'guestInfo');
+				let formatted = formatter({
+					host: 'Nita',
+					guestCount: 0
+				});
+				assert.strictEqual(formatted, 'Nita does not host a party.');
 
-					formatted = formatter({
-						host: 'Nita',
-						gender: 'female',
-						guestCount: 42,
-						guest: 'Bryan'
-					});
-					assert.strictEqual(formatted, 'Nita invites Bryan and 41 other people to her party.');
-				},
+				formatted = formatter({
+					host: 'Nita',
+					gender: 'female',
+					guestCount: 1,
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan to her party.');
 
-				async 'assert supported locale'() {
-					await i18n(bundle, 'ar');
-					const formatter = getMessageFormatter(bundle, 'hello', 'ar');
-					assert.strictEqual(formatter(), 'السلام عليكم');
-				},
+				formatted = formatter({
+					host: 'Nita',
+					gender: 'female',
+					guestCount: 2,
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan and one other person to her party.');
 
-				async 'assert unsupported locale'() {
-					await i18n(bundle, 'fr');
-					const formatter = getMessageFormatter(bundle, 'hello', 'fr');
-					assert.strictEqual(formatter(), 'Hello');
-				},
+				formatted = formatter({
+					host: 'Nita',
+					gender: 'female',
+					guestCount: 42,
+					guest: 'Bryan'
+				});
+				assert.strictEqual(formatted, 'Nita invites Bryan and 41 other people to her party.');
+			},
 
-				async 'assert partially-supported locale'() {
-					await i18n(bundle, 'ar-IR');
-					const formatter = getMessageFormatter(bundle, 'hello', 'ar-IR');
-					assert.strictEqual(formatter(), 'السلام عليكم');
-				}
+			async 'assert supported locale'() {
+				await i18n(bundle, 'ar');
+				const formatter = getMessageFormatter(bundle, 'hello', 'ar');
+				assert.strictEqual(formatter(), 'السلام عليكم');
+			},
+
+			async 'assert unsupported locale'() {
+				await i18n(bundle, 'fr');
+				const formatter = getMessageFormatter(bundle, 'hello', 'fr');
+				assert.strictEqual(formatter(), 'Hello');
+			},
+
+			async 'assert partially-supported locale'() {
+				await i18n(bundle, 'ar-IR');
+				const formatter = getMessageFormatter(bundle, 'hello', 'ar-IR');
+				assert.strictEqual(formatter(), 'السلام عليكم');
 			}
 		},
 
@@ -451,34 +376,30 @@ registerSuite('i18n', {
 
 		setLocaleMessages() {
 			try {
-				sinon.stub(Globalize, 'loadMessages');
 				const french = { hello: 'Bonjour', goodbye: 'Au revoir' };
 				const czech = { hello: 'Ahoj', goodbye: 'Ahoj' };
 
 				setLocaleMessages(bundle, french, 'fr');
 				setLocaleMessages(bundle, czech, 'cz');
 
-				const path = '..-_build-tests-support-mocks-common-main';
-				const first = (<any>Globalize).loadMessages.args[0][0].fr[path];
-				const second = (<any>Globalize).loadMessages.args[1][0].cz[path];
-
-				assert.isFrozen(first, 'locale messages should be frozen');
-				assert.isFrozen(second, 'locale messages should be frozen');
+				const cachedFrench = getCachedMessages(bundle, 'fr');
+				const cachedCzech = getCachedMessages(bundle, 'cz');
+				assert.isFrozen(cachedFrench, 'locale messages should be frozen');
+				assert.isFrozen(cachedCzech, 'locale messages should be frozen');
 
 				assert.deepEqual(
-					getCachedMessages(bundle, 'fr'),
+					cachedFrench,
 					{ ...french, helloReply: 'Hello' },
 					'Default messages should be included where not overridden'
 				);
 				assert.deepEqual(
-					getCachedMessages(bundle, 'cz'),
+					cachedCzech,
 					{ ...czech, helloReply: 'Hello' },
 					'Default messages should be included where not overridden'
 				);
 			} finally {
 				setLocaleMessages(bundle, {}, 'fr');
 				setLocaleMessages(bundle, {}, 'cz');
-				(<any>Globalize).loadMessages.restore();
 			}
 		},
 
@@ -498,33 +419,6 @@ registerSuite('i18n', {
 				switchLocale('ar');
 
 				assert.isFalse(next.calledTwice);
-			},
-
-			'assert new locale passed to Globalize'() {
-				sinon.spy(Globalize, 'locale');
-
-				return fetchCldrData(['fr']).then(
-					() => {
-						switchLocale('fr');
-						assert.isTrue(
-							(<any>Globalize).locale.calledWith('fr'),
-							'Locale should be passed to Globalize.'
-						);
-
-						cldrLoad.reset();
-						switchLocale('en');
-						assert.strictEqual(
-							(<any>Globalize).locale.callCount,
-							1,
-							'Locale should not be passed to Globalize.'
-						);
-						(<any>Globalize).locale.restore();
-					},
-					(error: Error) => {
-						(<any>Globalize).locale.restore();
-						throw error;
-					}
-				);
 			}
 		},
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #250 

Add [MessageFormat](https://messageformat.github.io/messageformat/) for ICU message formatting, and add deprecation warnings to the Globalize.js wrapper functions in `i18n/date.ts`, `i18n/number.ts`, and `i18n/unit.ts` with the intention of removing Globalize.js and CLDR.js as `@dojo/framework` dependencies in a future version.

Verified with the [World Clock and TODO MVC Kitchensink](https://github.com/mwistrand/examples/tree/feat/deprecate-globalize) example applications.