### PR TITLE
Add focus middleware mock and tests

### DIFF
--- a/tests/testing/unit/mocks/middleware/all.ts
+++ b/tests/testing/unit/mocks/middleware/all.ts
@@ -1,3 +1,4 @@
+import './focus';
 import './intersection';
 import './node';
 import './resize';

--- a/tests/testing/unit/mocks/middleware/focus.tsx
+++ b/tests/testing/unit/mocks/middleware/focus.tsx
@@ -1,0 +1,23 @@
+const { it } = intern.getInterface('bdd');
+const { describe } = intern.getPlugin('jsdom');
+import createFocusMock from '../../../../../src/testing/mocks/middleware/focus';
+import focus from '../../../../../src/core/middleware/focus';
+import { tsx, create } from '../../../../../src/core/vdom';
+import harness from '../../../../../src/testing/harness';
+
+describe('focus mock', () => {
+	it('should mock focus of a node', () => {
+		const focusMock = createFocusMock();
+		const factory = create({ focus });
+		const App = factory(({ middleware: { focus } }) => {
+			return <div key="root">{focus.isFocused('root') ? 'focus' : 'no focus'}</div>;
+		});
+		const h = harness(() => <App />, { middleware: [[focus, focusMock]] });
+
+		focusMock('root', false);
+		h.expect(() => <div key="root">no focus</div>);
+
+		focusMock('root', true);
+		h.expect(() => <div key="root">focus</div>);
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This adds a focus middleware mock that is capable of mocking the return value of the middleware's `isFocused` method.

```tsx
const focusMock = createFocusMock();
const factory = create({ focus });
const App = factory(({ middleware: { focus } }) => {
	return <div key="root">{focus.isFocused('root') ? 'focus' : 'no focus'}</div>;
});
const h = harness(() => <App />, { middleware: [[focus, focusMock]] });

focusMock('root', false);
h.expect(() => <div key="root">no focus</div>);

focusMock('root', true);
h.expect(() => <div key="root">focus</div>);
```

Resolves #627 