### PR TITLE
Fix inserting a node before a body tag with other siblings

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1222,7 +1222,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				let domNode = nextSibling.domNode;
 				if ((isWNodeWrapper(nextSibling) || isVirtualWrapper(nextSibling)) && nextSibling.childDomWrapperId) {
 					const childWrapper = _idToWrapperMap.get(nextSibling.childDomWrapperId);
-					if (childWrapper) {
+					if (childWrapper && !isBodyWrapper(childWrapper)) {
 						domNode = childWrapper.domNode;
 					}
 				}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Do not use a body node to as the insert before when inserting nodes into an existing tree.

Resolves #636 
