### PR TITLE
Ensure childDomWrapperId is available to insert nodes in the correct order

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1220,10 +1220,15 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			const nextSibling = _wrapperSiblingMap.get(searchNode);
 			if (nextSibling) {
 				let domNode = nextSibling.domNode;
-				if ((isWNodeWrapper(nextSibling) || isVirtualWrapper(nextSibling)) && nextSibling.childDomWrapperId) {
-					const childWrapper = _idToWrapperMap.get(nextSibling.childDomWrapperId);
-					if (childWrapper && !isBodyWrapper(childWrapper)) {
-						domNode = childWrapper.domNode;
+				if (isWNodeWrapper(nextSibling) || isVirtualWrapper(nextSibling)) {
+					if (!nextSibling.childDomWrapperId) {
+						nextSibling.childDomWrapperId = findDomNodeOnParentWrapper(nextSibling);
+					}
+					if (nextSibling.childDomWrapperId) {
+						const childWrapper = _idToWrapperMap.get(nextSibling.childDomWrapperId);
+						if (childWrapper && !isBodyWrapper(childWrapper)) {
+							domNode = childWrapper.domNode;
+						}
 					}
 				}
 				if (domNode && domNode.parentNode) {
@@ -2043,22 +2048,27 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		return processResult;
 	}
 
-	function setDomNodeOnParentWrapper(id: string) {
-		let wrapper = _idToWrapperMap.get(id)!;
-		let children = [...(_idToChildrenWrappers.get(id) || [])];
+	function findDomNodeOnParentWrapper(wrapper: DNodeWrapper): string | undefined {
+		let children = [...(_idToChildrenWrappers.get(wrapper.id) || [])];
 		let child: DNodeWrapper | undefined;
 		while (children.length && !wrapper.domNode) {
 			child = children.shift();
 			if (child) {
 				if (child.domNode) {
-					wrapper.childDomWrapperId = child.id;
-					break;
+					return child.id;
 				}
 				let nextChildren = _idToChildrenWrappers.get(child.id);
 				if (nextChildren) {
 					children = [...nextChildren, ...children];
 				}
 			}
+		}
+	}
+
+	function setDomNodeOnParentWrapper(id: string) {
+		let wrapper = _idToWrapperMap.get(id);
+		if (wrapper) {
+			wrapper.childDomWrapperId = findDomNodeOnParentWrapper(wrapper);
 		}
 	}
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

If the `childDomWrapperId` is not available when trying to find the correct node to insert before, try to find the wrapper id again.

Resolves #641 
