### PR TITLE
V6 - Bug: Fix calling invalidate when checking is a widget or node should focus

### DIFF
--- a/src/core/middleware/focus.ts
+++ b/src/core/middleware/focus.ts
@@ -5,7 +5,6 @@ import { FocusProperties } from '../mixins/Focus';
 
 interface FocusState {
 	current: number;
-	previous: number;
 }
 
 const icache = createICacheMiddleware<FocusState>();
@@ -15,6 +14,7 @@ const factory = create({ icache, diffProperty, node, destroy, invalidator }).pro
 export const focus = factory(({ middleware: { icache, diffProperty, node, destroy, invalidator } }) => {
 	let initialized = false;
 	let currentElement: HTMLElement | undefined;
+	let previous = 0;
 	const nodeSet = new Set<HTMLElement>();
 	diffProperty('focus', (_: FocusProperties, next: FocusProperties) => {
 		const result = next.focus && next.focus();
@@ -37,10 +37,10 @@ export const focus = factory(({ middleware: { icache, diffProperty, node, destro
 	});
 	return {
 		shouldFocus(): boolean {
-			const current = icache.getOrSet('current', 0);
-			const previous = icache.getOrSet('previous', 0);
-			icache.set('previous', current);
-			return current !== previous;
+			const current = icache.get('current') || 0;
+			const shouldFocus = current !== previous;
+			previous = current;
+			return shouldFocus;
 		},
 		focus(): void {
 			const current = icache.getOrSet('current', 0);

--- a/tests/core/unit/middleware/focus.ts
+++ b/tests/core/unit/middleware/focus.ts
@@ -15,6 +15,7 @@ const nodeStub = {
 	get: sb.stub()
 };
 const invalidatorStub = sb.stub();
+const icacheInvalidatorStub = sb.stub();
 
 function cacheFactory() {
 	return cacheMiddleware().callback({
@@ -30,7 +31,7 @@ function icacheFactory() {
 		id: 'test-cache',
 		properties: () => ({}),
 		children: () => [],
-		middleware: { cache: cacheFactory(), invalidator: sb.stub() }
+		middleware: { cache: cacheFactory(), invalidator: icacheInvalidatorStub }
 	});
 }
 
@@ -54,12 +55,19 @@ describe('focus middleware', () => {
 			children: () => []
 		});
 		assert.isFalse(focus.shouldFocus());
+		assert.isTrue(icacheInvalidatorStub.notCalled);
 		focus.focus();
+		assert.isTrue(icacheInvalidatorStub.calledTwice);
 		assert.isTrue(focus.shouldFocus());
+		assert.isTrue(icacheInvalidatorStub.calledTwice);
 		assert.isFalse(focus.shouldFocus());
+		assert.isTrue(icacheInvalidatorStub.calledTwice);
 		focus.focus();
+		assert.isTrue(icacheInvalidatorStub.calledThrice);
 		assert.isTrue(focus.shouldFocus());
+		assert.isTrue(icacheInvalidatorStub.calledThrice);
 		assert.isFalse(focus.shouldFocus());
+		assert.isTrue(icacheInvalidatorStub.calledThrice);
 	});
 
 	it('`shouldFocus` returns true when focus property returns true', () => {


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Backport of #583 