### PR TITLE
Support accepting null on mount

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -115,7 +115,7 @@ export interface MountOptions {
 	sync: boolean;
 	merge: boolean;
 	transition?: TransitionStrategy;
-	domNode: HTMLElement;
+	domNode: HTMLElement | null;
 	registry: Registry;
 }
 
@@ -964,7 +964,7 @@ export const defer = factory(({ id }) => {
 });
 
 export function renderer(renderer: () => RenderResult): Renderer {
-	let _mountOptions: MountOptions = {
+	let _mountOptions: MountOptions & { domNode: HTMLElement } = {
 		sync: false,
 		merge: true,
 		transition: undefined,
@@ -1389,8 +1389,14 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	}
 
 	function mount(mountOptions: Partial<MountOptions> = {}) {
-		_mountOptions = { ..._mountOptions, ...mountOptions };
-		const { domNode } = _mountOptions;
+		let domNode = mountOptions.domNode;
+		if (!domNode) {
+			if (has('dojo-debug') && domNode === null) {
+				console.warn('Unable to find node to mount the application, defaulting to the document body.');
+			}
+			domNode = global.document.body as HTMLElement;
+		}
+		_mountOptions = { ..._mountOptions, ...mountOptions, domNode };
 		const renderResult = wrapNodes(renderer)({}, []);
 		const nextWrapper = {
 			id: `${wrapperId++}`,

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -3936,6 +3936,19 @@ jsdomDescribe('vdom', () => {
 	});
 
 	describe('create', () => {
+		it('should default to document body if null is passed as the mount domNode', () => {
+			const r = renderer(() => v('div', { id: 'my-div' }, ['hello, world!']));
+			r.mount({ domNode: document.getElementById('unknown-id') });
+			const div = document.getElementById('my-div');
+			assert.isOk(div);
+			assert.strictEqual(div!.parentNode, document.body);
+			assert.isTrue(consoleWarnStub.calledOnce);
+			assert.strictEqual(
+				consoleWarnStub.firstCall.args[0],
+				'Unable to find node to mount the application, defaulting to the document body.'
+			);
+		});
+
 		it('should support rendering vnodes only', () => {
 			const r = renderer(() => v('div', ['hello, world!']));
 			const div = document.createElement('div');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support a `null` `domNode` on mount, if `null` is received then it will default to the document body but output a warning when in dev mode (as usually `null` will be received when a dom node using `getElementById` could not be found).
