### PR TITLE
Enable diffProperty to influence widget properties

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -915,21 +915,21 @@ export const diffProperty = factory(({ id }) => {
 			diff = propertiesOrDiff;
 		}
 		if (widgetMeta) {
-			if (has('dojo-debug')) {
-				if (widgetMeta.propertiesCalled) {
-					console.warn(
-						`Calling "propertyDiff" middleware after accessing properties in ${
-							widgetMeta.widgetName
-						}, can result in referencing stale properties.`
-					);
-				}
-			}
 			widgetMeta.customDiffMap = widgetMeta.customDiffMap || new Map();
 			widgetMeta.customDiffProperties = widgetMeta.customDiffProperties || new Set();
 			const propertyDiffMap = widgetMeta.customDiffMap.get(id) || new Map();
 			if (!propertyDiffMap.has(propertyName)) {
 				const result = diff({}, widgetMeta.properties);
 				if (result !== undefined) {
+					if (has('dojo-debug')) {
+						if (widgetMeta.propertiesCalled) {
+							console.warn(
+								`Calling "propertyDiff" middleware after accessing properties in "${
+									widgetMeta.widgetName
+								}", can result in referencing stale properties.`
+							);
+						}
+					}
 					widgetMeta.properties = { ...widgetMeta.properties, [propertyName]: result };
 				}
 				propertyDiffMap.set(propertyName, diff);

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -74,6 +74,7 @@ export interface WNodeWrapper extends BaseNodeWrapper {
 }
 
 export interface WidgetMeta {
+	widgetName: string;
 	mountNode: HTMLElement;
 	dirty: boolean;
 	invalidator: () => void;
@@ -917,7 +918,9 @@ export const diffProperty = factory(({ id }) => {
 			if (has('dojo-debug')) {
 				if (widgetMeta.propertiesCalled) {
 					console.warn(
-						'Calling `propertyDiff` middleware after accessing properties, can result in referencing stale properties.'
+						`Calling "propertyDiff" middleware after accessing properties in ${
+							widgetMeta.widgetName
+						}, can result in referencing stale properties.`
 					);
 				}
 			}
@@ -1894,6 +1897,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				};
 
 				widgetMeta = {
+					widgetName: Constructor.name || 'unknown',
 					mountNode: _mountOptions.domNode,
 					dirty: false,
 					invalidator: invalidate,

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1997,10 +1997,10 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		if (!isWidgetBaseConstructor(Constructor)) {
 			const widgetMeta = widgetMetaMap.get(id);
 			if (widgetMeta) {
-				widgetMeta.properties = next.properties;
+				widgetMeta.properties = { ...next.properties };
 				widgetMeta.children = next.node.children;
 				widgetMeta.rendering = true;
-				runDiffs(widgetMeta, current.properties, next.properties);
+				runDiffs(widgetMeta, current.properties, widgetMeta.properties);
 				if (current.node.children.length > 0 || next.node.children.length > 0) {
 					widgetMeta.dirty = true;
 				}

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -3961,7 +3961,7 @@ jsdomDescribe('vdom', () => {
 					it('Should warn if properties are accessed before registering a diff property', () => {
 						const createWidget = create({ diffProperty, invalidator }).properties<{ foo?: number }>();
 						let counter = 0;
-						const App = createWidget(function App({ middleware, properties }) {
+						const App = createWidget(function unknown({ middleware, properties }) {
 							const { foo } = properties();
 							middleware.diffProperty('foo', properties, () => {
 								return counter;
@@ -3980,9 +3980,9 @@ jsdomDescribe('vdom', () => {
 						const root = document.createElement('div');
 						r.mount({ domNode: root });
 						assert.isTrue(consoleWarnStub.calledOnce);
-						assert.strictEqual(
+						assert.include(
 							consoleWarnStub.firstCall.args[0],
-							'Calling "propertyDiff" middleware after accessing properties in "App", can result in referencing stale properties.'
+							'Calling "propertyDiff" middleware after accessing properties in "unknown", can result in referencing stale properties.'
 						);
 					});
 				});

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -3982,7 +3982,7 @@ jsdomDescribe('vdom', () => {
 						assert.isTrue(consoleWarnStub.calledOnce);
 						assert.strictEqual(
 							consoleWarnStub.firstCall.args[0],
-							'Calling `propertyDiff` middleware after accessing properties, can result in referencing stale properties.'
+							'Calling "propertyDiff" middleware after accessing properties in "App", can result in referencing stale properties.'
 						);
 					});
 				});

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -3961,7 +3961,7 @@ jsdomDescribe('vdom', () => {
 					it('Should warn if properties are accessed before registering a diff property', () => {
 						const createWidget = create({ diffProperty, invalidator }).properties<{ foo?: number }>();
 						let counter = 0;
-						const App = createWidget(({ middleware, properties }) => {
+						const App = createWidget(function App({ middleware, properties }) {
 							const { foo } = properties();
 							middleware.diffProperty('foo', properties, () => {
 								return counter;

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -3930,6 +3930,61 @@ jsdomDescribe('vdom', () => {
 						assert.strictEqual(root.outerHTML, '<div><div><button></button><div>1</div></div></div>');
 						sendEvent(root.childNodes[0].childNodes[0] as HTMLButtonElement, 'click');
 					});
+
+					it('Should inject property value when returned from diffProperty middleware', () => {
+						const createWidget = create({ diffProperty, invalidator }).properties<{ foo?: number }>();
+						let counter = 0;
+						const App = createWidget(({ middleware, properties }) => {
+							middleware.diffProperty('foo', properties, () => {
+								return counter;
+							});
+							const { foo } = properties();
+							return v('div', [
+								v('button', {
+									onclick: () => {
+										counter++;
+										middleware.invalidator();
+									}
+								}),
+								v('div', [`${foo}`])
+							]);
+						});
+						const r = renderer(() => App({}));
+						const root = document.createElement('div');
+						r.mount({ domNode: root });
+						assert.strictEqual(root.outerHTML, '<div><div><button></button><div>0</div></div></div>');
+						sendEvent(root.childNodes[0].childNodes[0] as HTMLButtonElement, 'click');
+						resolvers.resolve();
+						assert.strictEqual(root.outerHTML, '<div><div><button></button><div>1</div></div></div>');
+					});
+
+					it('Should warn if properties are accessed before registering a diff property', () => {
+						const createWidget = create({ diffProperty, invalidator }).properties<{ foo?: number }>();
+						let counter = 0;
+						const App = createWidget(({ middleware, properties }) => {
+							const { foo } = properties();
+							middleware.diffProperty('foo', properties, () => {
+								return counter;
+							});
+							return v('div', [
+								v('button', {
+									onclick: () => {
+										counter++;
+										middleware.invalidator();
+									}
+								}),
+								v('div', [`${foo}`])
+							]);
+						});
+						const r = renderer(() => App({}));
+						const root = document.createElement('div');
+						r.mount({ domNode: root });
+						assert.isTrue(consoleWarnStub.calledOnce);
+						assert.strictEqual(
+							consoleWarnStub.firstCall.args[0],
+							'Calling `propertyDiff` middleware after accessing properties, can result in referencing stale properties.'
+						);
+					});
 				});
 			});
 		});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

One use case for `diffProperty` is to be able to influence the property value when executing the diff property callback. For example in the `theme` middleware, it adds an optional `theme` property to a widget that will be used over the currently loaded theme in the injector. However if no property is explicitly passed to the widget, the `theme` property should be set to the injected theme and available in the downstream widget.
