### PR TITLE
Update to the creating widgets docs for defining a widgets primary key property

### DIFF
--- a/docs/en/creating-widgets/supplemental.md
+++ b/docs/en/creating-widgets/supplemental.md
@@ -345,9 +345,9 @@ Dojo uses a virtual node's key to uniquely identify a specific instance when re-
 
 ## Defining widget `key`s
 
-Traditionally the widget's `key` property is used by the Dojo rendering engine to uniquely identify and track widgets across renders. However updating the `key` property is also an effective way to guarantee that during the next render Dojo's rendering engine will recreate the widget instead of reusing the previous instance. In doing so this means all previous state will be reset widget and can be useful when working with widgets that manage logic based on a widget property.
+Traditionally the widget's `key` property is used by the Dojo rendering engine to uniquely identify and track widgets across renders. However, updating the `key` property is also an effective way to guarantee that during the next render Dojo's rendering engine will recreate the widget instead of reusing the previous instance. When recreating the widget all previous state will get reset. This behavior is useful when working with widgets that manage logic based on the value of a widget property.
 
-Dojo provides a mechanism for widget authors to associate a widget property to the widgets identity, by using the `.key()` chained method from the `create()` factory.
+Dojo provides a mechanism for widget authors to associate a widget property to the widget's identity by using the `.key()` chained method from the `create()` factory.
 
 ```tsx
 import { create } from '@dojo/framework/core/vdom';
@@ -361,7 +361,7 @@ const factory = create()
 	.key('id');
 ```
 
-Using this factory Dojo will recreate the widget instance if the `id` property changes. This powerful feature provides widget authors assurance their widget will be recreated when the defined property changes, therefore not having to deal with often complicated logic to refresh data based on the property.
+Using this factory Dojo will recreate the widget instance if the `id` property changes. This powerful feature provides widget authors assurance their widget will get recreated when the defined property changes, therefore not having to deal with complicated logic to refresh data based on the property.
 
 ```tsx
 import { create } from '@dojo/framework/core/vdom';
@@ -395,7 +395,7 @@ const MyWidget = factory(function MyWidget({ properties, middleware: { icache } 
 });
 ```
 
-This example demonstrates fetching data based the `id` property, without using `.key('id)` the widget would need to manage scenarios where the `id` property changes. This would include logic to determine the property has actually changed, re-fetch the data and also show the loading message. Using `.key('id')` means that we know that when the `id` property changes the widget will be recreated and the state reset, so that the widget show the "Loading Data..." message and fetch data based on the updated `id`.
+This example demonstrates fetching data based on the `id` property. Without using `.key('id)`, the widget would need to manage scenarios where the `id` property changes. This would include logic to determine if the property has actually changed, re-fetch the relevant data and also show the loading message. Using `.key('id')` guarantees that when the `id` property changes the widget will get recreated and the state reset, and the widget shows the "Loading Data..." message and fetches data based on the updated `id`.
 
 ## Configuring `VNode`s
 

--- a/docs/en/creating-widgets/supplemental.md
+++ b/docs/en/creating-widgets/supplemental.md
@@ -343,6 +343,17 @@ Dojo uses a virtual node's key to uniquely identify a specific instance when re-
 
 > **Note:** Virtual node `keys` should be consistent across multiple render function invocations. Generating different keys for what should be the same output node within every render call [is considered an anti-pattern in Dojo application development](/learn/creating-widgets/best-practice-development#the-virtual-dom), and should be avoided.
 
+## Controlling
+
+Changing the `key` property on a widget is an effective way to guarantee that during the next render Dojo's rendering engine will create a new widget "instance" **\*** all previous state and
+
+```tsx
+import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '';
+```
+
+the responsibility
+
 ## Configuring `VNode`s
 
 `VNodeProperties` contains many fields that act as the primary API to interact with concrete elements in the DOM. Many of these properties mirror those available on [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement), including specifying various `oneventname` event handlers.

--- a/docs/en/creating-widgets/supplemental.md
+++ b/docs/en/creating-widgets/supplemental.md
@@ -343,16 +343,59 @@ Dojo uses a virtual node's key to uniquely identify a specific instance when re-
 
 > **Note:** Virtual node `keys` should be consistent across multiple render function invocations. Generating different keys for what should be the same output node within every render call [is considered an anti-pattern in Dojo application development](/learn/creating-widgets/best-practice-development#the-virtual-dom), and should be avoided.
 
-## Controlling
+## Defining widget `key`s
 
-Changing the `key` property on a widget is an effective way to guarantee that during the next render Dojo's rendering engine will create a new widget "instance" **\*** all previous state and
+Traditionally the widget's `key` property is used by the Dojo rendering engine to uniquely identify and track widgets across renders. However updating the `key` property is also an effective way to guarantee that during the next render Dojo's rendering engine will recreate the widget instead of reusing the previous instance. In doing so this means all previous state will be reset widget and can be useful when working with widgets that manage logic based on a widget property.
+
+Dojo provides a mechanism for widget authors to associate a widget property to the widgets identity, by using the `.key()` chained method from the `create()` factory.
 
 ```tsx
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '';
+import { create } from '@dojo/framework/core/vdom';
+
+interface MyWidgetProperties {
+	id: string;
+}
+
+const factory = create()
+	.properties<MyWidgetProperties>()
+	.key('id');
 ```
 
-the responsibility
+Using this factory Dojo will recreate the widget instance if the `id` property changes. This powerful feature provides widget authors assurance their widget will be recreated when the defined property changes, therefore not having to deal with often complicated logic to refresh data based on the property.
+
+```tsx
+import { create } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
+
+interface MyWidgetProperties {
+	id: string;
+}
+
+const factory = create({ icache })
+	.properties<MyWidgetProperties>()
+	.key('id');
+
+const MyWidget = factory(function MyWidget({ properties, middleware: { icache } }) {
+	const { id } = properties();
+	const data = icache.getOrSet('data', async () => {
+		const response = await fetch(`https://my-api/items/${id}`);
+		const json = await response.json();
+		return json.data;
+	});
+
+	if (!data) {
+		return <div>Loading Data...</div>;
+	}
+
+	return (
+		<div>
+			<ul>{data.map((item) => <li>{item}</li>)}</ul>
+		</div>
+	);
+});
+```
+
+This example demonstrates fetching data based the `id` property, without using `.key('id)` the widget would need to manage scenarios where the `id` property changes. This would include logic to determine the property has actually changed, re-fetch the data and also show the loading message. Using `.key('id')` means that we know that when the `id` property changes the widget will be recreated and the state reset, so that the widget show the "Loading Data..." message and fetch data based on the updated `id`.
 
 ## Configuring `VNode`s
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds a section in the docs on `.key('id')` usage.