### PR TITLE
Provide a live binding to the current version of a widgets function properties

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -414,6 +414,10 @@ export interface Callback<Props, Children, Middleware, ReturnValue> {
 	middlewares?: any;
 }
 
+export type ProxyProperties<T> = {
+	[P in keyof T]: T[P] extends ((...args: any[]) => any) | undefined ? T[P] & { unwrap: () => string } : T[P]
+};
+
 export interface MiddlewareResult<Props, Children, Middleware, ReturnValue> {
 	api: ReturnValue;
 	properties: Props;

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -403,7 +403,9 @@ export type MiddlewareApiMap<U extends MiddlewareMap<any>> = { [P in keyof U]: R
 export type MiddlewareApi<T extends MiddlewareResultFactory<any, any, any, any>> = ReturnType<ReturnType<T>['api']>;
 
 export type ProxyProperties<T> = {
-	[P in keyof T]: T[P] extends ((...args: any[]) => any) | undefined ? T[P] & { unwrap: () => T[P] } : T[P]
+	[P in keyof T]: T[P] extends ((...args: any[]) => any) | Constructor<any> | undefined
+		? T[P] & { unwrap: () => T[P] }
+		: T[P]
 };
 
 export interface Callback<Props, Children, Middleware, ReturnValue> {

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -402,7 +402,7 @@ export type MiddlewareApiMap<U extends MiddlewareMap<any>> = { [P in keyof U]: R
 
 export type MiddlewareApi<T extends MiddlewareResultFactory<any, any, any, any>> = ReturnType<ReturnType<T>['api']>;
 
-export type ProxyProperties<T> = {
+export type WrappedProperties<T> = {
 	[P in keyof T]: T[P] extends ((...args: any[]) => any) | Constructor<any> | undefined
 		? T[P] & { unwrap: () => T[P] }
 		: T[P]
@@ -413,7 +413,7 @@ export interface Callback<Props, Children, Middleware, ReturnValue> {
 		options: {
 			id: string;
 			middleware: MiddlewareApiMap<Middleware>;
-			properties: () => ProxyProperties<Readonly<Props>>;
+			properties: () => WrappedProperties<Readonly<Props>>;
 			children: () => Children extends any[] ? Children : [Children];
 		}
 	): ReturnValue;

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -402,21 +402,21 @@ export type MiddlewareApiMap<U extends MiddlewareMap<any>> = { [P in keyof U]: R
 
 export type MiddlewareApi<T extends MiddlewareResultFactory<any, any, any, any>> = ReturnType<ReturnType<T>['api']>;
 
+export type ProxyProperties<T> = {
+	[P in keyof T]: T[P] extends ((...args: any[]) => any) | undefined ? T[P] & { unwrap: () => T[P] } : T[P]
+};
+
 export interface Callback<Props, Children, Middleware, ReturnValue> {
 	(
 		options: {
 			id: string;
 			middleware: MiddlewareApiMap<Middleware>;
-			properties: () => Props;
+			properties: () => ProxyProperties<Readonly<Props>>;
 			children: () => Children extends any[] ? Children : [Children];
 		}
 	): ReturnValue;
 	middlewares?: any;
 }
-
-export type ProxyProperties<T> = {
-	[P in keyof T]: T[P] extends ((...args: any[]) => any) | undefined ? T[P] & { unwrap: () => string } : T[P]
-};
 
 export interface MiddlewareResult<Props, Children, Middleware, ReturnValue> {
 	api: ReturnValue;

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1110,17 +1110,15 @@ function createProxyProperties(id: string, properties: any) {
 				const widgetMeta = widgetMetaMap.get(id);
 				if (widgetMeta) {
 					return widgetMeta.originalProperties[propertyName](...args);
-				} else {
-					properties[propertyName](...args);
 				}
+				return properties[propertyName](...args);
 			};
 			props[propertyName].unwrap = () => {
 				const widgetMeta = widgetMetaMap.get(id);
 				if (widgetMeta) {
 					return widgetMeta.originalProperties[propertyName];
-				} else {
-					properties[propertyName];
 				}
+				return properties[propertyName];
 			};
 		} else {
 			props[propertyName] = properties[propertyName];

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1105,7 +1105,7 @@ function createProxyProperties(id: string, properties: any) {
 	const propertyNames = Object.keys(properties);
 	for (let i = 0; i < propertyNames.length; i++) {
 		const propertyName = propertyNames[i];
-		if (typeof properties[propertyName] === 'function' && !isWidgetBaseConstructor(properties[propertyName])) {
+		if (typeof properties[propertyName] === 'function') {
 			props[propertyName] = function PropertyProxy(...args: any[]) {
 				const widgetMeta = widgetMetaMap.get(id);
 				if (widgetMeta) {

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -26,8 +26,7 @@ import {
 	RegistryLabel,
 	DeferredVirtualProperties,
 	DomOptions,
-	DefaultChildrenWNodeFactory,
-	ProxyProperties
+	DefaultChildrenWNodeFactory
 } from './interfaces';
 import { Registry, isWidget, isWidgetBaseConstructor, isWidgetFunction, isWNodeFactory } from './Registry';
 import { auto } from './diff';
@@ -715,12 +714,7 @@ export function create<T extends MiddlewareMap, MiddlewareProps = ReturnType<T[k
 ) {
 	function properties<Props>() {
 		function returns<ReturnValue>(
-			callback: Callback<
-				WidgetProperties & ProxyProperties<Props> & ProxyProperties<UnionToIntersection<MiddlewareProps>>,
-				DNode[],
-				T,
-				ReturnValue
-			>
+			callback: Callback<WidgetProperties & Props & UnionToIntersection<MiddlewareProps>, DNode[], T, ReturnValue>
 		): ReturnValue extends RenderResult
 			? DefaultChildrenWNodeFactory<{
 					properties: Props & WidgetProperties & UnionToIntersection<MiddlewareProps>;
@@ -738,7 +732,7 @@ export function create<T extends MiddlewareMap, MiddlewareProps = ReturnType<T[k
 		function key(key: KeysMatching<Props, string | number>) {
 			function returns<ReturnValue>(
 				callback: Callback<
-					WidgetProperties & ProxyProperties<Props> & ProxyProperties<UnionToIntersection<MiddlewareProps>>,
+					WidgetProperties & Props & UnionToIntersection<MiddlewareProps>,
 					DNode[],
 					T,
 					ReturnValue
@@ -762,7 +756,7 @@ export function create<T extends MiddlewareMap, MiddlewareProps = ReturnType<T[k
 		function children<Children>() {
 			function returns<ReturnValue>(
 				callback: Callback<
-					WidgetProperties & ProxyProperties<Props> & ProxyProperties<UnionToIntersection<MiddlewareProps>>,
+					WidgetProperties & Props & UnionToIntersection<MiddlewareProps>,
 					Children,
 					T,
 					ReturnValue
@@ -789,9 +783,7 @@ export function create<T extends MiddlewareMap, MiddlewareProps = ReturnType<T[k
 			function key(key: KeysMatching<Props, string | number>) {
 				function returns<ReturnValue>(
 					callback: Callback<
-						WidgetProperties &
-							ProxyProperties<Props> &
-							ProxyProperties<UnionToIntersection<MiddlewareProps>>,
+						WidgetProperties & Props & UnionToIntersection<MiddlewareProps>,
 						Children,
 						T,
 						ReturnValue
@@ -828,7 +820,7 @@ export function create<T extends MiddlewareMap, MiddlewareProps = ReturnType<T[k
 		function properties<Props>() {
 			function returns<ReturnValue>(
 				callback: Callback<
-					WidgetProperties & ProxyProperties<Props> & ProxyProperties<UnionToIntersection<MiddlewareProps>>,
+					WidgetProperties & Props & UnionToIntersection<MiddlewareProps>,
 					Children,
 					T,
 					ReturnValue
@@ -854,9 +846,7 @@ export function create<T extends MiddlewareMap, MiddlewareProps = ReturnType<T[k
 			function key(key: KeysMatching<Props, string | number>) {
 				function returns<ReturnValue>(
 					callback: Callback<
-						WidgetProperties &
-							ProxyProperties<Props> &
-							ProxyProperties<UnionToIntersection<MiddlewareProps>>,
+						WidgetProperties & Props & UnionToIntersection<MiddlewareProps>,
 						Children,
 						T,
 						ReturnValue
@@ -886,12 +876,7 @@ export function create<T extends MiddlewareMap, MiddlewareProps = ReturnType<T[k
 		}
 
 		function returns<ReturnValue>(
-			callback: Callback<
-				WidgetProperties & ProxyProperties<UnionToIntersection<MiddlewareProps>>,
-				Children,
-				T,
-				ReturnValue
-			>
+			callback: Callback<WidgetProperties & UnionToIntersection<MiddlewareProps>, Children, T, ReturnValue>
 		): ReturnValue extends RenderResult
 			? UnionToIntersection<Children> extends undefined
 				? OptionalWNodeFactory<{
@@ -915,12 +900,7 @@ export function create<T extends MiddlewareMap, MiddlewareProps = ReturnType<T[k
 	}
 
 	function returns<ReturnValue>(
-		callback: Callback<
-			WidgetProperties & ProxyProperties<UnionToIntersection<MiddlewareProps>>,
-			DNode[],
-			T,
-			ReturnValue
-		>
+		callback: Callback<WidgetProperties & UnionToIntersection<MiddlewareProps>, DNode[], T, ReturnValue>
 	): ReturnValue extends RenderResult
 		? DefaultChildrenWNodeFactory<{
 				properties: WidgetProperties & UnionToIntersection<MiddlewareProps>;

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1100,7 +1100,7 @@ export const defer = factory(({ id }) => {
 	};
 });
 
-function createProxyProperties(id: string, properties: any) {
+function wrapFunctionProperties(id: string, properties: any) {
 	const props: any = {};
 	const propertyNames = Object.keys(properties);
 	for (let i = 0; i < propertyNames.length; i++) {
@@ -2041,7 +2041,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					mountNode: _mountOptions.domNode,
 					dirty: false,
 					invalidator: invalidate,
-					properties: createProxyProperties(id, next.node.properties),
+					properties: wrapFunctionProperties(id, next.node.properties),
 					originalProperties: { ...next.node.properties },
 					children: next.node.children,
 					deferRefs: 0,
@@ -2139,7 +2139,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			const widgetMeta = widgetMetaMap.get(id);
 			if (widgetMeta) {
 				widgetMeta.originalProperties = { ...next.properties };
-				widgetMeta.properties = createProxyProperties(id, widgetMeta.originalProperties);
+				widgetMeta.properties = wrapFunctionProperties(id, widgetMeta.originalProperties);
 				widgetMeta.children = next.node.children;
 				widgetMeta.rendering = true;
 				runDiffs(widgetMeta, current.properties, widgetMeta.properties);

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1106,7 +1106,7 @@ function wrapFunctionProperties(id: string, properties: any) {
 	for (let i = 0; i < propertyNames.length; i++) {
 		const propertyName = propertyNames[i];
 		if (typeof properties[propertyName] === 'function') {
-			props[propertyName] = function PropertyProxy(...args: any[]) {
+			props[propertyName] = function WrappedProperty(...args: any[]) {
 				const widgetMeta = widgetMetaMap.get(id);
 				if (widgetMeta) {
 					return widgetMeta.originalProperties[propertyName](...args);

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -24,7 +24,7 @@ import {
 	incrementBlockCount,
 	decrementBlockCount
 } from '../../../src/core/vdom';
-import { VNode, DNode, DomVNode, RenderResult, WidgetBaseConstructor, Constructor } from '../../../src/core/interfaces';
+import { VNode, DNode, DomVNode, RenderResult, WidgetBaseConstructor } from '../../../src/core/interfaces';
 import { WidgetBase } from '../../../src/core/WidgetBase';
 import Registry from '../../../src/core/Registry';
 import { I18nMixin } from '../../../src/core/mixins/I18n';
@@ -3731,17 +3731,13 @@ jsdomDescribe('vdom', () => {
 
 			it('should create live binding to the latest version of function properties', () => {
 				const factory = create({ icache }).properties<any>();
-				class MyClass {}
 
 				const FunctionChild = create({ icache }).properties<{
-					Ctor: Constructor<MyClass>;
 					onChange: (value: number) => void;
 				}>()(function FunctionChild({ properties, middleware: { icache } }) {
 					const renderCount = icache.getOrSet('r', 1, false);
 					icache.set('r', renderCount + 1, false);
-					const { onChange, Ctor } = properties();
-					const MyCtor = Ctor.unwrap();
-					new MyCtor();
+					const { onChange } = properties();
 					return (
 						<div>
 							<button onclick={() => onChange(1)} />
@@ -3756,17 +3752,17 @@ jsdomDescribe('vdom', () => {
 						const result = icache.getOrSet('n', 1);
 						const renderCount = icache.getOrSet('r', 1);
 						icache.set('r', renderCount + 1);
+						const PropertyWidget = A.unwrap();
 						return (
 							<div>
 								<FunctionChild
-									Ctor={MyClass}
 									onChange={() => {
 										icache.set('n', result * multiplier);
 									}}
 								/>
 								<div>{`result: ${result}`}</div>
 								<div>{`Parent Rendered: ${renderCount}`}</div>
-								<A>Class</A>
+								<PropertyWidget>Class</PropertyWidget>
 							</div>
 						);
 					}

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -24,7 +24,7 @@ import {
 	incrementBlockCount,
 	decrementBlockCount
 } from '../../../src/core/vdom';
-import { VNode, DNode, DomVNode, RenderResult } from '../../../src/core/interfaces';
+import { VNode, DNode, DomVNode, RenderResult, WidgetBaseConstructor } from '../../../src/core/interfaces';
 import { WidgetBase } from '../../../src/core/WidgetBase';
 import Registry from '../../../src/core/Registry';
 import { I18nMixin } from '../../../src/core/mixins/I18n';
@@ -3726,6 +3726,107 @@ jsdomDescribe('vdom', () => {
 				assert.strictEqual(
 					root.outerHTML,
 					'<root><div><div>property-new-fooproperty-barwidget-state-1middleware-state-1</div><div>user-keyproperty-new-fooproperty-barwidget-state-1middleware-state-1</div><div>999943214321widget-state-1middleware-state-1</div><div>1234999943214321widget-state-1middleware-state-1</div><div>property-new-foowidget-state-1middleware-state-1</div><button></button></div></root>'
+				);
+			});
+
+			it('should create live binding to the latest function property', () => {
+				const factory = create({ icache }).properties<any>();
+
+				const FunctionChild = create({ icache }).properties<{ onChange: () => void }>()(function FunctionChild({
+					properties,
+					middleware: { icache }
+				}) {
+					const renderCount = icache.getOrSet('r', 1, false);
+					icache.set('r', renderCount + 1, false);
+					const { onChange } = properties();
+					return (
+						<div>
+							<button onclick={() => onChange()} />
+							<div>{`Child Rendered: ${renderCount}`}</div>
+						</div>
+					);
+				});
+
+				const FunctionBased = create({ icache }).properties<{ multiplier: number; A: WidgetBaseConstructor }>()(
+					function FunctionBased({ properties, middleware: { icache } }) {
+						const { multiplier, A } = properties();
+						const result = icache.getOrSet('n', 1);
+						const renderCount = icache.getOrSet('r', 1);
+						icache.set('r', renderCount + 1);
+						return (
+							<div>
+								<FunctionChild
+									onChange={() => {
+										icache.set('n', result * multiplier);
+									}}
+								/>
+								<div>{`result: ${result}`}</div>
+								<div>{`Parent Rendered: ${renderCount}`}</div>
+								<A>Class</A>
+							</div>
+						);
+					}
+				);
+
+				class ClassBased extends WidgetBase {
+					private _counter = 0;
+					render() {
+						return (
+							<div>
+								{this.children}
+								{`${this._counter++}`}
+							</div>
+						);
+					}
+				}
+
+				const App = factory(function App({ middleware: { icache } }) {
+					const multiplier = icache.getOrSet('m', 2);
+					return (
+						<div>
+							<button
+								onclick={() => {
+									icache.set('m', multiplier + 1);
+								}}
+							>
+								Multiplier++
+							</button>
+							<div>{`Multiplier: ${multiplier}`}</div>
+							<FunctionBased multiplier={multiplier} A={ClassBased} />
+						</div>
+					);
+				});
+				const root = document.createElement('root');
+				const r = renderer(() => <App />);
+				r.mount({ domNode: root });
+
+				assert.strictEqual(
+					root.outerHTML,
+					'<root><div><button>Multiplier++</button><div>Multiplier: 2</div><div><div><button></button><div>Child Rendered: 1</div></div><div>result: 1</div><div>Parent Rendered: 1</div><div>Class0</div></div></div></root>'
+				);
+				(root.children[0].children[0] as HTMLButtonElement).click();
+				resolvers.resolve();
+				assert.strictEqual(
+					root.outerHTML,
+					'<root><div><button>Multiplier++</button><div>Multiplier: 3</div><div><div><button></button><div>Child Rendered: 1</div></div><div>result: 1</div><div>Parent Rendered: 2</div><div>Class1</div></div></div></root>'
+				);
+				(root.children[0].children[2].children[0].children[0] as HTMLButtonElement).click();
+				resolvers.resolve();
+				assert.strictEqual(
+					root.outerHTML,
+					'<root><div><button>Multiplier++</button><div>Multiplier: 3</div><div><div><button></button><div>Child Rendered: 1</div></div><div>result: 3</div><div>Parent Rendered: 3</div><div>Class2</div></div></div></root>'
+				);
+				(root.children[0].children[2].children[0].children[0] as HTMLButtonElement).click();
+				resolvers.resolve();
+				assert.strictEqual(
+					root.outerHTML,
+					'<root><div><button>Multiplier++</button><div>Multiplier: 3</div><div><div><button></button><div>Child Rendered: 1</div></div><div>result: 9</div><div>Parent Rendered: 4</div><div>Class3</div></div></div></root>'
+				);
+				(root.children[0].children[2].children[0].children[0] as HTMLButtonElement).click();
+				resolvers.resolve();
+				assert.strictEqual(
+					root.outerHTML,
+					'<root><div><button>Multiplier++</button><div>Multiplier: 3</div><div><div><button></button><div>Child Rendered: 1</div></div><div>result: 27</div><div>Parent Rendered: 5</div><div>Class4</div></div></div></root>'
 				);
 			});
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Wraps functions passed to a widget to provide a proxy to the latest version.

Resolves #664 
