### PR TITLE
Update store paths to require numbers for indices

### DIFF
--- a/src/core/middleware/store.ts
+++ b/src/core/middleware/store.ts
@@ -30,12 +30,13 @@ export const createStoreMiddleware = <S = any>(initial?: (store: Store<S>) => vo
 		};
 		return {
 			get<U = any>(path: Path<S, U>): U {
-				if (registeredPaths.indexOf(path.path) === -1) {
+				const stringPath = Array.isArray(path.path) ? path.path.join('/') : String(path.path);
+				if (registeredPaths.indexOf(stringPath) === -1) {
 					const handle = store.onChange(path, () => {
 						invalidator();
 					});
 					handles.push(() => handle.remove());
-					registeredPaths.push(path.path);
+					registeredPaths.push(stringPath);
 				}
 				return store.get(path);
 			},

--- a/src/stores/process.ts
+++ b/src/stores/process.ts
@@ -242,7 +242,7 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 			const createHandler = (partialPath?: Path<T, any>) => ({
 				get(obj: any, prop: string): any {
 					const fullPath = partialPath ? path(partialPath, prop) : path(prop as keyof T);
-					const stringPath = fullPath.path;
+					const stringPath = Array.isArray(fullPath.path) ? fullPath.path.join('/') : String(fullPath.path);
 
 					if (typeof prop === 'symbol' && prop === valueSymbol) {
 						return proxied.get(stringPath);

--- a/src/stores/state/Patch.ts
+++ b/src/stores/state/Patch.ts
@@ -44,9 +44,8 @@ export interface PatchResult<T = any, U = any> {
 }
 
 function add(pointerTarget: PointerTarget, value: any): any {
-	let index = parseInt(pointerTarget.segment, 10);
-	if (Array.isArray(pointerTarget.target) && !isNaN(index)) {
-		pointerTarget.target.splice(index, 0, value);
+	if (Array.isArray(pointerTarget.target) && typeof pointerTarget.segment === 'number') {
+		pointerTarget.target.splice(pointerTarget.segment, 0, value);
 	} else {
 		pointerTarget.target[pointerTarget.segment] = value;
 	}
@@ -54,9 +53,8 @@ function add(pointerTarget: PointerTarget, value: any): any {
 }
 
 function replace(pointerTarget: PointerTarget, value: any): any {
-	let index = parseInt(pointerTarget.segment, 10);
-	if (Array.isArray(pointerTarget.target) && !isNaN(index)) {
-		pointerTarget.target.splice(index, 1, value);
+	if (Array.isArray(pointerTarget.target) && typeof pointerTarget.segment === 'number') {
+		pointerTarget.target.splice(pointerTarget.segment, 1, value);
 	} else {
 		pointerTarget.target[pointerTarget.segment] = value;
 	}
@@ -64,8 +62,8 @@ function replace(pointerTarget: PointerTarget, value: any): any {
 }
 
 function remove(pointerTarget: PointerTarget): any {
-	if (Array.isArray(pointerTarget.target)) {
-		pointerTarget.target.splice(parseInt(pointerTarget.segment, 10), 1);
+	if (Array.isArray(pointerTarget.target) && typeof pointerTarget.segment === 'number') {
+		pointerTarget.target.splice(pointerTarget.segment, 1);
 	} else {
 		delete pointerTarget.target[pointerTarget.segment];
 	}

--- a/tests/stores/unit/process.ts
+++ b/tests/stores/unit/process.ts
@@ -175,6 +175,15 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 			assert.strictEqual(foobar, 'foo/bar');
 		});
 
+		it('handles array indices in `path`', () => {
+			const store = new Store<{ foo: { bar: string }[] }>();
+			store.apply([add(store.path('foo'), [{ bar: 'baz' }])]);
+			const foo = store.get(store.path('foo'));
+			const foobar = store.get(store.path('foo', 0, 'bar'));
+			assert.deepEqual(foo, [{ bar: 'baz' }]);
+			assert.strictEqual(foobar, 'baz');
+		});
+
 		it('should handle optional properties for updates', () => {
 			type StateType = { a?: { b?: string }; foo?: number; bar: string };
 			const createCommand = createCommandFactory<StateType>();
@@ -649,7 +658,7 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 					const paths = result.operations.map((operation) => operation.path.path);
 					const logs = result.get(store.path('logs')) || [];
 
-					result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
+					result.apply([{ op: OperationType.ADD, path: new Pointer(['logs', logs.length]), value: paths }]);
 				}
 			});
 
@@ -682,7 +691,7 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 					store.apply([
 						{
 							op: OperationType.ADD,
-							path: new Pointer(`/initLogs/${initLog.length}`),
+							path: new Pointer(['initLogs', initLog.length]),
 							value: 'initial value'
 						}
 					]);
@@ -712,7 +721,7 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 					const paths = result.operations.map((operation) => operation.path.path);
 					const logs = result.get(store.path('logs')) || [];
 
-					result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
+					result.apply([{ op: OperationType.ADD, path: new Pointer(['logs', logs.length]), value: paths }]);
 				}
 			});
 
@@ -764,7 +773,7 @@ const tests = (stateType: string, state?: () => MutableState<any>) => {
 				const paths = result.operations.map((operation) => operation.path.path);
 				const logs = result.get(store.path('logs')) || [];
 
-				result.apply([{ op: OperationType.ADD, path: new Pointer(`/logs/${logs.length}`), value: paths }]);
+				result.apply([{ op: OperationType.ADD, path: new Pointer(['logs', logs.length]), value: paths }]);
 			};
 
 			const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('bar')], () => ({

--- a/tests/stores/unit/state/ImmutableState.ts
+++ b/tests/stores/unit/state/ImmutableState.ts
@@ -41,11 +41,11 @@ describe('state/ImmutableState', () => {
 
 		it('value to array index path', () => {
 			const state = new ImmutableState();
-			const result = state.apply([ops.add({ path: '/test/0', state: null, value: null }, 'test')]);
+			const result = state.apply([ops.add({ path: ['test', 0], state: null, value: null }, 'test')]);
 			assert.deepEqual(state.path('/test').value, ['test']);
 			assert.deepEqual(result, [
-				{ op: OperationType.TEST, path: new Pointer('/test/0'), value: 'test' },
-				{ op: OperationType.REMOVE, path: new Pointer('/test/0') }
+				{ op: OperationType.TEST, path: new Pointer(['test', 0]), value: 'test' },
+				{ op: OperationType.REMOVE, path: new Pointer(['test', 0]) }
 			]);
 		});
 	});
@@ -171,12 +171,12 @@ describe('state/ImmutableState', () => {
 			state.apply([ops.add({ path: '/foo/0/bar/baz/0/qux', state: null, value: null }, true)]);
 			const result = state.apply([ops.test({ path: '/foo/0/bar/baz/0/qux', state: null, value: null }, true)]);
 			assert.deepEqual(result, []);
-			assert.deepEqual(state.path('/foo').value, [{ bar: { baz: [{ qux: true }] } }]);
+			assert.deepEqual(state.path('/foo').value, { 0: { bar: { baz: { 0: { qux: true } } } } });
 		});
 
 		it('complex value', () => {
 			const state = new ImmutableState();
-			state.apply([ops.add({ path: '/foo/0/bar/baz/0/qux', state: null, value: null }, true)]);
+			state.apply([ops.add({ path: ['foo', 0, 'bar', 'baz', 0, 'qux'], state: null, value: null }, true)]);
 			const result = state.apply([
 				ops.test({ path: '/foo', state: null, value: null }, [
 					{

--- a/tests/stores/unit/state/Patch.ts
+++ b/tests/stores/unit/state/Patch.ts
@@ -154,13 +154,13 @@ describe('state/Patch', () => {
 		});
 
 		it('array index path', () => {
-			const patch = new Patch(ops.remove({ path: '/test/1', state: null, value: null }));
+			const patch = new Patch(ops.remove({ path: ['test', 1], state: null, value: null }));
 			const obj = { test: ['test', 'foo'] };
 			const result = patch.apply(obj);
 			assert.notStrictEqual(result.object, obj);
 			assert.deepEqual(result.object, { test: ['test'] });
 			assert.deepEqual(result.undoOperations, [
-				{ op: OperationType.ADD, path: new Pointer('/test/1'), value: 'foo' }
+				{ op: OperationType.ADD, path: new Pointer(['test', 1]), value: 'foo' }
 			]);
 		});
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This could move the store "paths" away from a JSON path style implementation and instead explicitly require numeric values to access array indices. Any string would be treated as an object property. Of course, if the targeted value is already an array passing a string would still work to index the array, but it would only use regular property access and not array methods.

This would resolve #645  but it'd also be a breaking change. 
