### PR TITLE
Move FocusProperties to interfaces and export from mixin and middleware

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -653,6 +653,11 @@ export interface LocaleData {
 	rtl?: boolean;
 }
 
+export interface FocusProperties {
+	/** Function to determine if the widget should focus */
+	focus?: () => boolean;
+}
+
 export interface I18nProperties extends LocaleData {
 	/**
 	 * An optional override for the bundle passed to the `localizeBundle`. If the override contains a `messages` object,

--- a/src/core/middleware/focus.ts
+++ b/src/core/middleware/focus.ts
@@ -1,7 +1,9 @@
 import global from '../../shim/global';
 import { create, diffProperty, node, destroy, invalidator } from '../vdom';
 import { createICacheMiddleware } from './icache';
-import { FocusProperties } from '../mixins/Focus';
+import { FocusProperties } from '../interfaces';
+
+export { FocusProperties } from '../interfaces';
 
 interface FocusState {
 	current: number;

--- a/src/core/mixins/Focus.ts
+++ b/src/core/mixins/Focus.ts
@@ -1,11 +1,9 @@
 import { Constructor } from './../interfaces';
 import { WidgetBase } from './../WidgetBase';
 import { diffProperty } from './../decorators/diffProperty';
+import { FocusProperties } from '../interfaces';
 
-export interface FocusProperties {
-	/** Function to determine if the widget should focus */
-	focus?: () => boolean;
-}
+export { FocusProperties } from '../interfaces';
 
 export interface FocusMixin {
 	focus: () => void;


### PR DESCRIPTION
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR (no test changes needed for this)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- move FocusProperties from mixins/Focus to core/interfaces
- export FocusProperties from mixins/Focus
- export FocusProperties from middleware/focus


Resolves #667 
