### PR TITLE
Add docs for validity middleware, validity middleware mock, and focus middleware mock

### DIFF
--- a/docs/en/middleware/supplemental.md
+++ b/docs/en/middleware/supplemental.md
@@ -625,7 +625,7 @@ The `ValidityState` object contains the following properties:
 
 | Property            | Type      | Description                                                                                                                       |
 | ------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `valid`             | `boolean` | The value of the node's `validity.valid` property, stating whether the value of the node meets all of the validation constraings. |
+| `valid`             | `boolean` | The value of the node's `validity.valid` property, stating whether the value of the node meets all of the validation constraints. |
 | `validationMessage` | `string`  | The value of the node's `validationMessage` property, a localized message describing the failing constraints of the node's value. |
 
 ## `injector`

--- a/docs/en/middleware/supplemental.md
+++ b/docs/en/middleware/supplemental.md
@@ -608,6 +608,7 @@ export default factory(function FocusableWidget({ middleware: { focus, icache } 
 	);
 });
 ```
+
 ## `validity`
 
 Allows retrieving information specifically about a node's [validity state](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) which is useful for using the browser's built-in methods for validating form inputs and providing locale-based error messages.
@@ -618,13 +619,12 @@ Allows retrieving information specifically about a node's [validity state](https
 import validity from '@dojo/framework/core/middleware/validity';
 ```
 
-- `validity.get(key: string, value: string)`
-	- Return the validity state for the DOM element, identified by the node's `key` property. Returns `{ valid: undefined, message: '' }` if the specified DOM element does not exist for the current widget. Otherwise, it returns a `ValidityState` object.
+-   `validity.get(key: string, value: string)` - Return the validity state for the DOM element, identified by the node's `key` property. Returns `{ valid: undefined, message: '' }` if the specified DOM element does not exist for the current widget. Otherwise, it returns a `ValidityState` object.
 
 The `ValidityState` object contains the following properties:
 
-| Property            | Type      | Description |
-| ------------------- | --------- | ----------- |
+| Property            | Type      | Description                                                                                                                       |
+| ------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `valid`             | `boolean` | The value of the node's `validity.valid` property, stating whether the value of the node meets all of the validation constraings. |
 | `validationMessage` | `string`  | The value of the node's `validationMessage` property, a localized message describing the failing constraints of the node's value. |
 

--- a/docs/en/middleware/supplemental.md
+++ b/docs/en/middleware/supplemental.md
@@ -608,6 +608,25 @@ export default factory(function FocusableWidget({ middleware: { focus, icache } 
 	);
 });
 ```
+## `validity`
+
+Allows retrieving information specifically about a node's [validity state](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) which is useful for using the browser's built-in methods for validating form inputs and providing locale-based error messages.
+
+**API:**
+
+```ts
+import validity from '@dojo/framework/core/middleware/validity';
+```
+
+- `validity.get(key: string, value: string)`
+	- Return the validity state for the DOM element, identified by the node's `key` property. Returns `{ valid: undefined, message: '' }` if the specified DOM element does not exist for the current widget. Otherwise, it returns a `ValidityState` object.
+
+The `ValidityState` object contains the following properties:
+
+| Property            | Type      | Description |
+| ------------------- | --------- | ----------- |
+| `valid`             | `boolean` | The value of the node's `validity.valid` property, stating whether the value of the node meets all of the validation constraings. |
+| `validationMessage` | `string`  | The value of the node's `validationMessage` property, a localized message describing the failing constraints of the node's value. |
 
 ## `injector`
 

--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -107,16 +107,16 @@ import breakpoint from '@dojo/framework/core/middleware/breakpoint';
 const factory = create({ breakpoint });
 
 export default factory(function Breakpoint({ middleware: { breakpoint } }) {
-  const bp = breakpoint.get('root');
-  const isLarge = bp && bp.breakpoint === 'LG';
+	const bp = breakpoint.get('root');
+	const isLarge = bp && bp.breakpoint === 'LG';
 
-  return (
-    <div key="root">
-      <h1>Header</h1>
-      {isLarge && <h2>Subtitle</h2>}
-      <div>Longer description</div>
-    </div>
-  );
+	return (
+		<div key="root">
+			<h1>Header</h1>
+			{isLarge && <h2>Subtitle</h2>}
+			<div>Longer description</div>
+		</div>
+	);
 });
 ```
 

--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -543,7 +543,7 @@ import createValidityMock from '@dojo/framework/testing/mocks/middleware/validit
 import * as css from './FormWidget.m.css';
 
 describe('Validity', () => {
-	it('adds a "invalid" class to the wrapper when the input is invalid and displays a message', () => {
+	it('adds the "invalid" class to the wrapper when the input is invalid and displays a message', () => {
 		const validityMock = createValidityMock();
 
 		const h = harness(() => <FormWidget />, {

--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -161,7 +161,7 @@ describe('Breakpoint', () => {
 
 #### Mock `focus` middleware
 
-Using `createFocusMock` from `@dojo/framework/testing/middleware/focus` offers tests manual control over when the `focus` middleware reports that a node with a specified key is focused.
+Using `createFocusMock` from `@dojo/framework/testing/middleware/focus` provides tests with manual control over when the `focus` middleware reports that a node with a specified key gets focused.
 
 Consider the following widget:
 

--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -100,7 +100,7 @@ Consider the following widget which displays an additonal `h2` when the `LG` bre
 
 > src/Breakpoint.tsx
 
-```
+```tsx
 import { tsx, create } from '@dojo/framework/core/vdom';
 import breakpoint from '@dojo/framework/core/middleware/breakpoint';
 

--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -185,7 +185,7 @@ export const FormWidget = factory(function FormWidget({ middleware: { focus } })
 });
 ```
 
-By calling `focusMock(key: string | number, value: boolean)` the result of the focus middleware's `isFocused` method can be controlled during a test.
+By calling `focusMock(key: string | number, value: boolean)` the result of the focus middleware's `isFocused` method can get controlled during a test.
 
 > tests/unit/FormWidget.tsx
 

--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -530,7 +530,7 @@ export const FormWidget = factory(function FormWidget({ middleware: { validity, 
 });
 ```
 
-Using `validityMock(key: string, value: { valid?: boolean, message?: string; })`, the results of the validity mock's `get` method can be controlled in a test.
+Using `validityMock(key: string, value: { valid?: boolean, message?: string; })`, the results of the validity mock's `get` method can get controlled in a test.
 
 > tests/unit/FormWidget.tsx
 

--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -503,7 +503,7 @@ describe('MyWidget', () => {
 
 #### Mock `validity` middleware
 
-Using `createValidityMock` from `@dojo/framework/testing/mocks/middleware/validity` creates a mock validity middleware where the return value of the `get` method can be controlled in a test.
+Using `createValidityMock` from `@dojo/framework/testing/mocks/middleware/validity` creates a mock validity middleware where the return value of the `get` method can get controlled in a test.
 
 Consider the following example:
 

--- a/src/core/middleware/validity.ts
+++ b/src/core/middleware/validity.ts
@@ -2,7 +2,7 @@ import { create, node, invalidator } from '../vdom';
 
 const factory = create({ node, invalidator });
 
-const validity = factory(function({ middleware: { node, invalidator } }) {
+export const validity = factory(function({ middleware: { node, invalidator } }) {
 	return {
 		get(key: string | number, value: string) {
 			const domNode = node.get(key) as HTMLFormElement | undefined;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- Add docs for validity middleware
- Add docs for validity middleware mock
- Add docs for focus middleware mock
- Add missing tsx type to breakpoint middleware code fence in docs
- export validity mock as a named export, in addition to the default export

Resolves #638 
Resolves #639 
