### PR TITLE
Data middleware and resource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ env:
 install:
 - travis_retry npm install
 script:
-- npm run lint && npm run test:browserstack && npm run uploadCoverage && npm run benchmark
+- npm run lint && npm run test:browserstack && npm run uploadCoverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ env:
 install:
 - travis_retry npm install
 script:
-- npm run lint && npm run test:browserstack && npm run uploadCoverage
+- npm run lint && npm run test:browserstack && npm run uploadCoverage && npm run benchmark

--- a/package-lock.json
+++ b/package-lock.json
@@ -2590,8 +2590,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2612,14 +2611,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2634,20 +2631,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2764,8 +2758,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2777,7 +2770,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2792,7 +2784,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2800,14 +2791,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2826,7 +2815,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2916,8 +2904,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2929,7 +2916,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3015,8 +3001,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3052,7 +3037,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3072,7 +3056,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3116,14 +3099,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,9 +74,9 @@
       }
     },
     "@theintern/digdug": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.2.5.tgz",
-      "integrity": "sha512-pjRa2gHvlflzkB4+UBWetz4GFvdVi3qkSc/ea6wTywaNMgozKo73coim/RJ3WJX9g7KYYDvm84T1k/DfH0NFdQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.2.4.tgz",
+      "integrity": "sha512-hVsQ9YFFW8F675ITnNsCfrIMTOYf4JdhceHKx8O40r4xZImXPBnTGYHGh6djBV68ULxxv1dWyCI+1xa/dTjWdg==",
       "dev": true,
       "requires": {
         "@theintern/common": "~0.1.3",
@@ -110,9 +110,9 @@
       "dev": true
     },
     "@types/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -2110,9 +2110,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.13.0.tgz",
+      "integrity": "sha512-eYk2dCkxR07DsHA/X2hRBj0CFAZeri/LyDMc0C8JT1Hqi6JnVpMhJ7XFITbb0+yZS3lVkaPL2oCkZ3AVmeVbMw==",
       "dev": true,
       "requires": {
         "esprima": "^4.0.1",
@@ -2583,24 +2583,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2610,13 +2615,17 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2624,34 +2633,43 @@
         },
         "chownr": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "3.2.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2660,25 +2678,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2687,13 +2709,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2709,7 +2733,8 @@
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2723,13 +2748,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2738,7 +2765,8 @@
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2747,7 +2775,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2757,46 +2786,58 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2804,7 +2845,8 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2813,21 +2855,25 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2838,7 +2884,8 @@
         },
         "node-pre-gyp": {
           "version": "0.14.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2856,7 +2903,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2866,7 +2914,8 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2875,13 +2924,15 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2891,7 +2942,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2903,38 +2955,46 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2944,19 +3004,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2968,7 +3031,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -2976,7 +3040,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2991,7 +3056,8 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3000,43 +3066,52 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3045,7 +3120,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3054,21 +3130,25 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3083,13 +3163,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3098,13 +3180,17 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3710,10 +3796,13 @@
       "dev": true
     },
     "is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -4919,9 +5008,9 @@
       },
       "dependencies": {
         "resolve": {
-          "version": "1.15.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+          "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -6014,9 +6103,9 @@
       }
     },
     "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -6026,7 +6115,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -6036,7 +6125,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       }
@@ -6861,13 +6950,21 @@
       }
     },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
       }
     },
     "tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2590,7 +2590,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2611,12 +2612,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2631,17 +2634,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2758,7 +2764,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2770,6 +2777,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2784,6 +2792,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2791,12 +2800,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2815,6 +2826,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2904,7 +2916,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2916,6 +2929,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3001,7 +3015,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3037,6 +3052,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3056,6 +3072,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3099,12 +3116,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -712,5 +712,7 @@ export interface ResourceOptions {
 export interface Resource {
 	getOrRead(options: ResourceOptions, invalidator: Invalidator): any;
 	getTotal(options: ResourceOptions, invalidator: Invalidator): number | undefined;
+	isLoading(options: ResourceOptions): boolean;
+	isFailed(options: ResourceOptions): boolean;
 	disconnect(invalidator: Invalidator): void;
 }

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -703,6 +703,8 @@ export type LocalizedMessages<T extends Messages> = {
 
 export type Invalidator = () => void;
 
+export type SubscriptionType = 'data' | 'total' | 'loading' | 'failed';
+
 export interface ResourceOptions {
 	pageNumber?: number;
 	query?: string;
@@ -710,9 +712,10 @@ export interface ResourceOptions {
 }
 
 export interface Resource {
-	getOrRead(options: ResourceOptions, invalidator: Invalidator): any;
-	getTotal(options: ResourceOptions, invalidator: Invalidator): number | undefined;
+	getOrRead(options: ResourceOptions): any;
+	getTotal(options: ResourceOptions): number | undefined;
 	isLoading(options: ResourceOptions): boolean;
 	isFailed(options: ResourceOptions): boolean;
-	disconnect(invalidator: Invalidator): void;
+	subscribe(type: SubscriptionType, options: ResourceOptions, invalidator: Invalidator): void;
+	unsubscribe(invalidator: Invalidator): void;
 }

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -702,20 +702,3 @@ export type LocalizedMessages<T extends Messages> = {
 };
 
 export type Invalidator = () => void;
-
-export type SubscriptionType = 'data' | 'total' | 'loading' | 'failed';
-
-export interface ResourceOptions {
-	pageNumber?: number;
-	query?: string;
-	pageSize?: number;
-}
-
-export interface Resource {
-	getOrRead(options: ResourceOptions): any;
-	getTotal(options: ResourceOptions): number | undefined;
-	isLoading(options: ResourceOptions): boolean;
-	isFailed(options: ResourceOptions): boolean;
-	subscribe(type: SubscriptionType, options: ResourceOptions, invalidator: Invalidator): void;
-	unsubscribe(invalidator: Invalidator): void;
-}

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -700,3 +700,17 @@ export type LocalizedMessages<T extends Messages> = {
 	 */
 	readonly messages: T;
 };
+
+export type Invalidator = () => void;
+
+export interface ResourceOptions {
+	pageNumber?: number;
+	query?: string;
+	pageSize?: number;
+}
+
+export interface Resource {
+	getOrRead(options: ResourceOptions, invalidator: Invalidator): any;
+	getTotal(options: ResourceOptions, invalidator: Invalidator): number | undefined;
+	disconnect(invalidator: Invalidator): void;
+}

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -160,6 +160,7 @@ export function createDataMiddleware<T = void>() {
 					nextResource.data.length !== currentResource.data.length
 				) {
 					resourceWithDataMap.delete(nextResource.data);
+					invalidator();
 				}
 			}
 		});

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -89,14 +89,12 @@ export function createDataMiddleware<T = void>() {
 			let resourceWrapperOrResource = dataOptions.resource || properties().resource;
 			let resourceWrapper: ResourceWrapper;
 
-			// Get or create the resource wrapper
 			if (isResource(resourceWrapperOrResource)) {
 				resourceWrapper = createResourceWrapper(resourceWrapperOrResource);
 			} else {
 				resourceWrapper = resourceWrapperOrResource as ResourceWrapper;
 			}
 
-			// Create a new wrapper if reset is set to true
 			if (dataOptions.reset) {
 				resourceWrapper = createResourceWrapper(resourceWrapper.resource);
 			}
@@ -104,7 +102,6 @@ export function createDataMiddleware<T = void>() {
 			const { resource } = resourceWrapper;
 			const { key = '' } = dataOptions;
 
-			// Get or create an options wrapper
 			let keyedCachedOptions = optionsWrapperMap.get(resource);
 			if (!keyedCachedOptions) {
 				keyedCachedOptions = new Map<string, OptionsWrapper>();

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -1,5 +1,5 @@
 import { create, invalidator, destroy } from '../vdom';
-import { ResourceOptions, Invalidator, Resource } from '../interfaces';
+import { Resource, ResourceOptions, Invalidator } from '../interfaces';
 
 interface OptionsWrapper {
 	getOptions(invalidator: Invalidator): ResourceOptions;
@@ -81,7 +81,7 @@ export function createDataMiddleware<T = void>() {
 
 		destroy(() => {
 			[...optionsWrapperMap.keys()].forEach((resource) => {
-				resource.disconnect(invalidator);
+				resource.unsubscribe(invalidator);
 			});
 		});
 
@@ -123,8 +123,9 @@ export function createDataMiddleware<T = void>() {
 			}
 
 			return {
-				getOrRead(options: ResourceOptions) {
-					const data = resource.getOrRead(options, invalidator);
+				getOrRead(options: ResourceOptions): T extends void ? any : T[] | undefined {
+					resource.subscribe('data', options, invalidator);
+					const data = resource.getOrRead(options);
 					const props = properties();
 
 					if (data && data.length && isDataTransformProperties(props)) {
@@ -134,12 +135,15 @@ export function createDataMiddleware<T = void>() {
 					return data;
 				},
 				getTotal(options: ResourceOptions) {
-					return resource.getTotal(options, invalidator);
+					resource.subscribe('total', options, invalidator);
+					return resource.getTotal(options);
 				},
 				isLoading(options: ResourceOptions) {
+					resource.subscribe('loading', options, invalidator);
 					return resource.isLoading(options);
 				},
 				isFailed(options: ResourceOptions) {
+					resource.subscribe('failed', options, invalidator);
 					return resource.isFailed(options);
 				},
 				setOptions(newOptions: ResourceOptions) {

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -9,8 +9,8 @@ export interface ResourceOptions {
 }
 
 export interface Resource {
-	getOrRead: (options: ResourceOptions, invalidator: Invalidator) => any;
-	getTotal: (options: ResourceOptions, invalidator: Invalidator) => number | undefined;
+	getOrRead(options: ResourceOptions, invalidator: Invalidator): any;
+	getTotal(options: ResourceOptions, invalidator: Invalidator): number | undefined;
 }
 
 interface OptionsWrapper {

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -1,18 +1,5 @@
 import { create, invalidator, destroy } from '../vdom';
-
-type Invalidator = () => void;
-
-export interface ResourceOptions {
-	pageNumber?: number;
-	query?: string;
-	pageSize?: number;
-}
-
-export interface Resource {
-	getOrRead(options: ResourceOptions, invalidator: Invalidator): any;
-	getTotal(options: ResourceOptions, invalidator: Invalidator): number | undefined;
-	disconnect(invalidator: Invalidator): void;
-}
+import { ResourceOptions, Invalidator, Resource } from '../interfaces';
 
 interface OptionsWrapper {
 	getOptions(invalidator: Invalidator): ResourceOptions;

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -136,6 +136,12 @@ export function createDataMiddleware<T = void>() {
 				getTotal(options: ResourceOptions) {
 					return resource.getTotal(options, invalidator);
 				},
+				isLoading(options: ResourceOptions) {
+					return resource.isLoading(options);
+				},
+				isFailed(options: ResourceOptions) {
+					return resource.isFailed(options);
+				},
 				setOptions(newOptions: ResourceOptions) {
 					optionsWrapper.setOptions(newOptions, invalidator);
 				},

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -10,6 +10,7 @@ export interface ResourceOptions {
 
 export interface Resource {
 	getOrRead: (options: ResourceOptions, invalidator: Invalidator) => any;
+	getTotal: (options: ResourceOptions, invalidator: Invalidator) => number | undefined;
 }
 
 interface OptionsWrapper {
@@ -22,22 +23,24 @@ export interface ResourceWrapper {
 	createOptionsWrapper(): OptionsWrapper;
 }
 
+export type ResourceOrResourceWrapper = Resource | ResourceWrapper;
+
 interface DataProperties {
-	resource: Resource | ResourceWrapper;
+	resource: ResourceOrResourceWrapper;
 }
 
 interface DataTransformProperties<T = void> {
 	transform(item: any): T;
-	resource: Resource | ResourceWrapper;
+	resource: ResourceOrResourceWrapper;
 }
 
 interface DataInitialiserOptions {
 	reset?: boolean;
-	resource?: Resource | ResourceWrapper;
+	resource?: ResourceOrResourceWrapper;
 	key?: string;
 }
 
-function isResource(resourceWrapperOrResource: ResourceWrapper | Resource): resourceWrapperOrResource is Resource {
+function isResource(resourceWrapperOrResource: ResourceOrResourceWrapper): resourceWrapperOrResource is Resource {
 	return !(resourceWrapperOrResource as any).resource;
 }
 
@@ -133,6 +136,9 @@ export function createDataMiddleware<T = void>() {
 					}
 
 					return data;
+				},
+				getTotal(options: ResourceOptions) {
+					return resource.getTotal(options, invalidator);
 				},
 				setOptions(newOptions: ResourceOptions) {
 					optionsWrapper.setOptions(newOptions, invalidator);

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -1,0 +1,155 @@
+import { create, invalidator } from '../vdom';
+
+export interface ResourceOptions {
+	pageNumber: number;
+	query: string;
+	pageSize: number;
+}
+
+interface Resource {
+	getOrRead: (options: ResourceOptions) => any;
+	registerInvalidator: (invalidator: any) => void;
+}
+
+interface ResourceWrapper {
+	resource: Resource;
+	createOptions: any;
+}
+
+interface DataProperties<T = void> {
+	resource: Resource | ResourceWrapper;
+	transform: (item: any) => T;
+}
+
+interface Basic {
+	resource: Resource | ResourceWrapper;
+}
+
+interface DataOptions {
+	reset?: boolean;
+	resource?: Resource | ResourceWrapper;
+	key?: string;
+}
+
+function isResource(resourceWrapperOrResource: ResourceWrapper | Resource): resourceWrapperOrResource is Resource {
+	return !(resourceWrapperOrResource as any).resource;
+}
+
+function isDataProperties<T>(value: any): value is DataProperties<T> {
+	return !!value.transform;
+}
+
+function createOptions() {
+	let options: ResourceOptions = {
+		pageNumber: 1,
+		pageSize: 5,
+		query: ''
+	};
+
+	let invalidators = new Set();
+
+	function setOptions(newOptions: ResourceOptions) {
+		if (newOptions !== options) {
+			options = newOptions;
+			invalidate();
+		}
+	}
+
+	function invalidate() {
+		[...invalidators].forEach((invalidator: any) => {
+			invalidator();
+		});
+	}
+
+	function getOptions() {
+		return options;
+	}
+
+	return {
+		setOptions,
+		getOptions,
+		registerInvalidator: (invalidator: () => void) => {
+			invalidators.add(invalidator);
+		}
+	};
+}
+
+function createResourceWrapper(resource: Resource, options?: any): ResourceWrapper {
+	return {
+		resource,
+		createOptions: options ? () => options : createOptions
+	};
+}
+
+export function createDataMiddleware<T = void>() {
+	const factory = create({ invalidator }).properties<T extends void ? Basic : DataProperties<T>>();
+
+	const data = factory(({ middleware: { invalidator }, properties }) => {
+		const optionsMap = new WeakMap<Resource, Map<string, Resource>>();
+
+		return (dataOptions: DataOptions = {}) => {
+			let resourceWrapperOrResource = dataOptions.resource || properties().resource;
+			let resourceWrapper: ResourceWrapper;
+			if (isResource(resourceWrapperOrResource)) {
+				resourceWrapper = createResourceWrapper(resourceWrapperOrResource);
+			} else {
+				resourceWrapper = resourceWrapperOrResource;
+			}
+			if (dataOptions.reset) {
+				resourceWrapper = createResourceWrapper(resourceWrapper.resource);
+			}
+			let options: any;
+			const { resource } = resourceWrapper;
+			const { key = '' } = dataOptions;
+
+			let keyedCachedOptions = optionsMap.get(resource);
+			if (!keyedCachedOptions) {
+				keyedCachedOptions = new Map<string, Resource>();
+			}
+
+			let cachedOptions = keyedCachedOptions.get(key);
+
+			if (!cachedOptions) {
+				const newOptions = resourceWrapper.createOptions();
+				keyedCachedOptions.set(key, newOptions);
+				optionsMap.set(resource, keyedCachedOptions);
+				options = newOptions;
+			} else {
+				options = cachedOptions;
+			}
+
+			return {
+				getOrRead(options: ResourceOptions) {
+					resource.registerInvalidator(invalidator);
+					const data = resource.getOrRead(options);
+					const props = properties();
+
+					if (data && data.length && isDataProperties(props)) {
+						return data.map(props.transform);
+					}
+
+					return data;
+				},
+				setOptions(newOptions: ResourceOptions) {
+					options.registerInvalidator(invalidator);
+					options.setOptions(newOptions);
+				},
+				getOptions() {
+					options.registerInvalidator(invalidator);
+					return options.getOptions();
+				},
+				get resource() {
+					return resourceWrapper;
+				},
+				shared() {
+					return createResourceWrapper(resource, options);
+				}
+			};
+		};
+	});
+	return data;
+}
+
+export const data = createDataMiddleware();
+
+export default data;

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -1,0 +1,296 @@
+import { Invalidator } from './interfaces';
+
+export type SubscriptionType = 'data' | 'total' | 'loading' | 'failed';
+
+export interface ResourceOptions {
+	pageNumber?: number;
+	query?: ResourceQuery[];
+	pageSize?: number;
+}
+
+export type ResourceQuery = { keys: string[]; value: string | undefined };
+
+export interface Resource {
+	getOrRead(options: ResourceOptions): any;
+	get(options: ResourceOptions): any;
+	getTotal(options: ResourceOptions): number | undefined;
+	isLoading(options: ResourceOptions): boolean;
+	isFailed(options: ResourceOptions): boolean;
+	subscribe(type: SubscriptionType, options: ResourceOptions, invalidator: Invalidator): void;
+	unsubscribe(invalidator: Invalidator): void;
+	set(data: any[]): void;
+}
+
+export type TransformConfig<T, S = void> = { [P in keyof T]: (S extends void ? string : keyof S)[] };
+
+export interface ReadOptions {
+	offset?: number;
+	size?: number;
+	query?: ResourceQuery[];
+}
+
+type Putter<S> = (start: number, data: S[]) => void;
+type Getter<S> = (query?: ResourceQuery[]) => S[];
+
+export type DataResponse<S> = { data: S[]; total: number };
+export type DataResponsePromise<S> = Promise<{ data: S[]; total: number }>;
+export type DataFetcher<S> = (
+	options: ReadOptions,
+	put: Putter<S>,
+	get: Getter<S>
+) => DataResponse<S> | DataResponsePromise<S>;
+
+export interface DataTemplate<S = {}> {
+	read: DataFetcher<S>;
+	set?: any;
+}
+
+type Status = 'LOADING' | 'FAILED';
+type InvalidatorMaps = { [key in SubscriptionType]: Map<string, Set<Invalidator>> };
+
+export function createTransformer<S, T>(template: DataTemplate<S>, transformer: TransformConfig<T, S>) {
+	return transformer;
+}
+
+function isAsyncResponse<S>(response: DataResponsePromise<S> | DataResponse<S>): response is DataResponsePromise<S> {
+	return (response as any).then !== undefined;
+}
+
+export function createResource<S>(config: DataTemplate<S>): Resource {
+	const { read } = config;
+	let queryMap = new Map<string, S[]>();
+	let statusMap = new Map<string, { [key: string]: Status }>();
+	let totalMap = new Map<string, number>();
+
+	const invalidatorMaps: InvalidatorMaps = {
+		data: new Map<string, Set<Invalidator>>(),
+		total: new Map<string, Set<Invalidator>>(),
+		loading: new Map<string, Set<Invalidator>>(),
+		failed: new Map<string, Set<Invalidator>>()
+	};
+
+	function invalidate(key: string, types: SubscriptionType[]) {
+		types.forEach((type) => {
+			const keyedInvalidatorMap = invalidatorMaps[type];
+			const invalidatorSet = keyedInvalidatorMap.get(key);
+			if (invalidatorSet) {
+				[...invalidatorSet].forEach((invalidator: any) => {
+					invalidator();
+				});
+			}
+		});
+	}
+
+	function getPageKey({ pageNumber, pageSize }: ResourceOptions): string {
+		return `page-${pageNumber}-pageSize-${pageSize}`;
+	}
+
+	function getQueryKey(query = {}): string {
+		return JSON.stringify(query, Object.keys(query).sort());
+	}
+
+	function subscribe(type: SubscriptionType, options: ResourceOptions, invalidator: Invalidator) {
+		const key = getPageKey(options);
+		const keyedInvalidatorMap = invalidatorMaps[type];
+		const invalidatorSet = keyedInvalidatorMap.get(key) || new Set<Invalidator>();
+		invalidatorSet.add(invalidator);
+		keyedInvalidatorMap.set(key, invalidatorSet);
+	}
+
+	function unsubscribe(invalidator: Invalidator) {
+		Object.keys(invalidatorMaps).forEach((type) => {
+			const keyedInvalidatorMap = invalidatorMaps[type as SubscriptionType];
+
+			const keys = keyedInvalidatorMap.keys();
+			[...keys].forEach((key) => {
+				const invalidatorSet = keyedInvalidatorMap.get(key);
+				if (invalidatorSet && invalidatorSet.has(invalidator)) {
+					invalidatorSet.delete(invalidator);
+					keyedInvalidatorMap.set(key, invalidatorSet);
+				}
+			});
+		});
+	}
+
+	function isStatus(status: Status, options: ResourceOptions) {
+		const queryKey = getQueryKey(options.query);
+		const pageKey = getPageKey(options);
+		const pageStatuses = statusMap.get(queryKey);
+		if (pageStatuses) {
+			return pageStatuses[pageKey] === status;
+		}
+		return false;
+	}
+
+	function setStatus(status: Status, options: ResourceOptions) {
+		const queryKey = getQueryKey(options.query);
+		const pageKey = getPageKey(options);
+		const pageStatuses = statusMap.get(queryKey) || {};
+		pageStatuses[pageKey] = status;
+		statusMap.set(queryKey, pageStatuses);
+	}
+
+	function clearStatus(options: ResourceOptions) {
+		const queryKey = getQueryKey(options.query);
+		const pageKey = getPageKey(options);
+		const pageStatuses = statusMap.get(queryKey);
+		if (pageStatuses && pageStatuses[pageKey]) {
+			delete pageStatuses[pageKey];
+			statusMap.set(queryKey, pageStatuses);
+		}
+	}
+
+	function isLoading(options: ResourceOptions) {
+		return isStatus('LOADING', options);
+	}
+
+	function isFailed(options: ResourceOptions) {
+		return isStatus('FAILED', options);
+	}
+
+	function getTotal(options: ResourceOptions) {
+		const queryKey = getQueryKey(options.query);
+		return totalMap.get(queryKey);
+	}
+
+	function get(options: ResourceOptions): S[] {
+		const { pageNumber, pageSize } = options;
+		const queryKey = getQueryKey(options.query);
+		const cachedQueryData = queryMap.get(queryKey);
+
+		if (!cachedQueryData) {
+			return [];
+		}
+
+		if (pageSize && pageNumber) {
+			const start = (pageNumber - 1) * pageSize;
+			const end = start + pageSize;
+			const total = totalMap.get(queryKey) || end;
+			const calculatedEnd = Math.min(end, total);
+			const requiredData = cachedQueryData.slice(start, calculatedEnd);
+			if (requiredData.filter(() => true).length === calculatedEnd - start) {
+				return requiredData;
+			} else {
+				return [];
+			}
+		} else {
+			return cachedQueryData;
+		}
+	}
+
+	function setData(start: number, data: S[], size: number, query = {}) {
+		console.log(`set data called with start: ${start}, size: ${size}, query: ${query}`);
+		const queryKey = getQueryKey(query);
+		const cachedQueryData = queryMap.get(queryKey);
+		const newQueryData = cachedQueryData && cachedQueryData.length ? cachedQueryData : [];
+
+		for (let i = 0; i < size; i += 1) {
+			newQueryData[start + i] = data[i];
+		}
+
+		queryMap.set(queryKey, newQueryData);
+	}
+
+	function getOrRead(options: ResourceOptions): S[] | undefined {
+		const { pageNumber, query, pageSize } = options;
+		const pageKey = getPageKey(options);
+		const queryKey = getQueryKey(options.query);
+
+		if (isLoading(options) || isFailed(options)) {
+			return undefined;
+		}
+
+		const cachedQueryData = queryMap.get(queryKey);
+
+		if (
+			cachedQueryData &&
+			(!pageSize || !pageNumber) &&
+			cachedQueryData.filter(() => true).length === totalMap.get(queryKey)
+		) {
+			return cachedQueryData;
+		}
+
+		if (pageSize && pageNumber && cachedQueryData && cachedQueryData.length) {
+			const start = (pageNumber - 1) * pageSize;
+			const end = start + pageSize;
+			const total = totalMap.get(queryKey) || end;
+			const calculatedEnd = Math.min(end, total);
+			const requiredData = cachedQueryData.slice(start, calculatedEnd);
+			if (requiredData.length && requiredData.filter(() => true).length === calculatedEnd - start) {
+				return requiredData;
+			}
+		}
+
+		const readOptions: ReadOptions = {};
+
+		if (pageNumber !== undefined && pageSize !== undefined) {
+			readOptions.offset = (pageNumber - 1) * pageSize;
+			readOptions.size = pageSize;
+		}
+
+		if (query) {
+			readOptions.query = query;
+		}
+
+		const response = read(
+			readOptions,
+			(start = 0, data: S[]) => {
+				setData(start, data, data.length, query);
+			},
+			(query) => {
+				return get({ query });
+			}
+		);
+
+		if (isAsyncResponse(response)) {
+			setStatus('LOADING', options);
+			invalidate(pageKey, ['loading']);
+
+			response
+				.then(({ data, total }) => {
+					const start = readOptions.offset || 0;
+					const size = Math.min(data.length, readOptions.size || data.length);
+					setData(start, data, size, query);
+
+					clearStatus(options);
+
+					invalidate(pageKey, ['loading', 'data']);
+					if (total !== totalMap.get(queryKey)) {
+						totalMap.set(queryKey, total);
+						invalidate(pageKey, ['total']);
+					}
+				})
+				.catch(() => {
+					setStatus('FAILED', options);
+					invalidate(pageKey, ['failed', 'loading']);
+				});
+
+			return undefined;
+		} else {
+			const { data, total } = response;
+			const start = readOptions.offset || 0;
+			const size = Math.min(data.length, readOptions.size || data.length);
+			setData(start, data, size, query);
+			invalidate(pageKey, ['data']);
+
+			if (total !== totalMap.get(queryKey)) {
+				totalMap.set(queryKey, total);
+				invalidate(pageKey, ['total']);
+			}
+			return data;
+		}
+	}
+
+	return {
+		getOrRead,
+		get,
+		getTotal,
+		subscribe,
+		unsubscribe,
+		isFailed,
+		isLoading,
+		set(data: S[]) {
+			setData(0, data, data.length);
+		}
+	};
+}

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -126,7 +126,6 @@ export function createResource<S>(config: DataTemplate<S>): Resource {
 	function setStatus(status: Status, options: ResourceOptions) {
 		const queryKey = getQueryKey(options.query);
 		const pageKey = getPageKey(options);
-		console.log(`setting status: ${status}, query: ${queryKey}, page: ${pageKey}`);
 		const pageStatuses = statusMap.get(queryKey) || {};
 		pageStatuses[pageKey] = status;
 		statusMap.set(queryKey, pageStatuses);
@@ -135,7 +134,6 @@ export function createResource<S>(config: DataTemplate<S>): Resource {
 	function clearStatus(options: ResourceOptions) {
 		const queryKey = getQueryKey(options.query);
 		const pageKey = getPageKey(options);
-		console.log(`clearing status, query: ${queryKey}, page: ${pageKey}`);
 		const pageStatuses = statusMap.get(queryKey);
 		if (pageStatuses && pageStatuses[pageKey]) {
 			delete pageStatuses[pageKey];

--- a/tests/core/unit/all.ts
+++ b/tests/core/unit/all.ts
@@ -14,6 +14,7 @@ import './tsx';
 import './tsxIntegration';
 import './NodeHandler';
 import './meta/all';
+import './resource';
 import './vdom';
 import './registerCustomElement';
 import './middleware/all';

--- a/tests/core/unit/middleware/all.ts
+++ b/tests/core/unit/middleware/all.ts
@@ -1,6 +1,7 @@
 import './block';
 import './breakpoint';
 import './cache';
+import './data';
 import './dimensions';
 import './i18n';
 import './focus';

--- a/tests/core/unit/middleware/data.tsx
+++ b/tests/core/unit/middleware/data.tsx
@@ -12,7 +12,8 @@ const sb = sandbox.create();
 const invalidatorStub = sb.stub();
 
 let resourceStub = {
-	getOrRead: sb.stub()
+	getOrRead: sb.stub(),
+	getTotal: sb.stub()
 };
 
 jsdomDescribe('data middleware', () => {

--- a/tests/core/unit/middleware/data.tsx
+++ b/tests/core/unit/middleware/data.tsx
@@ -12,8 +12,7 @@ const sb = sandbox.create();
 const invalidatorStub = sb.stub();
 
 let resourceStub = {
-	getOrRead: sb.stub(),
-	registerInvalidator: sb.stub()
+	getOrRead: sb.stub()
 };
 
 jsdomDescribe('data middleware', () => {
@@ -42,27 +41,6 @@ jsdomDescribe('data middleware', () => {
 		const { getOrRead, getOptions } = data();
 		const result = getOrRead(getOptions());
 		assert.equal(result, 'test');
-		assert.isTrue(resourceStub.registerInvalidator.called);
-	});
-
-	it('should return options with default values', () => {
-		const { callback } = dataMiddleware();
-		const data = callback({
-			id: 'test',
-			middleware: {
-				invalidator: invalidatorStub
-			},
-			properties: () => ({
-				resource: resourceStub
-			}),
-			children: () => []
-		});
-
-		const { getOptions } = data();
-		const options = getOptions();
-		assert.equal(options.pageNumber, 1);
-		assert.equal(options.pageSize, 10);
-		assert.equal(options.query, '');
 	});
 
 	it('should invalidate when new options are set', () => {
@@ -153,12 +131,17 @@ jsdomDescribe('data middleware', () => {
 			setOptions({
 				pageNumber: 99,
 				pageSize: 99,
-				query: 'test'
+				query: 'testA'
 			});
 			return <div>{JSON.stringify(getOptions())}</div>;
 		});
 		const WidgetB = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-			const { getOptions } = dataMiddleware({ reset: true });
+			const { getOptions, setOptions } = dataMiddleware({ reset: true });
+			setOptions({
+				pageNumber: 10,
+				pageSize: 10,
+				query: 'testB'
+			});
 			return <div>{JSON.stringify(getOptions())}</div>;
 		});
 		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
@@ -179,11 +162,11 @@ jsdomDescribe('data middleware', () => {
 			`<div>${JSON.stringify({
 				pageNumber: 99,
 				pageSize: 99,
-				query: 'test'
+				query: 'testA'
 			})}</div><div>${JSON.stringify({
-				pageNumber: 1,
+				pageNumber: 10,
 				pageSize: 10,
-				query: ''
+				query: 'testB'
 			})}</div>`
 		);
 	});

--- a/tests/core/unit/middleware/data.tsx
+++ b/tests/core/unit/middleware/data.tsx
@@ -16,7 +16,9 @@ const destroyStub = sb.stub();
 let resourceStub = {
 	getOrRead: sb.stub(),
 	getTotal: sb.stub(),
-	disconnect: sb.stub()
+	disconnect: sb.stub(),
+	isLoading: sb.stub(),
+	isFailed: sb.stub()
 };
 
 jsdomDescribe('data middleware', () => {
@@ -181,7 +183,9 @@ jsdomDescribe('data middleware', () => {
 		const otherResource = {
 			getOrRead: sb.stub(),
 			getTotal: sb.stub(),
-			disconnect: sb.stub()
+			disconnect: sb.stub(),
+			isLoading: sb.stub(),
+			isFailed: sb.stub()
 		};
 		otherResource.getOrRead.returns(['apple', 'pear']);
 		const Widget = create({ dataMiddleware }).properties<{ otherResource: Resource }>()(function Widget({
@@ -265,5 +269,41 @@ jsdomDescribe('data middleware', () => {
 		invalidate();
 		resolvers.resolveRAF();
 		assert.isTrue(resourceStub.disconnect.called);
+	});
+
+	it('returns loading status of resource', () => {
+		resourceStub.isLoading.returns(true);
+		const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+			const { isLoading, getOptions } = dataMiddleware();
+			const loading = isLoading(getOptions());
+			return <div>{`${loading}`}</div>;
+		});
+		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+			const { resource } = dataMiddleware();
+			return <Widget resource={resource} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App resource={resourceStub} />);
+		r.mount({ domNode: root });
+
+		assert.strictEqual(root.innerHTML, `<div>true</div>`);
+	});
+
+	it('returns failed status of resource', () => {
+		resourceStub.isFailed.returns(true);
+		const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+			const { isFailed, getOptions } = dataMiddleware();
+			const failed = isFailed(getOptions());
+			return <div>{`${failed}`}</div>;
+		});
+		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+			const { resource } = dataMiddleware();
+			return <Widget resource={resource} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App resource={resourceStub} />);
+		r.mount({ domNode: root });
+
+		assert.strictEqual(root.innerHTML, `<div>true</div>`);
 	});
 });

--- a/tests/core/unit/middleware/data.tsx
+++ b/tests/core/unit/middleware/data.tsx
@@ -175,7 +175,7 @@ jsdomDescribe('data middleware', () => {
 	it('can have a resource passed via a different property', () => {
 		const otherResource = {
 			getOrRead: sb.stub(),
-			registerInvalidator: sb.stub()
+			getTotal: sb.stub()
 		};
 		otherResource.getOrRead.returns(['apple', 'pear']);
 		const Widget = create({ dataMiddleware }).properties<{ otherResource: Resource }>()(function Widget({

--- a/tests/core/unit/middleware/data.tsx
+++ b/tests/core/unit/middleware/data.tsx
@@ -1,0 +1,254 @@
+const { it, afterEach, beforeEach } = intern.getInterface('bdd');
+const { describe: jsdomDescribe } = intern.getPlugin('jsdom');
+const { assert } = intern.getPlugin('chai');
+import { sandbox } from 'sinon';
+import { renderer, tsx, create } from '../../../../src/core/vdom';
+import dataMiddleware, { createDataMiddleware, Resource, ResourceWrapper } from '../../../../src/core/middleware/data';
+import { createResolvers } from '../../support/util';
+
+const resolvers = createResolvers();
+
+const sb = sandbox.create();
+const invalidatorStub = sb.stub();
+
+let resourceStub = {
+	getOrRead: sb.stub(),
+	registerInvalidator: sb.stub()
+};
+
+jsdomDescribe('data middleware', () => {
+	beforeEach(() => {
+		resolvers.stub();
+	});
+	afterEach(() => {
+		resolvers.restore();
+		sb.resetHistory();
+	});
+
+	it('should return default API with options', () => {
+		const { callback } = dataMiddleware();
+		const data = callback({
+			id: 'test',
+			middleware: {
+				invalidator: invalidatorStub
+			},
+			properties: () => ({
+				resource: resourceStub
+			}),
+			children: () => []
+		});
+
+		resourceStub.getOrRead.returns('test');
+		const { getOrRead, getOptions } = data();
+		const result = getOrRead(getOptions());
+		assert.equal(result, 'test');
+		assert.isTrue(resourceStub.registerInvalidator.called);
+	});
+
+	it('should return options with default values', () => {
+		const { callback } = dataMiddleware();
+		const data = callback({
+			id: 'test',
+			middleware: {
+				invalidator: invalidatorStub
+			},
+			properties: () => ({
+				resource: resourceStub
+			}),
+			children: () => []
+		});
+
+		const { getOptions } = data();
+		const options = getOptions();
+		assert.equal(options.pageNumber, 1);
+		assert.equal(options.pageSize, 10);
+		assert.equal(options.query, '');
+	});
+
+	it('should invalidate when new options are set', () => {
+		const { callback } = dataMiddleware();
+		const data = callback({
+			id: 'test',
+			middleware: {
+				invalidator: invalidatorStub
+			},
+			properties: () => ({
+				resource: resourceStub
+			}),
+			children: () => []
+		});
+
+		let { setOptions, getOptions } = data();
+		setOptions({
+			pageNumber: 2,
+			pageSize: 15,
+			query: 'test'
+		});
+		assert.isTrue(invalidatorStub.calledOnce);
+		const options = getOptions();
+		assert.equal(options.pageNumber, 2);
+		assert.equal(options.pageSize, 15);
+		assert.equal(options.query, 'test');
+	});
+
+	it('should use a transform function when using createDataMiddleware', () => {
+		resourceStub.getOrRead.returns(['foo', 'bar']);
+		const factory = create({ data: createDataMiddleware<{ value: string }>() });
+		const App = factory(function App({ middleware: { data } }) {
+			const { getOrRead, getOptions } = data();
+			return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App resource={resourceStub} transform={(item: any) => ({ value: item })} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ value: 'foo' }, { value: 'bar' }])}</div>`);
+	});
+
+	it('can create shared resources that share options', () => {
+		resourceStub.getOrRead.returns(['foo', 'bar']);
+		const WidgetA = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+			const { getOptions, setOptions } = dataMiddleware();
+			setOptions({
+				pageNumber: 99,
+				pageSize: 99,
+				query: 'test'
+			});
+			return <div>{JSON.stringify(getOptions())}</div>;
+		});
+		const WidgetB = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+			const { getOptions } = dataMiddleware();
+			return <div>{JSON.stringify(getOptions())}</div>;
+		});
+		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+			const { shared } = dataMiddleware();
+			const sharedResource = shared();
+			return (
+				<virtual>
+					<WidgetA resource={sharedResource} />
+					<WidgetB resource={sharedResource} />
+				</virtual>
+			);
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App resource={resourceStub} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(
+			root.innerHTML,
+			`<div>${JSON.stringify({
+				pageNumber: 99,
+				pageSize: 99,
+				query: 'test'
+			})}</div><div>${JSON.stringify({
+				pageNumber: 99,
+				pageSize: 99,
+				query: 'test'
+			})}</div>`
+		);
+	});
+
+	it('can reset a shared resource to obtain its own options', () => {
+		resourceStub.getOrRead.returns(['foo', 'bar']);
+		const WidgetA = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+			const { getOptions, setOptions } = dataMiddleware({ reset: true });
+			setOptions({
+				pageNumber: 99,
+				pageSize: 99,
+				query: 'test'
+			});
+			return <div>{JSON.stringify(getOptions())}</div>;
+		});
+		const WidgetB = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+			const { getOptions } = dataMiddleware({ reset: true });
+			return <div>{JSON.stringify(getOptions())}</div>;
+		});
+		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+			const { shared } = dataMiddleware();
+			const sharedResource = shared();
+			return (
+				<virtual>
+					<WidgetA resource={sharedResource} />
+					<WidgetB resource={sharedResource} />
+				</virtual>
+			);
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App resource={resourceStub} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(
+			root.innerHTML,
+			`<div>${JSON.stringify({
+				pageNumber: 99,
+				pageSize: 99,
+				query: 'test'
+			})}</div><div>${JSON.stringify({
+				pageNumber: 1,
+				pageSize: 10,
+				query: ''
+			})}</div>`
+		);
+	});
+
+	it('can have a resource passed via a different property', () => {
+		const otherResource = {
+			getOrRead: sb.stub(),
+			registerInvalidator: sb.stub()
+		};
+		otherResource.getOrRead.returns(['apple', 'pear']);
+		const Widget = create({ dataMiddleware }).properties<{ otherResource: Resource }>()(function Widget({
+			properties,
+			middleware: { dataMiddleware }
+		}) {
+			const { getOrRead, getOptions } = dataMiddleware({ resource: properties().otherResource });
+			return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
+		});
+		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+			const { resource } = dataMiddleware();
+
+			return <Widget resource={resource} otherResource={otherResource} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App resource={resourceStub} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify(['apple', 'pear'])}</div>`);
+	});
+
+	it('can use key property to differentiate between options on same resource', () => {
+		resourceStub.getOrRead.returns(['foo', 'bar']);
+		const Widget = create({ dataMiddleware }).properties<{ otherResource: Resource | ResourceWrapper }>()(
+			function Widget({ properties, middleware: { dataMiddleware } }) {
+				const { setOptions } = dataMiddleware();
+				const { setOptions: setOptions2, getOptions: getOptions2 } = dataMiddleware({
+					key: 'two',
+					resource: properties().otherResource
+				});
+				setOptions2({
+					pageSize: 2,
+					pageNumber: 2,
+					query: 'two-query'
+				});
+				setOptions({
+					pageSize: 1,
+					pageNumber: 1,
+					query: 'one-query'
+				});
+				return <div>{JSON.stringify(getOptions2())}</div>;
+			}
+		);
+		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+			const { resource } = dataMiddleware();
+
+			return <Widget resource={resource} otherResource={resource} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App resource={resourceStub} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(
+			root.innerHTML,
+			`<div>${JSON.stringify({
+				pageSize: 2,
+				pageNumber: 2,
+				query: 'two-query'
+			})}</div>`
+		);
+	});
+});

--- a/tests/core/unit/resource.ts
+++ b/tests/core/unit/resource.ts
@@ -61,35 +61,91 @@ describe('resource', () => {
 		assert.isTrue(template.read.notCalled);
 	});
 
-	it('sets status flags correctly if read returns a promise', () => {
+	it('sets loading flag when read returns a promise', () => {
+		template.read.returns(new Promise(() => {}));
+		const invalidatorStub = sb.stub();
+		const resource = createResource(template);
+		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		resource.subscribe('loading', options, invalidatorStub);
+		resource.getOrRead(options);
+		assert.isTrue(resource.isLoading(options));
+		assert.isFalse(resource.isFailed(options));
+		assert.isTrue(invalidatorStub.called);
+	});
+
+	it('sets failed flag when read fails', () => {
+		template.read.returns({ then: sb.stub().returns({ catch: sb.stub().callsArg(0) }) });
+		const loadingInvalidator = sb.stub();
+		const failedInvalidator = sb.stub();
+		const resource = createResource(template);
+		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		resource.subscribe('loading', options, loadingInvalidator);
+		resource.subscribe('failed', options, failedInvalidator);
+		resource.getOrRead(options);
+		assert.isFalse(resource.isLoading(options));
+		assert.isTrue(resource.isFailed(options));
+		assert.isTrue(loadingInvalidator.called);
+		assert.isTrue(failedInvalidator.called);
+	});
+
+	it('sets data and total when async read resolves', () => {
 		let resolver: any;
+		const dataInvalidator = sb.stub();
 		const promise = new Promise((resolve) => {
 			resolver = resolve;
 		});
 		template.read.returns(promise);
 		const resource = createResource(template);
 		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		resource.subscribe('data', options, dataInvalidator);
 		resource.getOrRead(options);
-		assert.isTrue(resource.isLoading(options), 'a');
-		assert.isFalse(resource.isFailed(options), 'b');
 		resolver({ data: ['foo', 'bar'], total: 2 });
-		assert.isFalse(resource.isLoading(options), 'c');
-		assert.isFalse(resource.isFailed(options), 'd');
+		return promise.then(() => {
+			assert.isTrue(dataInvalidator.calledOnce);
+			const data = resource.getOrRead(options);
+			assert.deepEqual(data, ['foo', 'bar']);
+			assert.isTrue(template.read.calledOnce);
+			assert.equal(resource.getTotal(options), 2);
+		});
 	});
 
-	it('sets status flags correctly when read rejects a promise', () => {
-		let rejecter: any;
-		const promise = new Promise((resolve, reject) => {
-			rejecter = reject;
-		});
-		template.read.returns(promise);
+	it('allows a widget to unsubscribe from invalidations', () => {
+		template.read.returns(new Promise(() => {}));
+		const invalidatorStub = sb.stub();
 		const resource = createResource(template);
 		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		resource.subscribe('loading', options, invalidatorStub);
 		resource.getOrRead(options);
-		assert.isTrue(resource.isLoading(options));
-		assert.isFalse(resource.isFailed(options));
-		rejecter();
-		assert.isFalse(resource.isLoading(options));
-		assert.isTrue(resource.isFailed(options));
+		assert.isTrue(invalidatorStub.called);
+		resource.unsubscribe(invalidatorStub);
+		invalidatorStub.resetHistory();
+		resource.getOrRead(options);
+		assert.isTrue(invalidatorStub.notCalled);
+	});
+
+	it('returns an empty array from get if data requested not present', () => {
+		template.read.returns({ data: [], total: 0 });
+		const resource = createResource(template);
+		resource.getOrRead({ pageNumber: 1, pageSize: 10 });
+		const set: any = template.read.args[0][1];
+		const data = ['foo', 'bar'];
+		set(2, data);
+		const firstPageGet = resource.get({ pageNumber: 1, pageSize: 2 });
+		assert.isEmpty(firstPageGet);
+		const secondPageGet = resource.get({ pageNumber: 2, pageSize: 2 });
+		assert.deepEqual(secondPageGet, ['foo', 'bar']);
+	});
+
+	it('returns immediately from getOrRead if requested data present', () => {
+		template.read.returns({ data: [], total: 0 });
+		const resource = createResource(template);
+		resource.getOrRead({ pageNumber: 1, pageSize: 10 });
+		const set: any = template.read.args[0][1];
+		const data = ['foo', 'bar'];
+		set(2, data);
+		template.read.resetHistory();
+		const secondPageGetOrRead = resource.getOrRead({ pageNumber: 2, pageSize: 2 });
+		assert.deepEqual(secondPageGetOrRead, ['foo', 'bar']);
+		assert.isTrue(template.read.notCalled);
 	});
 });

--- a/tests/core/unit/resource.ts
+++ b/tests/core/unit/resource.ts
@@ -1,0 +1,95 @@
+const { describe, it, afterEach, beforeEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { sandbox } from 'sinon';
+import { createResource } from '../../../src/core/resource';
+
+const sb = sandbox.create();
+
+describe('resource', () => {
+	const template = {
+		read: sb.stub()
+	};
+
+	beforeEach(() => {});
+	afterEach(() => {
+		sb.resetHistory();
+	});
+
+	it('creates a resouce given a template', () => {
+		const resource = createResource(template);
+		assert.hasAllKeys(resource, [
+			'getOrRead',
+			'get',
+			'getTotal',
+			'subscribe',
+			'unsubscribe',
+			'isFailed',
+			'isLoading',
+			'set'
+		]);
+	});
+
+	it('calls the read template function with calculated offset when getOrRead is called', () => {
+		template.read.returns({ data: [], total: 0 });
+		const resource = createResource(template);
+		const query = [{ value: 'test', keys: ['foo', 'bar'] }];
+		resource.getOrRead({ pageNumber: 2, pageSize: 10, query });
+		assert.isTrue(template.read.calledWith({ offset: 10, size: 10, query }));
+	});
+
+	it('provides the read function with a set callback to set data directly on the resource', () => {
+		template.read.returns({ data: [], total: 0 });
+		const resource = createResource(template);
+		resource.getOrRead({ pageNumber: 1, pageSize: 10 });
+		const set: any = template.read.args[0][1];
+		const data = ['foo', 'bar'];
+		set(0, data);
+		assert.deepEqual(resource.get({}), data);
+	});
+
+	it('does not call read if the data is already present', () => {
+		template.read.returns({ data: [], total: 0 });
+		const resource = createResource(template);
+		resource.getOrRead({ pageNumber: 1, pageSize: 3 });
+		const set: any = template.read.args[0][1];
+		const data = ['foo', 'bar', 'baz'];
+		set(0, data);
+
+		sb.resetHistory();
+		const response = resource.getOrRead({ pageNumber: 1, pageSize: 3 });
+		assert.deepEqual(response, data);
+		assert.isTrue(template.read.notCalled);
+	});
+
+	it('sets status flags correctly if read returns a promise', () => {
+		let resolver: any;
+		const promise = new Promise((resolve) => {
+			resolver = resolve;
+		});
+		template.read.returns(promise);
+		const resource = createResource(template);
+		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		resource.getOrRead(options);
+		assert.isTrue(resource.isLoading(options), 'a');
+		assert.isFalse(resource.isFailed(options), 'b');
+		resolver({ data: ['foo', 'bar'], total: 2 });
+		assert.isFalse(resource.isLoading(options), 'c');
+		assert.isFalse(resource.isFailed(options), 'd');
+	});
+
+	it('sets status flags correctly when read rejects a promise', () => {
+		let rejecter: any;
+		const promise = new Promise((resolve, reject) => {
+			rejecter = reject;
+		});
+		template.read.returns(promise);
+		const resource = createResource(template);
+		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		resource.getOrRead(options);
+		assert.isTrue(resource.isLoading(options));
+		assert.isFalse(resource.isFailed(options));
+		rejecter();
+		assert.isFalse(resource.isLoading(options));
+		assert.isTrue(resource.isFailed(options));
+	});
+});


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds a data middleware capable of making widgets data aware and able to deal with a resource.
- When using the middleware, `resource` will be added to the widget's properties. This can be used to pass a resource to be interacted with.
- Provides `createDataMiddleware` function which takes a generic to determine the type of data the widget requires, this adds a `transform` function to the widget properties which uses the generic to ensure the correct data type is supplied.

*Data middleware API interface:*

- getOrRead(options: ResourceOptions): any;
- getTotal(options: ResourceOptions): number | undefined;
- isLoading(options: ResourceOptions): boolean;
- isFailed(options: ResourceOptions): boolean;
- isLoading(options: ResourceOptions): boolean;
- isFailed(options: ResourceOptions): boolean;
- isLoading(options: ResourceOptions): boolean;
- isFailed(options: ResourceOptions): boolean;
- setOptions(newOptions: ResourceOptions): void;
- getOptions(): ResourceOptions;
- readonly resource: ResourceWrapper;
- shared(): ResourceWrapper;

`ResourceOptions` are made up of:
- pageNumber?: number
- pageSize?: number
- query?: string

When a widget using the middleware is destroyed, the middleware will disconnect from the resource.

*The Resource will need to provide the following API*

- getOrRead(options: ResourceOptions: any
- getTotal(options: ResourceOptions): number | undefined
- unsubscribe(invalidator: () => void): void
- subscribe(type: SubscriptionType, options: ResourceOptions, invalidator: () => void): void;
- isLoading(options: ResourceOptions): boolean;
- isFailed(options: ResourceOptions): boolean;

Both API 

Will work in future with resources.

Resolves #660 

Codesandbox of it in use with dummy resource: https://codesandbox.io/s/hardcore-swartz-kezpc