### PR TITLE
Small docs reorg and fix spelling mistakes

### DIFF
--- a/docs/en/creating-widgets/supplemental.md
+++ b/docs/en/creating-widgets/supplemental.md
@@ -888,7 +888,7 @@ When working with Dojo widgets, a few important principles should be kept in min
 -   Widgets should avoid deriving further render state from their properties, and instead rely on their complete render state being provided to them.
     -   Deriving render state can cause similar divergences between the widget and the framework as modifying received properties; the framework is not aware of the derived state, so cannot properly determine when a widget has been updated and requires invalidation and re-rendering.
 -   Internal or private state can be fully encapsulated within a widget, if required.
-    -   It is a valid and often desireable pattern to implement 'pure' widgets that incur no side effects and receive their entire state as properties, but this is not the only pattern in Dojo widget development.
+    -   It is a valid and often desirable pattern to implement 'pure' widgets that incur no side effects and receive their entire state as properties, but this is not the only pattern in Dojo widget development.
 
 ## Using class-based widgets
 

--- a/docs/en/i18n/introduction.md
+++ b/docs/en/i18n/introduction.md
@@ -155,7 +155,7 @@ r.mount({ registry });
 
 -   Using the [i18n middleware](/learn/middleware/available-middleware#i18n) to allow users to to choose between supported locales, and enact a locale change via the middleware's `.set` API.
 
-**Reminder:** When using both class-based and function-based widgets, this middleware should be used together with [registeri18nInjector](/learn/i18n/internationalizing-a-dojo-application/#providing-locale-data-to-i18n-aware-widgets) to reactively propagate locale changes to all i18n-aware widgets.
+**Reminder:** When using both class-based and function-based widgets, this middleware should be used together with [`registeri18nInjector`](/learn/i18n/internationalizing-a-dojo-application/#providing-locale-data-to-i18n-aware-widgets) to reactively propagate locale changes to all i18n-aware widgets.
 
 > src/widgets/LocaleChanger.tsx
 

--- a/docs/en/stores/introduction.md
+++ b/docs/en/stores/introduction.md
@@ -272,7 +272,7 @@ export const login = createProcess('login', [ fetchUser, loadUserData ]);
 
 #### `payload` type
 
-The process executor's `payload` is inferred from the `payload` type of the commands. If the payloads differ then it is necessary to explictly define the `payload` type.
+The process executor's `payload` is inferred from the `payload` type of the commands. If the payloads differ then it is necessary to explicitly define the `payload` type.
 
 ```ts
 const createCommand = createCommandFactory<State>();

--- a/docs/en/stores/supplemental.md
+++ b/docs/en/stores/supplemental.md
@@ -29,7 +29,7 @@ The StoreProvider accepts three properties
 
 ### Invalidation
 
-The `StoreProvider` has two main ways to trigger invalidation and cause a rerender.
+The `StoreProvider` has two main ways to trigger invalidation and cause a re-render.
 
 1.  The recommended approach is to register `path`s by passing the `paths` property to the provider to ensure invalidation only occurs when relevant state changes.
 2.  A catch-all when no `path`s are defined for the container, it will invalidate when _any_ data changes in the store.
@@ -253,7 +253,7 @@ const store = new Store({ state: myStateImpl });
 
 ### `MutableState` API
 
-Any `State` implemention must provide four methods to properly apply operations to the state.
+Any `State` implementation must provide four methods to properly apply operations to the state.
 
 -   `get<S>(path: Path<M, S>): S` takes a `Path` object and returns the value in the current state at the provided path
 -   `at<S extends Path<M, Array<any>>>(path: S, index: number): Path<M, S['value'][0]>` returns a `Path` object that points to the provided `index` in the array at the provided path

--- a/docs/en/testing/supplemental.md
+++ b/docs/en/testing/supplemental.md
@@ -962,7 +962,6 @@ export function createMockMiddleware() {
 
 There are plenty of full mock examples in [`framework/src/testing/mocks/middlware`](https://github.com/dojo/framework/tree/master/src/testing/mocks/middleware) which can be used for reference.
 
-
 # Functional tests
 
 Unlike unit tests that load and execute code, functional tests load a page in the browser and test how users interact with the running application.


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR (**Docs changes only**)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This moves the documentation on provided middleware mocks to the Mocking section under Testing, rather than being under the harness section. However, I did add a link to the harness section to make it easy to navigate.

- Move mock middleware documentation to Mocking section
- Fix typos and spelling issues seen in other docs

Resolves #632 

![image](https://user-images.githubusercontent.com/293805/73984706-da533280-48fe-11ea-8ca4-f697ca74f13e.png)

