### PR TITLE
An empty computed locale causes message values to be undefined

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -72,6 +72,8 @@ const DOJO_PATH = 'dojo/{bundle}/lookup';
 
 let supportedLocales: string[] = [];
 let defaultLocale = '';
+// Set to `unknown` to support using default message bundles
+// without an application locale configured
 let computedLocale = 'unknown';
 let currentLocale = '';
 let cldrLoaders: CldrLoaders = {};

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -72,7 +72,7 @@ const DOJO_PATH = 'dojo/{bundle}/lookup';
 
 let supportedLocales: string[] = [];
 let defaultLocale = '';
-let computedLocale = '';
+let computedLocale = 'unknown';
 let currentLocale = '';
 let cldrLoaders: CldrLoaders = {};
 let bundleId = 0;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Sets a default for the `computedLocale` as the existing `''` causes messages to return as undefined. This did not surface in testing as it the computed locale was always being set via `setLocale` however when using this downstream with dojo/widgets the tests were not able to return the default message bundles.