### PR TITLE
Fallback to the root bundle when no locales are configured

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -288,9 +288,9 @@
       "dev": true
     },
     "@types/selenium-webdriver": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz",
-      "integrity": "sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.17.tgz",
+      "integrity": "sha512-tGomyEuzSC1H28y2zlW6XPCaDaXFaD6soTdb4GNdmte2qfHtrKqhy0ZFs4r/1hpazCfEZqeTSRLvSasmEx89uw==",
       "dev": true
     },
     "@types/serve-static": {
@@ -7010,9 +7010,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.7.tgz",
-      "integrity": "sha512-FeSU+hi7ULYy6mn8PKio/tXsdSXN35lm4KgV2asx00kzrLU9Pi3oAslcJT70Jdj7PHX29gGUPOT6+lXGBbemhA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -177,31 +177,32 @@ async function loadCldrData(
 	isLocal: boolean,
 	invalidator?: () => void
 ): Promise<any> {
-	const loaderData = await Promise.all(loaderPromises);
-	cldrLoaders[userLocale] = true;
-	cldrLoaders.supplemental = true;
-	loaderData.forEach((results) => {
-		results.forEach((result: any) => {
-			Globalize.load(result.default);
+	return Promise.all(loaderPromises).then((loaderData) => {
+		cldrLoaders[userLocale] = true;
+		cldrLoaders.supplemental = true;
+		loaderData.forEach((results) => {
+			results.forEach((result: any) => {
+				Globalize.load(result.default);
+			});
 		});
-	});
-	if (shouldLoadFallbackCldr(requestedLocale)) {
-		cldrLoaders.fallback = true;
-		const data = cldr.get('dojo') || {};
-		const locales = Object.keys(data);
-		for (let i = 0; i < locales.length; i++) {
-			const locale = locales[i];
-			if (data[locale].bundles) {
-				Globalize.loadMessages({ [locale]: data[locale].bundles });
+		if (shouldLoadFallbackCldr(requestedLocale)) {
+			cldrLoaders.fallback = true;
+			const data = cldr.get('dojo') || {};
+			const locales = Object.keys(data);
+			for (let i = 0; i < locales.length; i++) {
+				const locale = locales[i];
+				if (data[locale].bundles) {
+					Globalize.loadMessages({ [locale]: data[locale].bundles });
+				}
+			}
+			if (requestedLocale && locales.indexOf(requestedLocale) === -1) {
+				Globalize.loadMessages({ [requestedLocale]: {} });
 			}
 		}
-		if (requestedLocale && locales.indexOf(requestedLocale) === -1) {
-			Globalize.loadMessages({ [requestedLocale]: {} });
-		}
-	}
-	setI18nLocales(calculatedLocale, isDefault, isLocal);
-	invalidator && invalidator();
-	return calculatedLocale;
+		setI18nLocales(calculatedLocale, isDefault, isLocal);
+		invalidator && invalidator();
+		return calculatedLocale;
+	});
 }
 
 /**

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -357,10 +357,8 @@ export function localizeBundle<T extends Messages>(
 		};
 	}
 	if (shouldLoadFallbackCldr(locale)) {
-		const promise = setLocale({ default: false, local: true, locale, invalidator });
-		if (typeof promise === 'string') {
-			return getPlaceholderBundle(bundle);
-		}
+		setLocale({ default: false, local: true, locale, invalidator });
+		return getPlaceholderBundle(bundle);
 	}
 	const bundleId = registerBundle(bundle);
 	const globalize = globalizeInstanceMap.get(locale) || new Globalize(locale);

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -185,7 +185,7 @@ async function loadCldrData(
 	});
 	if (shouldLoadFallbackCldr(requestedLocale)) {
 		cldrLoaders.fallback = true;
-		const data = cldr.get('dojo');
+		const data = cldr.get('dojo') || {};
 		const locales = Object.keys(data);
 		for (let i = 0; i < locales.length; i++) {
 			const locale = locales[i];
@@ -301,9 +301,8 @@ function registerBundle<T extends Messages>(bundle: Bundle<T>): string {
 			} else {
 				messages = bundleLoader;
 			}
-			if (isSupportedLocale) {
-				messageBundles[locale] = messages;
-			} else if (lookup[locale]) {
+			messageBundles[locale] = isSupportedLocale ? messages : {};
+			if (lookup[locale]) {
 				lookup[locale].bundles = { [bundleId]: messages };
 			} else {
 				lookup[locale] = {

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -304,7 +304,7 @@ function registerBundle<T extends Messages>(bundle: Bundle<T>): string {
 				messages = bundleLoader;
 			}
 			if (isSupportedLocale) {
-				messageBundles[locale] = isSupportedLocale ? messages : {};
+				messageBundles[locale] = messages;
 			} else if (lookup[locale]) {
 				lookup[locale].bundles = { [bundleId]: messages };
 			} else {

--- a/tests/i18n/unit/i18n.ts
+++ b/tests/i18n/unit/i18n.ts
@@ -180,6 +180,22 @@ describe('i18n', () => {
 			assert.isFalse(isPlaceholder);
 		});
 
+		it('should use fallback message bundle resolution for a non localised app', async () => {
+			const invalidator = stub();
+			const bundle = {
+				messages: { foo: 'bonjour, {name}', fallback: 'root/fr fallback' },
+				locales: {
+					en: { foo: 'hello, {name}', fallback: 'en' }
+				}
+			};
+			setDefaultLocale('unknown');
+			await setLocale({ locale: 'unknown', default: true });
+			let { messages, format, isPlaceholder } = localizeBundle(bundle, { invalidator, locale: 'en' });
+			assert.deepEqual(messages, { foo: 'bonjour, {name}', fallback: 'root/fr fallback' });
+			assert.strictEqual(format('foo', { name: 'Steven' }), 'bonjour, Steven');
+			assert.isFalse(isPlaceholder);
+		});
+
 		describe('fallback cldr supplemental', () => {
 			let originalLikelySubtags: any;
 

--- a/tests/i18n/unit/i18n.ts
+++ b/tests/i18n/unit/i18n.ts
@@ -194,16 +194,16 @@ describe('i18n', () => {
 		it('should use fallback message bundle resolution for a non localised app', async () => {
 			const invalidator = stub();
 			const bundle = {
-				messages: { foo: 'bonjour, {name}', fallback: 'root/fr fallback' },
+				messages: { foo: 'bonjour, {name}, {other}', fallback: 'root/fr fallback' },
 				locales: {
-					en: { foo: 'hello, {name}', fallback: 'en' }
+					en: { foo: 'hello, {name}, {other}', fallback: 'en' }
 				}
 			};
 			setDefaultLocale('unknown');
 			await setLocale({ locale: 'unknown', default: true });
 			let { messages, format, isPlaceholder } = localizeBundle(bundle, { invalidator, locale: 'en' });
-			assert.deepEqual(messages, { foo: 'bonjour, {name}', fallback: 'root/fr fallback' });
-			assert.strictEqual(format('foo', { name: 'Steven' }), 'bonjour, Steven');
+			assert.deepEqual(messages, { foo: 'bonjour, {name}, {other}', fallback: 'root/fr fallback' });
+			assert.strictEqual(format('foo', { name: 'Steven' }), 'bonjour, Steven, {other}');
 			assert.isFalse(isPlaceholder);
 		});
 

--- a/tests/i18n/unit/i18n.ts
+++ b/tests/i18n/unit/i18n.ts
@@ -131,10 +131,13 @@ describe('i18n', () => {
 		});
 
 		it('Resolves async messages bundles', async () => {
+			const fallback = createAsyncMessageLoader();
 			const invalidator = stub();
 			setDefaultLocale('fr');
 			setSupportedLocales(['fr']);
-			setCldrLoaders({});
+			setCldrLoaders({
+				fallback: fallback.loader
+			});
 			await setLocale({ locale: 'fr' });
 			const enGb = createAsyncMessageLoader();
 			const en = createAsyncMessageLoader();
@@ -158,18 +161,26 @@ describe('i18n', () => {
 			assert.deepEqual(messages, { foo: '', fallback: '' });
 			assert.strictEqual(format('foo', { name: 'Steven' }), '');
 			assert.isTrue(isPlaceholder);
-			enGb.resolver({ default: { foo: 'Oi, {name}' } });
 			assert.isTrue(invalidator.notCalled);
-			await enGb.promise;
+			fallback.resolver([{ default: {} }]);
+			await fallback.promise;
 			assert.isTrue(invalidator.calledOnce);
 			({ messages, format, isPlaceholder } = localizeBundle(bundle, { locale: 'en-GB', invalidator }));
 			assert.deepEqual(messages, { foo: '', fallback: '' });
 			assert.strictEqual(format('foo', { name: 'Steven' }), '');
 			assert.isTrue(isPlaceholder);
-			en.resolver({ default: { foo: 'Hello, {name}', fallback: 'en fallback' } });
+			enGb.resolver({ default: { foo: 'Oi, {name}' } });
 			assert.isTrue(invalidator.calledOnce);
-			await en.promise;
+			await enGb.promise;
 			assert.isTrue(invalidator.calledTwice);
+			({ messages, format, isPlaceholder } = localizeBundle(bundle, { locale: 'en-GB', invalidator }));
+			assert.deepEqual(messages, { foo: '', fallback: '' });
+			assert.strictEqual(format('foo', { name: 'Steven' }), '');
+			assert.isTrue(isPlaceholder);
+			en.resolver({ default: { foo: 'Hello, {name}', fallback: 'en fallback' } });
+			assert.isTrue(invalidator.calledTwice);
+			await en.promise;
+			assert.isTrue(invalidator.calledThrice);
 			({ messages, format, isPlaceholder } = localizeBundle(bundle, { locale: 'en-GB', invalidator }));
 			assert.deepEqual(messages, { foo: 'Oi, {name}', fallback: 'en fallback' });
 			assert.strictEqual(format('foo', { name: 'Steven' }), 'Oi, Steven');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

* Use a basic message loader when i18n has not been configured for the application.
* Load the fallback cldr for unknown locales that are passed to localizeBundle but not set through changing the local via the i18n middleware or mixin.
