### PR TITLE
Add Theme variants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1309,9 +1309,9 @@
       }
     },
     "cldrjs": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.1.tgz",
-      "integrity": "sha512-xyiP8uAm8K1IhmpDndZLraloW1yqu0L+HYdQ7O1aGPxx9Cr+BMnPANlNhSt++UKfxytL2hd2NPXgTjiy7k43Ew=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.0.tgz",
+      "integrity": "sha1-N76S2NGo5myO4S8TA+0xbYXY6zc="
     },
     "cli-cursor": {
       "version": "1.0.2",
@@ -2339,21 +2339,6 @@
           "dev": true,
           "requires": {
             "pend": "~1.2.0"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
           }
         },
         "yauzl": {
@@ -4744,18 +4729,18 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "0.0.8"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
       }
@@ -6755,9 +6740,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
           "dev": true
         }
       }

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -124,6 +124,23 @@ export interface Theme {
 	[key: string]: object;
 }
 
+export interface Variant {
+	root: string;
+}
+
+export interface ThemeVariant {
+	theme: Theme;
+	variant: Variant;
+}
+
+export interface ThemeVariantConfig {
+	theme: Theme;
+	variants: {
+		default: Variant;
+		[key: string]: Variant;
+	};
+}
+
 export interface Classes {
 	[widgetKey: string]: {
 		[classKey: string]: SupportedClassName[];

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -129,8 +129,8 @@ export interface Variant {
 }
 
 export interface ThemeVariant {
-	theme: Theme;
-	variant: Variant;
+	theme: Theme | ThemeVariantConfig;
+	variant: Variant | string;
 }
 
 export interface ThemeVariantConfig {

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -128,13 +128,13 @@ export interface Variant {
 	root: string;
 }
 
-export interface ThemeVariant {
-	theme: Theme | ThemeVariantConfig;
+export interface ThemeWithVariant {
+	css: Theme | ThemeWithVariants;
 	variant: Variant | string;
 }
 
-export interface ThemeVariantConfig {
-	theme: Theme;
+export interface ThemeWithVariants {
+	css: Theme;
 	variants: {
 		default: Variant;
 		[key: string]: Variant;

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -89,8 +89,11 @@ export const theme = factory(
 		});
 
 		function set(theme: Theme): void;
-		function set<T extends ThemeVariantConfig>(theme: T, variant?: keyof T['variants']): void;
-		function set<T extends ThemeVariantConfig>(theme: Theme | T, variant?: keyof T['variants']): void {
+		function set<T extends ThemeVariantConfig>(theme: T, variant?: Extract<keyof T['variants'], string>): void;
+		function set<T extends ThemeVariantConfig>(
+			theme: Theme | T,
+			variant?: Extract<keyof T['variants'], string>
+		): void {
 			const currentTheme = injector.get<Injector<Theme | ThemeVariant | undefined>>(INJECTED_THEME_KEY);
 
 			if (currentTheme) {

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -89,16 +89,13 @@ export const theme = factory(
 		});
 
 		function set(theme: Theme): void;
-		function set<T extends ThemeVariantConfig>(theme: T, variant?: Extract<keyof T['variants'], string>): void;
-		function set<T extends ThemeVariantConfig>(
-			theme: Theme | T,
-			variant?: Extract<keyof T['variants'], string>
-		): void {
+		function set<T extends ThemeVariantConfig>(theme: T, variant?: keyof T['variants']): void;
+		function set<T extends ThemeVariantConfig>(theme: Theme | T, variant?: keyof T['variants']): void {
 			const currentTheme = injector.get<Injector<Theme | ThemeVariant | undefined>>(INJECTED_THEME_KEY);
 
 			if (currentTheme) {
 				if (isThemeVariantConfig(theme)) {
-					theme = { theme: theme.theme, variant: theme.variants[variant || 'default'] };
+					theme = { theme: theme.theme, variant: theme.variants[`${variant || 'default'}`] };
 				}
 
 				currentTheme.set(theme);

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -19,11 +19,11 @@ export const THEME_KEY = ' _key';
 export const INJECTED_THEME_KEY = '__theme_injector';
 
 function isThemeWithVariant(theme: Theme | ThemeWithVariant): theme is ThemeWithVariant {
-	return theme.hasOwnProperty('variant');
+	return theme && theme.hasOwnProperty('variant');
 }
 
 function isThemeWithVariants(theme: Theme | ThemeWithVariants): theme is ThemeWithVariants {
-	return theme.hasOwnProperty('variants');
+	return theme && theme.hasOwnProperty('variants');
 }
 
 function isVariantModule(variant: string | Variant): variant is Variant {
@@ -52,6 +52,7 @@ export const theme = factory(
 				icache.clear();
 				invalidator();
 			}
+
 			if (!next.theme && themeInjector) {
 				return themeInjector.get();
 			}

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -30,7 +30,7 @@ function isVariantModule(variant: string | Variant): variant is Variant {
 	return typeof variant !== 'string';
 }
 
-function registerThemeInjector(theme: any, themeRegistry: Registry): Injector {
+function registerThemeInjector(theme: Theme | ThemeWithVariant | undefined, themeRegistry: Registry): Injector {
 	const themeInjector = new Injector(theme);
 	themeRegistry.defineInjector(INJECTED_THEME_KEY, (invalidator) => {
 		themeInjector.setInvalidator(invalidator);

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -108,6 +108,11 @@ export const theme = factory(
 				themeKeys.add(key);
 				theme = classes as T;
 				let { theme: currentTheme, classes: currentClasses } = properties();
+
+				if (currentTheme && isThemeVariant(currentTheme)) {
+					currentTheme = currentTheme.theme;
+				}
+
 				if (currentTheme && currentTheme[key]) {
 					theme = { ...theme, ...currentTheme[key] };
 				}

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -163,7 +163,7 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 		}
 
 		public variant() {
-			const { theme = {} } = this.properties;
+			const { theme } = this.properties;
 
 			if (theme && isThemeVariant(theme)) {
 				if (isVariantModule(theme.variant)) {

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -4,8 +4,8 @@ import {
 	ClassNames,
 	Constructor,
 	SupportedClassName,
-	ThemeVariant,
-	ThemeVariantConfig,
+	ThemeWithVariant,
+	ThemeWithVariants,
 	Variant
 } from './../interfaces';
 import { Registry } from './../Registry';
@@ -22,7 +22,7 @@ export { Theme, Classes, ClassNames } from './../interfaces';
  */
 export interface ThemedProperties<T = ClassNames> {
 	/** Overriding custom theme for the widget */
-	theme?: Theme | ThemeVariant;
+	theme?: Theme | ThemeWithVariant;
 	/** Map of widget keys and associated overriding classes */
 	classes?: Classes;
 	/** Extra classes to be applied to the widget */
@@ -33,11 +33,11 @@ export const THEME_KEY = ' _key';
 
 export const INJECTED_THEME_KEY = '__theme_injector';
 
-function isThemeVariant(theme: Theme | ThemeVariant): theme is ThemeVariant {
+function isThemeVariant(theme: Theme | ThemeWithVariant): theme is ThemeWithVariant {
 	return theme.hasOwnProperty('variant');
 }
 
-function isThemeVariantConfig(theme: Theme | ThemeVariantConfig): theme is ThemeVariantConfig {
+function isThemeVariantConfig(theme: Theme | ThemeWithVariants): theme is ThemeWithVariants {
 	return theme.hasOwnProperty('variants');
 }
 
@@ -169,8 +169,8 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 				if (isVariantModule(theme.variant)) {
 					return theme.variant.root;
 				}
-				if (isThemeVariantConfig(theme.theme)) {
-					return theme.theme.variants[theme.variant].root;
+				if (isThemeVariantConfig(theme.css)) {
+					return theme.css.variants[theme.variant].root;
 				}
 			}
 		}
@@ -238,7 +238,7 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 			let theme: Theme;
 
 			if (isThemeVariant(themeProp)) {
-				theme = isThemeVariantConfig(themeProp.theme) ? themeProp.theme.theme : themeProp.theme;
+				theme = isThemeVariantConfig(themeProp.css) ? themeProp.css.css : themeProp.css;
 			} else {
 				theme = themeProp;
 			}

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -169,9 +169,6 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 				if (isVariantModule(theme.variant)) {
 					return theme.variant.root;
 				}
-				if (isThemeVariantConfig(theme.css)) {
-					return theme.css.variants[theme.variant].root;
-				}
 			}
 		}
 

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -92,7 +92,7 @@ function createThemeClassesLookup(classes: ClassNames[]): ClassNames {
  *
  * @returns the theme injector used to set the theme
  */
-export function registerThemeInjector(theme: any, themeRegistry: Registry): Injector {
+export function registerThemeInjector(theme: Theme | ThemeWithVariant, themeRegistry: Registry): Injector {
 	const themeInjector = new Injector(theme);
 	themeRegistry.defineInjector(INJECTED_THEME_KEY, (invalidator) => {
 		themeInjector.setInvalidator(invalidator);

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -5,7 +5,8 @@ import {
 	Constructor,
 	SupportedClassName,
 	ThemeVariant,
-	ThemeVariantConfig
+	ThemeVariantConfig,
+	Variant
 } from './../interfaces';
 import { Registry } from './../Registry';
 import { Injector } from './../Injector';
@@ -34,6 +35,14 @@ export const INJECTED_THEME_KEY = '__theme_injector';
 
 function isThemeVariant(theme: Theme | ThemeVariant): theme is ThemeVariant {
 	return theme.hasOwnProperty('variant');
+}
+
+function isThemeVariantConfig(theme: Theme | ThemeVariantConfig): theme is ThemeVariantConfig {
+	return theme.hasOwnProperty('variants');
+}
+
+function isVariantModule(variant: string | Variant): variant is Variant {
+	return typeof variant !== 'string';
 }
 
 /**
@@ -155,8 +164,14 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 
 		public variant() {
 			const { theme = {} } = this.properties;
-			if (isThemeVariant(theme)) {
-				return theme.variant.root;
+
+			if (theme && isThemeVariant(theme)) {
+				if (isVariantModule(theme.variant)) {
+					return theme.variant.root;
+				}
+				if (isThemeVariantConfig(theme.theme)) {
+					return theme.theme.variants[theme.variant].root;
+				}
 			}
 		}
 
@@ -223,7 +238,7 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 			let theme: Theme;
 
 			if (isThemeVariant(themeProp)) {
-				theme = themeProp.theme;
+				theme = isThemeVariantConfig(themeProp.theme) ? themeProp.theme.theme : themeProp.theme;
 			} else {
 				theme = themeProp;
 			}

--- a/tests/core/unit/middleware/theme.tsx
+++ b/tests/core/unit/middleware/theme.tsx
@@ -157,4 +157,156 @@ jsdomDescribe('theme middleware', () => {
 			'<div><div><div class="themed-root classes-root"></div><button></button><div>{"test-key":{"root":"themed-root"}}</div></div></div>'
 		);
 	});
+
+	it('returns theme variant class', () => {
+		const factory = create({ theme });
+		const themeWithVariant = {
+			css: {
+				'test-key': {
+					root: 'themed-root'
+				}
+			},
+			variant: {
+				root: 'variant-root'
+			}
+		};
+
+		const App = factory(function App({ middleware: { theme } }) {
+			const variantRoot = theme.variant();
+			return <div classes={variantRoot} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App theme={themeWithVariant} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, '<div class="variant-root"></div>');
+	});
+
+	it('selects default variant theme with variants is set', () => {
+		const factory = create({ theme });
+		const themeWithVariants = {
+			css: {
+				'test-key': {
+					root: 'themed-root'
+				}
+			},
+			variants: {
+				default: {
+					root: 'default-variant-root'
+				}
+			}
+		};
+
+		const App = factory(function App({ middleware: { theme } }) {
+			const variantRoot = theme.variant();
+			return (
+				<div classes={variantRoot}>
+					<button
+						onclick={() => {
+							theme.set(themeWithVariants);
+						}}
+					/>
+				</div>
+			);
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App />);
+		r.mount({ domNode: root });
+		(root.children[0].children[0] as HTMLButtonElement).click();
+		resolvers.resolve();
+		assert.strictEqual(root.innerHTML, '<div class="default-variant-root"><button></button></div>');
+	});
+
+	it('selects keyes variant theme with variants is set with variant key', () => {
+		const factory = create({ theme });
+		const themeWithVariants = {
+			css: {
+				'test-key': {
+					root: 'themed-root'
+				}
+			},
+			variants: {
+				default: {
+					root: 'default-variant-root'
+				},
+				foo: {
+					root: 'foo-variant-root'
+				}
+			}
+		};
+
+		const App = factory(function App({ middleware: { theme } }) {
+			const variantRoot = theme.variant();
+			return (
+				<div classes={variantRoot}>
+					<button
+						onclick={() => {
+							theme.set(themeWithVariants, 'foo');
+						}}
+					/>
+				</div>
+			);
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App />);
+		r.mount({ domNode: root });
+		(root.children[0].children[0] as HTMLButtonElement).click();
+		resolvers.resolve();
+		assert.strictEqual(root.innerHTML, '<div class="foo-variant-root"><button></button></div>');
+	});
+
+	it('selects specific variant when passed', () => {
+		const factory = create({ theme });
+		const themeWithVariants = {
+			css: {
+				'test-key': {
+					root: 'themed-root'
+				}
+			},
+			variants: {
+				default: {
+					root: 'default-variant-root'
+				},
+				foo: {
+					root: 'foo-variant-root'
+				}
+			}
+		};
+
+		const App = factory(function App({ middleware: { theme } }) {
+			const variantRoot = theme.variant();
+			return <div classes={variantRoot} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App theme={{ css: themeWithVariants, variant: themeWithVariants.variants.foo }} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, '<div class="foo-variant-root"></div>');
+	});
+
+	it('selects specific variant when key passed', () => {
+		const factory = create({ theme });
+		const themeWithVariants = {
+			css: {
+				'test-key': {
+					root: 'themed-root'
+				}
+			},
+			variants: {
+				default: {
+					root: 'default-variant-root'
+				},
+				bar: {
+					root: 'bar-variant-root'
+				}
+			}
+		};
+
+		const App = factory(function App({ middleware: { theme } }) {
+			const variantRoot = theme.variant();
+			return <div classes={variantRoot} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App theme={{ css: themeWithVariants, variant: 'bar' }} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, '<div class="bar-variant-root"></div>');
+	});
 });

--- a/tests/core/unit/mixins/Themed.ts
+++ b/tests/core/unit/mixins/Themed.ts
@@ -353,6 +353,129 @@ registerSuite('ThemedMixin', {
 					fixedClassName
 				]);
 			}
+		},
+		variants: {
+			'theme variant can be injected via a registry'() {
+				const themeWithVariant = {
+					css: {
+						'test-key': {
+							root: 'themed-root'
+						}
+					},
+					variant: {
+						root: 'default-variant-root'
+					}
+				};
+
+				registerThemeInjector(themeWithVariant, testRegistry);
+				class InjectedTheme extends TestWidget {
+					render() {
+						return v('div', { classes: this.variant() });
+					}
+				}
+				const themedInstance = new InjectedTheme();
+				themedInstance.registry.base = testRegistry;
+				themedInstance.__setProperties__({});
+				const renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, 'default-variant-root');
+			},
+			'theme variant can be set via theme context'() {
+				const theme = {
+					'test-key': {
+						root: 'themed-root'
+					}
+				};
+
+				const themeWithVariant = {
+					css: {
+						'test-key': {
+							root: 'variant-themed-root'
+						}
+					},
+					variant: {
+						root: 'variant-root'
+					}
+				};
+
+				const themeInjectorContext = registerThemeInjector(theme, testRegistry);
+				class InjectedTheme extends TestWidget {
+					render() {
+						return v('div', { classes: this.variant() });
+					}
+				}
+				const themedInstance = new InjectedTheme();
+				themedInstance.registry.base = testRegistry;
+				themedInstance.__setProperties__({});
+				let renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, undefined);
+				themeInjectorContext.set(themeWithVariant);
+				themedInstance.__setProperties__({});
+				renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, 'variant-root');
+			},
+			'theme variant can be set at the widget level'() {
+				const themeWithVariant = {
+					css: {
+						'test-key': {
+							root: 'themed-root'
+						}
+					},
+					variant: {
+						root: 'variant-root'
+					}
+				};
+
+				class ThemedWidget extends TestWidget {
+					render() {
+						return v('div', { classes: this.variant() });
+					}
+				}
+				const themedInstance = new ThemedWidget();
+				themedInstance.__setProperties__({});
+				let renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, undefined);
+				themedInstance.__setProperties__({ theme: themeWithVariant });
+				renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, 'variant-root');
+			},
+			'theme property overrides injected property'() {
+				const themeWithVariant = {
+					css: {
+						'test-key': {
+							root: 'themed-root'
+						}
+					},
+					variant: {
+						root: 'variant-root'
+					}
+				};
+
+				const secondThemeWithVariant = {
+					css: {
+						'test-key': {
+							root: 'themed-root'
+						}
+					},
+					variant: {
+						root: 'second-variant-root'
+					}
+				};
+
+				registerThemeInjector(themeWithVariant, testRegistry);
+				class InjectedTheme extends TestWidget {
+					render() {
+						return v('div', { classes: this.variant() });
+					}
+				}
+				const themedInstance = new InjectedTheme();
+				themedInstance.registry.base = testRegistry;
+				themedInstance.__setProperties__({});
+				let renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, 'variant-root');
+				themedInstance.__setProperties__({ theme: secondThemeWithVariant });
+				renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, 'second-variant-root');
+			}
 		}
 	}
 });

--- a/tests/core/unit/mixins/Themed.ts
+++ b/tests/core/unit/mixins/Themed.ts
@@ -475,6 +475,37 @@ registerSuite('ThemedMixin', {
 				themedInstance.__setProperties__({ theme: secondThemeWithVariant });
 				renderResult = themedInstance.__render__() as VNode;
 				assert.deepEqual(renderResult.properties.classes, 'second-variant-root');
+			},
+			'can inject theme config with variants'() {
+				const themeWithVariantConfig = {
+					css: {
+						css: {
+							'test-key': {
+								root: 'themed-root'
+							}
+						},
+						variants: {
+							default: {
+								root: 'default-root'
+							}
+						}
+					},
+					variant: {
+						root: 'variant-root'
+					}
+				};
+
+				registerThemeInjector(themeWithVariantConfig, testRegistry);
+				class InjectedTheme extends TestWidget {
+					render() {
+						return v('div', { classes: this.variant() });
+					}
+				}
+				const themedInstance = new InjectedTheme();
+				themedInstance.registry.base = testRegistry;
+				themedInstance.__setProperties__({});
+				let renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, 'variant-root');
 			}
 		}
 	}


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds ability to pass both a theme and a variant to widgets via theme middleware / mixin

Related to: https://github.com/dojo/framework/issues/683
