### PR TITLE
Change diff type for Themed Mixin to `auto`

### DIFF
--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -5,7 +5,6 @@ import { inject } from './../decorators/inject';
 import { WidgetBase } from './../WidgetBase';
 import { handleDecorator } from './../decorators/handleDecorator';
 import { diffProperty } from './../decorators/diffProperty';
-import { shallow } from './../diff';
 
 export { Theme, Classes, ClassNames } from './../interfaces';
 
@@ -144,9 +143,9 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 		/**
 		 * Function fired when `theme` or `extraClasses` are changed.
 		 */
-		@diffProperty('theme', shallow)
-		@diffProperty('extraClasses', shallow)
-		@diffProperty('classes', shallow)
+		@diffProperty('theme')
+		@diffProperty('extraClasses')
+		@diffProperty('classes')
 		protected onPropertiesChanged() {
 			this._recalculateClasses = true;
 		}

--- a/tests/core/unit/mixins/Themed.ts
+++ b/tests/core/unit/mixins/Themed.ts
@@ -300,6 +300,25 @@ registerSuite('ThemedMixin', {
 				testWidget.__setProperties__({ foo: 'bar' });
 				renderResult = testWidget.__render__() as VNode;
 				assert.deepEqual(renderResult.properties.classes, 'theme1Class1');
+			},
+			'should not invalidate when previous and current theme is undefined'() {
+				let invalidateStub = stub();
+				class UndefinedTheme extends TestWidget {
+					invalidate() {
+						invalidateStub();
+						super.invalidate();
+					}
+				}
+
+				const testWidget = new UndefinedTheme();
+				assert.isTrue(invalidateStub.notCalled);
+				testWidget.registry.base = testRegistry;
+				testWidget.__setProperties__({ theme: undefined, classes: undefined, extraClasses: undefined });
+				testWidget.__render__() as VNode;
+				assert.isTrue(invalidateStub.notCalled);
+				testWidget.__setProperties__({ theme: undefined, classes: undefined, extraClasses: undefined });
+				testWidget.__render__() as VNode;
+				assert.isTrue(invalidateStub.notCalled);
 			}
 		},
 		integration: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Use `auto` over `shallow` for the diff type of `theme`, `classes` and `extraClasses` in the `Themed`  mixin to prevent unnecessarily invalidating when `undefined` is explicitly passed to a widget.

Resolves #609 
