### PR TITLE
Return the current locale if no locale is set via properties or injector

### DIFF
--- a/src/core/middleware/i18n.ts
+++ b/src/core/middleware/i18n.ts
@@ -43,20 +43,20 @@ export const i18n = factory(({ properties, middleware: { invalidator, injector, 
 				result.then(() => {
 					invalidator();
 				});
-				return current.locale || injectedLocale;
+				return current.locale || injectedLocale || getCurrentLocale();
 			}
 		}
 		if (current.locale !== next.locale) {
 			invalidator();
 		}
-		return next.locale || injectedLocale;
+		return next.locale || injectedLocale || getCurrentLocale();
 	});
 
 	injector.subscribe(INJECTOR_KEY);
 
 	return {
 		localize<T extends Messages>(bundle: Bundle<T>): LocalizedMessages<T> {
-			let { locale = getCurrentLocale(), i18nBundle } = properties();
+			let { locale, i18nBundle } = properties();
 			if (i18nBundle) {
 				if (i18nBundle instanceof Map) {
 					bundle = i18nBundle.get(bundle) || bundle;

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -77,7 +77,7 @@ let defaultLocale = '';
 // Set to `unknown` to support using default message bundles
 // without an application locale configured
 let computedLocale = 'unknown';
-let currentLocale = '';
+let currentLocale: string | undefined;
 let cldrLoaders: CldrLoaders = {};
 let bundleId = 0;
 const cldr = new Cldr('');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The i18n middleware should set the locale property to be the computed locale from the default locale that has been set.