### PR TITLE
Invalidate for clear and delete on icache

### DIFF
--- a/docs/en/middleware/supplemental.md
+++ b/docs/en/middleware/supplemental.md
@@ -181,9 +181,9 @@ import icache from '@dojo/framework/core/middleware/icache';
     -   Sets the provided `value` for the given `key`. If `value` is a function, it will be invoked in order to obtain the actual value to cache. If the function returns a promise, a 'pending' value will be cached until the final value is fully resolved. In all scenarios, once a value is available and has been stored in the cache, the widget will be marked as invalid so it can be re-rendered with the final value available.
 -   `icache.has(key: any): boolean`
     -   Returns `true` or `false` based in whether the key is set in the cache.
--   `icache.delete(key: any): void`
+-   `icache.delete(key: any, invalidate: boolean = true): void`
     -   Remove the item from the cache.
--   `clear()`
+-   `clear(invalidate: boolean = true)`
     -   Clears all values currently stored in the widget's local cache.
 
 `icache` can be typed in two different ways. One approach uses generics to enable the return type to get specified at the call-site, and for `getOrSet`, the return type can get inferred from the value type. If the `value` for `getOrSet` is a function then the type will get inferred from the functions return type.

--- a/docs/zh-CN/middleware/supplemental.md
+++ b/docs/zh-CN/middleware/supplemental.md
@@ -186,9 +186,9 @@ import icache from '@dojo/framework/core/middleware/icache';
     -   将提供的 `value` 设置给指定的 `key`。如果 `value` 是一个函数，则将调用它以获取要缓存的实际值。如果函数返回的是 promise，则会先缓存一个“pending”值，直到解析出最终的值。在所有场景中，一旦一个值可用并存储到缓存中，该部件将被标记为无效，这样就可以使用最终的值重新渲染。
 -   `icache.has(key: any): boolean`
     -   根据 key 是否已在缓存中设置，来返回 `true` 或 `false`。
--   `icache.delete(key: any): void`
+-   `icache.delete(key: any, invalidate: boolean = true): void`
     -   从缓存中移除对应的项。
--   `clear()`
+-   `clear(invalidate: boolean = true)`
     -   清除当前在部件本地缓存中存储的所有值。
 
 可以使用两种方式为 `icache` 设置类型。一种方式是使用泛型来在调用的地方指定返回类型，对于 `getOrSet`，可以根据值类型推断出返回的类型，如果 `getOrSet` 的 `value` 是一个函数，则使用函数返回的类型推断出值类型。

--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -48,8 +48,8 @@ export interface ICacheResult<S = void> {
 		): void;
 	};
 	has<T extends void extends S ? any : keyof S>(key: void extends S ? any : T): boolean;
-	delete<T extends void extends S ? any : keyof S>(key: void extends S ? any : T): void;
-	clear(): void;
+	delete<T extends void extends S ? any : keyof S>(key: void extends S ? any : T, invalidate?: boolean): void;
+	clear(invalidate?: boolean): void;
 }
 
 export function createICacheMiddleware<S = void>() {
@@ -108,11 +108,13 @@ export function createICacheMiddleware<S = void>() {
 				has(key: any) {
 					return cacheMap.has(key);
 				},
-				delete(key: any) {
+				delete(key: any, invalidate = true) {
 					cacheMap.delete(key);
+					invalidate && invalidator();
 				},
-				clear(): void {
+				clear(invalidate = true): void {
 					cacheMap.clear();
+					invalidate && invalidator();
 				}
 			};
 		}

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -126,7 +126,7 @@ describe('icache middleware', () => {
 		});
 		icache.set('test', () => promiseOne);
 		assert.isUndefined(icache.get('test'));
-		invalidatorStub.notCalled;
+		assert.isTrue(invalidatorStub.notCalled);
 		resolverOne('value');
 		await promiseOne;
 
@@ -161,11 +161,15 @@ describe('icache middleware', () => {
 		assert.isUndefined(icache.get('test'));
 		icache.set('test', 'value');
 		icache.set('test-two', 'value');
+		assert.isTrue(invalidatorStub.calledTwice);
 		assert.strictEqual(icache.get('test'), 'value');
 		assert.strictEqual(icache.get('test-two'), 'value');
 		icache.delete('test');
+		assert.isTrue(invalidatorStub.calledThrice);
 		assert.isUndefined(icache.get('test'));
 		assert.strictEqual(icache.get('test-two'), 'value');
+		icache.delete('test', false);
+		assert.isTrue(invalidatorStub.calledThrice);
 	});
 
 	it('should be able to clear the cache', () => {
@@ -180,9 +184,13 @@ describe('icache middleware', () => {
 		});
 		assert.isUndefined(icache.get('test'));
 		icache.set('test', 'value');
+		assert.isTrue(invalidatorStub.calledOnce);
 		assert.strictEqual(icache.get('test'), 'value');
 		icache.clear();
+		assert.isTrue(invalidatorStub.calledTwice);
 		assert.isUndefined(icache.get('test'));
+		icache.clear(false);
+		assert.isTrue(invalidatorStub.calledTwice);
 	});
 
 	describe('icache factory', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Call `invalidate` for `delete` and `clear` `icache` APIs with an option to skip invalidation mirroring the `set` API

Resolves #663 
