### PR TITLE
Active link on query param matches

### DIFF
--- a/src/routing/ActiveLink.ts
+++ b/src/routing/ActiveLink.ts
@@ -55,7 +55,7 @@ export const ActiveLink = factory(function ActiveLink({
 			icache.set('handle', () => handle);
 		}
 		const context = router.getOutlet(to);
-		const isActive = context && paramsEqual(params, context.params);
+		const isActive = context && paramsEqual(params, { ...context.params, ...context.queryParams });
 		const contextIsExact = context && context.isExact();
 
 		classes = Array.isArray(classes) ? classes : [classes];

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -28,6 +28,10 @@ const router = new Router(
 			outlet: 'other'
 		},
 		{
+			path: 'query/{path}?{query}',
+			outlet: 'query'
+		},
+		{
 			path: 'param',
 			outlet: 'param',
 			children: [
@@ -68,6 +72,20 @@ describe('ActiveLink', () => {
 			middleware: [[getRegistry, mockGetRegistry]]
 		});
 		h.expect(() => w(Link, { classes: ['foo'], to: 'foo' }, ['hello']));
+	});
+
+	it('Should render the ActiveLink children when matching query params', () => {
+		router.setPath('/query/path?query=query');
+		const h = harness(
+			() =>
+				w(ActiveLink, { to: 'query', params: { path: 'path', query: 'query' }, activeClasses: ['foo'] }, [
+					'hello'
+				]),
+			{
+				middleware: [[getRegistry, mockGetRegistry]]
+			}
+		);
+		h.expect(() => w(Link, { classes: ['foo'], to: 'query', params: { path: 'path', query: 'query' } }, ['hello']));
 	});
 
 	it('Should mix the active class onto existing string class when the outlet is active', () => {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Include query params when checking if a link is considered active.

Resolves #697 
