### PR TITLE
Set total when side-loading data into a resource

### DIFF
--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -290,6 +290,7 @@ export function createResource<S>(config: DataTemplate<S>): Resource {
 		isLoading,
 		set(data: S[]) {
 			setData(0, data, data.length);
+			totalMap.set(getQueryKey(), data.length);
 		}
 	};
 }

--- a/tests/core/unit/resource.ts
+++ b/tests/core/unit/resource.ts
@@ -47,6 +47,15 @@ describe('resource', () => {
 		assert.deepEqual(resource.get({}), data);
 	});
 
+	it('sets the date and total when the set function is used to sideload data', () => {
+		const testData = [{ value: 1 }, { value: 2 }];
+		template.read.returns({ data: testData, total: 2 });
+		const resource = createResource(template);
+		resource.set(testData);
+		assert.deepEqual(resource.get({}), testData);
+		assert.equal(resource.getTotal({}), 2);
+	});
+
 	it('does not call read if the data is already present', () => {
 		template.read.returns({ data: [], total: 0 });
 		const resource = createResource(template);


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR fixes an issue where the data total was not being set when `set` was used to side-load the resource data. 

Resolves #700 
