### PR TITLE
Stop data transform from converting values to strings when not required

### DIFF
--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -128,11 +128,18 @@ function transformData<T>(item: any, transformConfig: TransformConfig<T>) {
 	Object.keys(transformConfig).forEach((key: string) => {
 		const sourceValues = transformConfig[key as keyof T];
 		if (sourceValues) {
-			const transformedValues: string[] = sourceValues.map((value) => item[value] || '');
-			transformedItem = {
-				...transformedItem,
-				[key]: transformedValues.join(' ')
-			};
+			if (sourceValues.length === 1) {
+				transformedItem = {
+					...transformedItem,
+					[key]: item[sourceValues[0]]
+				};
+			} else {
+				const transformedValues: string | undefined[] = sourceValues.map((value) => item[value]);
+				transformedItem = {
+					...transformedItem,
+					[key]: transformedValues.join(' ')
+				};
+			}
 		}
 	});
 	return transformedItem;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Checks to see if a single transform value is specified and if so copies rather than converting to a string and joining.

Resolves #702 
