### PR TITLE
Allow generic-ish properties for functional widgets

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -451,9 +451,12 @@ export interface MiddlewareResultFactory<Props, Children, Middleware, ReturnValu
 }
 
 export interface DefaultChildrenWNodeFactory<W extends WNodeFactoryTypes> {
-	(properties: W['properties'], children?: W['children'] extends any[] ? W['children'] : [W['children']]): WNode<W>;
-	new (): {
-		__properties__: W['properties'] & { __children__?: DNode | DNode[] | (DNode | DNode[])[] };
+	<V extends W['properties'] = W['properties']>(
+		properties: V,
+		children?: W['children'] extends any[] ? W['children'] : [W['children']]
+	): WNode<W>;
+	new <V extends W['properties'] = W['properties']>(): {
+		__properties__: V & { __children__?: DNode | DNode[] | (DNode | DNode[])[] };
 	};
 	properties: W['properties'];
 	children: W['children'];
@@ -461,14 +464,14 @@ export interface DefaultChildrenWNodeFactory<W extends WNodeFactoryTypes> {
 }
 
 export interface WNodeFactory<W extends WNodeFactoryTypes> {
-	(
-		properties: W['properties'],
+	<V extends W['properties'] = W['properties']>(
+		properties: V,
 		children: W['children'] extends [any]
 			? W['children'][0][]
 			: W['children'] extends any[] ? W['children'] : [W['children']]
 	): WNode<W>;
-	new (): {
-		__properties__: W['properties'] & { __children__: W['children'] };
+	new <V extends W['properties'] = W['properties']>(): {
+		__properties__: V & { __children__: W['children'] };
 	};
 	properties: W['properties'];
 	children: W['children'];
@@ -476,14 +479,14 @@ export interface WNodeFactory<W extends WNodeFactoryTypes> {
 }
 
 export interface OptionalWNodeFactory<W extends WNodeFactoryTypes> {
-	(
-		properties: W['properties'],
+	<V extends W['properties'] = W['properties']>(
+		properties: V,
 		children?: W['children'] extends [any]
 			? W['children'][0][]
 			: W['children'] extends any[] ? W['children'] : [W['children']]
 	): WNode<W>;
-	new (): {
-		__properties__: W['properties'] & { __children__?: W['children'] };
+	new <V extends W['properties'] = W['properties']>(): {
+		__properties__: V & { __children__?: W['children'] };
 	};
 	properties: W['properties'];
 	children: W['children'];


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
An attempt at resolving the issue of generic types for functional widgets. It's not ideal because you have to specify the entire interface again but it does allow you to narrow a generic down. I can't seem to think of a way to get more ideal typing to work without higher order types or creating the widget factory at at render which is obviously a nonstarter.

Resolves #679 
