### PR TITLE
Rename css to theme for ThemeWithVariant / ThemeWithVariants

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -129,12 +129,12 @@ export interface Variant {
 }
 
 export interface ThemeWithVariant {
-	css: Theme | ThemeWithVariants;
+	theme: Theme | ThemeWithVariants;
 	variant: Variant | string;
 }
 
 export interface ThemeWithVariants {
-	css: Theme;
+	theme: Theme;
 	variants: {
 		default: Variant;
 		[key: string]: Variant;

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -96,7 +96,7 @@ export const theme = factory(
 
 			if (currentTheme) {
 				if (isThemeWithVariants(theme)) {
-					theme = { css: theme.css, variant: theme.variants[`${variant || 'default'}`] };
+					theme = { theme: theme.theme, variant: theme.variants[`${variant || 'default'}`] };
 				}
 
 				currentTheme.set(theme);
@@ -115,7 +115,9 @@ export const theme = factory(
 				let { theme: currentTheme, classes: currentClasses } = properties();
 
 				if (currentTheme && isThemeWithVariant(currentTheme)) {
-					currentTheme = isThemeWithVariants(currentTheme.css) ? currentTheme.css.css : currentTheme.css;
+					currentTheme = isThemeWithVariants(currentTheme.theme)
+						? currentTheme.theme.theme
+						: currentTheme.theme;
 				}
 
 				if (currentTheme && currentTheme[key]) {
@@ -141,8 +143,8 @@ export const theme = factory(
 						return theme.variant.root;
 					}
 
-					if (isThemeWithVariants(theme.css)) {
-						return theme.css.variants[theme.variant].root;
+					if (isThemeWithVariants(theme.theme)) {
+						return theme.theme.variants[theme.variant].root;
 					}
 				}
 			},

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -235,7 +235,7 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 			let theme: Theme;
 
 			if (isThemeVariant(themeProp)) {
-				theme = isThemeVariantConfig(themeProp.css) ? themeProp.css.css : themeProp.css;
+				theme = isThemeVariantConfig(themeProp.theme) ? themeProp.theme.theme : themeProp.theme;
 			} else {
 				theme = themeProp;
 			}

--- a/tests/core/unit/middleware/theme.tsx
+++ b/tests/core/unit/middleware/theme.tsx
@@ -161,7 +161,7 @@ jsdomDescribe('theme middleware', () => {
 	it('returns theme variant class', () => {
 		const factory = create({ theme });
 		const themeWithVariant = {
-			css: {
+			theme: {
 				'test-key': {
 					root: 'themed-root'
 				}
@@ -184,7 +184,7 @@ jsdomDescribe('theme middleware', () => {
 	it('selects default variant theme with variants is set', () => {
 		const factory = create({ theme });
 		const themeWithVariants = {
-			css: {
+			theme: {
 				'test-key': {
 					root: 'themed-root'
 				}
@@ -219,7 +219,7 @@ jsdomDescribe('theme middleware', () => {
 	it('selects keyes variant theme with variants is set with variant key', () => {
 		const factory = create({ theme });
 		const themeWithVariants = {
-			css: {
+			theme: {
 				'test-key': {
 					root: 'themed-root'
 				}
@@ -257,7 +257,7 @@ jsdomDescribe('theme middleware', () => {
 	it('selects specific variant when passed', () => {
 		const factory = create({ theme });
 		const themeWithVariants = {
-			css: {
+			theme: {
 				'test-key': {
 					root: 'themed-root'
 				}
@@ -277,7 +277,7 @@ jsdomDescribe('theme middleware', () => {
 			return <div classes={variantRoot} />;
 		});
 		const root = document.createElement('div');
-		const r = renderer(() => <App theme={{ css: themeWithVariants, variant: themeWithVariants.variants.foo }} />);
+		const r = renderer(() => <App theme={{ theme: themeWithVariants, variant: themeWithVariants.variants.foo }} />);
 		r.mount({ domNode: root });
 		assert.strictEqual(root.innerHTML, '<div class="foo-variant-root"></div>');
 	});
@@ -285,7 +285,7 @@ jsdomDescribe('theme middleware', () => {
 	it('selects specific variant when key passed', () => {
 		const factory = create({ theme });
 		const themeWithVariants = {
-			css: {
+			theme: {
 				'test-key': {
 					root: 'themed-root'
 				}
@@ -305,7 +305,7 @@ jsdomDescribe('theme middleware', () => {
 			return <div classes={variantRoot} />;
 		});
 		const root = document.createElement('div');
-		const r = renderer(() => <App theme={{ css: themeWithVariants, variant: 'bar' }} />);
+		const r = renderer(() => <App theme={{ theme: themeWithVariants, variant: 'bar' }} />);
 		r.mount({ domNode: root });
 		assert.strictEqual(root.innerHTML, '<div class="bar-variant-root"></div>');
 	});


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Rename `css` to `theme` for the `ThemeWithVariant` / `ThemeWithVariants` interfaces.