### PR TITLE
Support setting variant through the theme injector

### DIFF
--- a/src/core/ThemeInjector.ts
+++ b/src/core/ThemeInjector.ts
@@ -1,0 +1,36 @@
+import { Theme, ThemeWithVariants, ThemeWithVariant, Variant } from './interfaces';
+import Injector from './Injector';
+
+function isThemeVariantConfig(theme: Theme | ThemeWithVariants | ThemeWithVariant): theme is ThemeWithVariants {
+	return theme.hasOwnProperty('variants');
+}
+
+function isVariantModule(variant: string | Variant): variant is Variant {
+	return typeof variant !== 'string';
+}
+
+function createThemeInjectorPayload(theme: Theme | ThemeWithVariants | ThemeWithVariant, variant?: string | Variant) {
+	if (isThemeVariantConfig(theme)) {
+		variant = variant || 'default';
+		if (isVariantModule(variant)) {
+			return { theme: theme.theme, variant };
+		}
+
+		return { theme: theme.theme, variant: theme.variants[variant] };
+	}
+	return theme;
+}
+
+export class ThemeInjector extends Injector {
+	constructor(theme?: Theme | ThemeWithVariants | ThemeWithVariant) {
+		theme = theme ? createThemeInjectorPayload(theme) : theme;
+		super(theme);
+	}
+
+	set<T extends ThemeWithVariants>(theme: T, variant?: keyof T['variants'] | Variant): void;
+	set(theme: ThemeWithVariant): void;
+	set(theme: Theme): void;
+	set(theme: Theme | ThemeWithVariants | ThemeWithVariant, variant?: string | Variant) {
+		super.set(createThemeInjectorPayload(theme, variant));
+	}
+}

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -121,7 +121,9 @@ export type ClassNames = {
 };
 
 export interface Theme {
-	[key: string]: object;
+	[key: string]: {
+		[key: string]: string;
+	};
 }
 
 export interface Variant {

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -91,8 +91,8 @@ export const theme = factory(
 		});
 
 		function set(theme: Theme): void;
-		function set<T extends ThemeWithVariants>(theme: T, variant?: keyof T['variants']): void;
-		function set<T extends ThemeWithVariants>(theme: Theme | T, variant?: keyof T['variants']): void {
+		function set<T extends ThemeWithVariants>(theme: T, variant?: keyof T['variants'] | Variant): void;
+		function set<T extends ThemeWithVariants>(theme: Theme | T, variant?: keyof T['variants'] | Variant): void {
 			const currentTheme = injector.get<ThemeInjector>(INJECTED_THEME_KEY);
 			if (currentTheme) {
 				if (isThemeWithVariants(theme)) {

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -14,6 +14,7 @@ import { inject } from './../decorators/inject';
 import { WidgetBase } from './../WidgetBase';
 import { handleDecorator } from './../decorators/handleDecorator';
 import { diffProperty } from './../decorators/diffProperty';
+import { ThemeInjector } from '../ThemeInjector';
 
 export { Theme, Classes, ClassNames } from './../interfaces';
 
@@ -37,7 +38,7 @@ function isThemeVariant(theme: Theme | ThemeWithVariant): theme is ThemeWithVari
 	return theme.hasOwnProperty('variant');
 }
 
-function isThemeVariantConfig(theme: Theme | ThemeWithVariants): theme is ThemeWithVariants {
+function isThemeVariantConfig(theme: Theme | ThemeWithVariants | ThemeWithVariant): theme is ThemeWithVariants {
 	return theme.hasOwnProperty('variants');
 }
 
@@ -92,8 +93,11 @@ function createThemeClassesLookup(classes: ClassNames[]): ClassNames {
  *
  * @returns the theme injector used to set the theme
  */
-export function registerThemeInjector(theme: Theme | ThemeWithVariant, themeRegistry: Registry): Injector {
-	const themeInjector = new Injector(theme);
+export function registerThemeInjector(
+	theme: Theme | ThemeWithVariants | ThemeWithVariant,
+	themeRegistry: Registry
+): ThemeInjector {
+	const themeInjector = new ThemeInjector(theme);
 	themeRegistry.defineInjector(INJECTED_THEME_KEY, (invalidator) => {
 		themeInjector.setInvalidator(invalidator);
 		return () => themeInjector;

--- a/tests/core/unit/mixins/Themed.ts
+++ b/tests/core/unit/mixins/Themed.ts
@@ -357,7 +357,7 @@ registerSuite('ThemedMixin', {
 		variants: {
 			'theme variant can be injected via a registry'() {
 				const themeWithVariant = {
-					css: {
+					theme: {
 						'test-key': {
 							root: 'themed-root'
 						}
@@ -387,7 +387,7 @@ registerSuite('ThemedMixin', {
 				};
 
 				const themeWithVariant = {
-					css: {
+					theme: {
 						'test-key': {
 							root: 'variant-themed-root'
 						}
@@ -413,9 +413,71 @@ registerSuite('ThemedMixin', {
 				renderResult = themedInstance.__render__() as VNode;
 				assert.deepEqual(renderResult.properties.classes, 'variant-root');
 			},
+			'should use default theme when set via theme context'() {
+				const themeWithVariants = {
+					theme: {
+						'test-key': {
+							root: 'variant-themed-root'
+						}
+					},
+					variants: {
+						default: {
+							root: 'variant-root'
+						},
+						red: {
+							root: 'red-root'
+						}
+					}
+				};
+
+				registerThemeInjector(themeWithVariants, testRegistry);
+				class InjectedTheme extends TestWidget {
+					render() {
+						return v('div', { classes: this.variant() });
+					}
+				}
+				const themedInstance = new InjectedTheme();
+				themedInstance.registry.base = testRegistry;
+				themedInstance.__setProperties__({});
+				let renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, 'variant-root');
+			},
+			'should use be able to choose variant via theme context'() {
+				const themeWithVariants = {
+					theme: {
+						'test-key': {
+							root: 'variant-themed-root'
+						}
+					},
+					variants: {
+						default: {
+							root: 'variant-root'
+						},
+						red: {
+							root: 'red-root'
+						}
+					}
+				};
+
+				const themeInjectorContext = registerThemeInjector(themeWithVariants, testRegistry);
+				class InjectedTheme extends TestWidget {
+					render() {
+						return v('div', { classes: this.variant() });
+					}
+				}
+				const themedInstance = new InjectedTheme();
+				themedInstance.registry.base = testRegistry;
+				themedInstance.__setProperties__({});
+				let renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, 'variant-root');
+				themeInjectorContext.set(themeWithVariants, 'red');
+				themedInstance.__setProperties__({});
+				renderResult = themedInstance.__render__() as VNode;
+				assert.deepEqual(renderResult.properties.classes, 'red-root');
+			},
 			'theme variant can be set at the widget level'() {
 				const themeWithVariant = {
-					css: {
+					theme: {
 						'test-key': {
 							root: 'themed-root'
 						}
@@ -440,7 +502,7 @@ registerSuite('ThemedMixin', {
 			},
 			'theme property overrides injected property'() {
 				const themeWithVariant = {
-					css: {
+					theme: {
 						'test-key': {
 							root: 'themed-root'
 						}
@@ -451,7 +513,7 @@ registerSuite('ThemedMixin', {
 				};
 
 				const secondThemeWithVariant = {
-					css: {
+					theme: {
 						'test-key': {
 							root: 'themed-root'
 						}
@@ -478,8 +540,8 @@ registerSuite('ThemedMixin', {
 			},
 			'can inject theme config with variants'() {
 				const themeWithVariantConfig = {
-					css: {
-						css: {
+					theme: {
+						theme: {
 							'test-key': {
 								root: 'themed-root'
 							}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support setting variants via the theme injector.