### PR TITLE
Bug: Widgets can render twice during a scheduled render

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -2205,8 +2205,8 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				if (widgetMeta.dirty) {
 					_idToChildrenWrappers.delete(id);
 					didRender = true;
-					widgetMeta.dirty = false;
 					rendered = Constructor(createWidgetOptions(id, id, widgetMeta.middleware));
+					widgetMeta.dirty = false;
 					if (widgetMeta.deferRefs > 0) {
 						rendered = null;
 					}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Widgets can end up rendering twice during a single scheduled render which can cause issues with the rendered dom and cause unnecessary processing. This happens when the widget and a parent of a widget is invalidated and ends up rendering due to a property changes or being marked as dirty - then during the render something marks the widget dirty again which means it's rendered again.

The widget should be marked as not dirty _after_ the render and not before.

codesandbox: https://codesandbox.io/s/dreamy-swartz-dco38
