### PR TITLE
Custom element slots

### DIFF
--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -247,15 +247,25 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 		}
 
 		public __children__() {
-			function wrap(node: WNode | VNode | (WNode | VNode)[]) {
-				function w() {
+			const wrap = (domNode: HTMLElement, node: WNode | VNode) => {
+				const w = (...args: any[]) => {
+					if (args.length) {
+						setTimeout(() => {
+							domNode.dispatchEvent(
+								new CustomEvent('render', {
+									bubbles: false,
+									detail: args
+								})
+							);
+						});
+					}
 					return node;
-				}
+				};
 
 				Object.keys(node).forEach((key) => ((w as any)[key] = (node as any)[key]));
 
 				return w;
-			}
+			};
 
 			if (this._children.some((child) => child.domNode.getAttribute && child.domNode.getAttribute('slot'))) {
 				const slots = this._children.reduce((slots, child) => {
@@ -268,6 +278,7 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 					}
 
 					let slotResult = wrap(
+						child.domNode,
 						child.domNode.isWidget
 							? w(child, { ...domNode.__properties__() }, [...domNode.__children__()])
 							: dom({ node: domNode, diffType: 'dom' })
@@ -296,10 +307,10 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 			if (this._childType === CustomElementChildType.DOJO) {
 				return this._children.filter((Child) => Child.domNode.isWidget).map((Child: any) => {
 					const { domNode } = Child;
-					return wrap(w(Child, { ...domNode.__properties__() }, [...domNode.__children__()]));
+					return wrap(domNode, w(Child, { ...domNode.__properties__() }, [...domNode.__children__()]));
 				});
 			} else {
-				return this._children.map(wrap);
+				return this._children.map((child) => wrap(child.domNode, child));
 			}
 		}
 

--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -281,10 +281,10 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 			if (this._childType === CustomElementChildType.DOJO) {
 				return this._children.filter((Child) => Child.domNode.isWidget).map((Child: any) => {
 					const { domNode } = Child;
-					return w(Child, { ...domNode.__properties__() }, [...domNode.__children__()]);
+					return wrap(w(Child, { ...domNode.__properties__() }, [...domNode.__children__()]));
 				});
 			} else {
-				return this._children;
+				return this._children.map(wrap);
 			}
 		}
 

--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -246,6 +246,25 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 		}
 
 		public __children__() {
+			if (this._children.some((child) => child.domNode.getAttribute && child.domNode.getAttribute('slot'))) {
+				return [
+					this._children.reduce((slots, child) => {
+						const { domNode } = child;
+
+						if (!domNode.getAttribute || !domNode.getAttribute('slot')) {
+							return slots;
+						}
+
+						return {
+							...slots,
+							[domNode.getAttribute('slot')]: child.domNode.isWidget
+								? w(child, { ...domNode.__properties__() }, [...domNode.__children__()])
+								: dom({ node: domNode, diffType: 'dom' })
+						};
+					}, {})
+				];
+			}
+
 			if (this._childType === CustomElementChildType.DOJO) {
 				return this._children.filter((Child) => Child.domNode.isWidget).map((Child: any) => {
 					const { domNode } = Child;

--- a/tests/core/support/util.ts
+++ b/tests/core/support/util.ts
@@ -4,6 +4,7 @@ import { stub, SinonStub } from 'sinon';
 export function createResolvers() {
 	let rAFStub: SinonStub;
 	let rICStub: SinonStub;
+	let timeoutStub: SinonStub;
 
 	function resolveRAFCallbacks() {
 		const calls = rAFStub.getCalls();
@@ -21,10 +22,21 @@ export function createResolvers() {
 		}
 	}
 
+	function resolveTimeoutCallbacks() {
+		if (timeoutStub) {
+			const calls = timeoutStub.getCalls();
+			timeoutStub.resetHistory();
+			for (let i = 0; i < calls.length; i++) {
+				calls[i].callArg(0);
+			}
+		}
+	}
+
 	return {
 		resolve() {
 			resolveRAFCallbacks();
 			resolveRICCallbacks();
+			resolveTimeoutCallbacks();
 		},
 		resolveRIC() {
 			resolveRICCallbacks();
@@ -36,6 +48,7 @@ export function createResolvers() {
 			rAFStub = stub(global, 'requestAnimationFrame').returns(1);
 			if (global.requestIdleCallback) {
 				rICStub = stub(global, 'requestIdleCallback').returns(1);
+				timeoutStub = stub(global, 'setTimeout').returns(1);
 			} else {
 				rICStub = stub(global, 'setTimeout').returns(1);
 			}
@@ -43,6 +56,10 @@ export function createResolvers() {
 		restore() {
 			rAFStub.restore();
 			rICStub.restore();
+
+			if (timeoutStub) {
+				timeoutStub.restore();
+			}
 		}
 	};
 }

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -740,9 +740,8 @@ describe('registerCustomElement', () => {
 		);
 	});
 
-	it('dispatches events when child render funcs have arguments', () => {
+	it('dispatches events when child render funcs have arguments', async () => {
 		const eventStub = stub();
-		const timeoutStub = stub(global, 'setTimeout').returns(1);
 
 		@customElement({
 			tag: 'dispatch-element',
@@ -776,13 +775,8 @@ describe('registerCustomElement', () => {
 		document.body.appendChild(element);
 
 		resolvers.resolve();
-
-		const calls = timeoutStub.getCalls();
-		for (let i = 0; i < calls.length; i++) {
-			calls[i].callArg(0);
-		}
-
-		timeoutStub.restore();
+		await new Promise((resolve) => setTimeout(resolve));
+		resolvers.resolve();
 
 		assert.strictEqual(
 			element.outerHTML,

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -659,4 +659,44 @@ describe('registerCustomElement', () => {
 			'<render-func-element style="display: block;"><div><label>test</label></div></render-func-element>'
 		);
 	});
+
+	it('combines children with the same slot name into an array', () => {
+		@customElement({
+			tag: 'slot-array-element',
+			properties: [],
+			attributes: [],
+			events: []
+		})
+		class WidgetA extends WidgetBase<any> {
+			render() {
+				const child: any = this.children[0];
+
+				return v('div', {}, [child.foo]);
+			}
+		}
+
+		const CustomElement = create((WidgetA as any).__customElementDescriptor, WidgetA);
+
+		customElements.define('slot-array-element', CustomElement);
+
+		const element = document.createElement('slot-array-element');
+
+		const slotChild1 = document.createElement('label');
+		slotChild1.setAttribute('slot', 'foo');
+		slotChild1.innerHTML = 'test1';
+		const slotChild2 = document.createElement('label');
+		slotChild2.setAttribute('slot', 'foo');
+		slotChild2.innerHTML = 'test2';
+
+		element.appendChild(slotChild1);
+		element.appendChild(slotChild2);
+		document.body.appendChild(element);
+
+		resolvers.resolve();
+
+		assert.strictEqual(
+			element.outerHTML,
+			'<render-func-element style="display: block;"><div><label>test1</label><label>test2</label></div></render-func-element>'
+		);
+	});
 });

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -581,7 +581,7 @@ describe('registerCustomElement', () => {
 
 				return v('div', {}, [
 					v('div', { classes: ['a-slot'] }, [child && (child as any).a]),
-					v('div', { classes: ['b-slot'] }, [child && (child as any).b])
+					v('div', { classes: ['b-slot'] }, [child && (child as any).b && (child as any).b()])
 				]);
 			}
 		}

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -775,8 +775,7 @@ describe('registerCustomElement', () => {
 		document.body.appendChild(element);
 
 		resolvers.resolve();
-		await new Promise((resolve) => setTimeout(resolve));
-		resolvers.resolve();
+		await Promise.resolve();
 
 		assert.strictEqual(
 			element.outerHTML,

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -671,7 +671,7 @@ describe('registerCustomElement', () => {
 			render() {
 				const child: any = this.children[0];
 
-				return v('div', {}, [child.foo]);
+				return v('div', {}, child.foo);
 			}
 		}
 
@@ -696,7 +696,7 @@ describe('registerCustomElement', () => {
 
 		assert.strictEqual(
 			element.outerHTML,
-			'<render-func-element style="display: block;"><div><label>test1</label><label>test2</label></div></render-func-element>'
+			'<slot-array-element style="display: block;"><div><label slot="foo">test1</label><label slot="foo">test2</label></div></slot-array-element>'
 		);
 	});
 });

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -774,8 +774,10 @@ describe('registerCustomElement', () => {
 		element.appendChild(slotChild1);
 		document.body.appendChild(element);
 
+		// this one to render
 		resolvers.resolve();
-		await Promise.resolve();
+		// this one to call the event dispatch
+		resolvers.resolve();
 
 		assert.strictEqual(
 			element.outerHTML,

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -699,4 +699,43 @@ describe('registerCustomElement', () => {
 			'<slot-array-element style="display: block;"><div><label slot="foo">test1</label><label slot="foo">test2</label></div></slot-array-element>'
 		);
 	});
+
+	it('ignores elements with no slots when at least one element has a slot', () => {
+		@customElement({
+			tag: 'ignore-slot-element',
+			properties: [],
+			attributes: [],
+			events: []
+		})
+		class WidgetA extends WidgetBase<any> {
+			render() {
+				const child: any = this.children[0];
+
+				return v('div', {}, [child.foo]);
+			}
+		}
+
+		const CustomElement = create((WidgetA as any).__customElementDescriptor, WidgetA);
+
+		customElements.define('ignore-slot-element', CustomElement);
+
+		const element = document.createElement('ignore-slot-element');
+
+		const slotChild1 = document.createElement('label');
+		slotChild1.setAttribute('slot', 'foo');
+		slotChild1.innerHTML = 'test1';
+		const slotChild2 = document.createElement('label');
+		slotChild2.innerHTML = 'test2';
+
+		element.appendChild(slotChild1);
+		element.appendChild(slotChild2);
+		document.body.appendChild(element);
+
+		resolvers.resolve();
+
+		assert.strictEqual(
+			element.outerHTML,
+			'<ignore-slot-element style="display: inline;"><label>test2</label><div><label slot="foo">test1</label></div></ignore-slot-element>'
+		);
+	});
 });

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -624,4 +624,39 @@ describe('registerCustomElement', () => {
 			'<parent-element style="display: block;"><div><div class="a-slot"><div slot="a">test</div></div><div class="b-slot"><slot-b-element slot="b">WidgetB</slot-b-element></div></div></parent-element>'
 		);
 	});
+
+	it('wraps child nodes in render functions', () => {
+		@customElement({
+			tag: 'render-func-element',
+			properties: [],
+			attributes: [],
+			events: []
+		})
+		class WidgetA extends WidgetBase<any> {
+			render() {
+				const child: any = this.children[0];
+
+				return v('div', {}, [child && child()]);
+			}
+		}
+
+		const CustomElement = create((WidgetA as any).__customElementDescriptor, WidgetA);
+
+		customElements.define('render-func-element', CustomElement);
+
+		const element = document.createElement('render-func-element');
+
+		const slotChild = document.createElement('label');
+		slotChild.innerHTML = 'test';
+
+		element.appendChild(slotChild);
+		document.body.appendChild(element);
+
+		resolvers.resolve();
+
+		assert.strictEqual(
+			element.outerHTML,
+			'<render-func-element style="display: block;"><div><label>test</label></div></render-func-element>'
+		);
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding custom element support for (some) child functions.  

The following scenarios are supported now,

## Render Func

### Dojo
```tsx
<Foo>
    { () => <Bar /> }
</Foo>
```

### Custom Elements

```html
<element-foo>
    <element-bar></element-bar>
</element-foo>
```

## Named Renders

### Dojo

```tsx
<Foo>
    {{ 
      bar: <Bar />, 
      qux: [<Qux />, <Qux />]
    }}
</Foo>
```

### Custom Elements

```html
<element-foo>
    <element-bar slot="bar"></element-bar>
    <element-qux slot="qux"></element-qux>
    <element-qux slot="qux"></element-qux>
</element-foo>
```

## Named Render Funcs

### Dojo

```tsx
<Foo>
    {{ 
      bar: () => <Bar />, 
      qux: () => <Qux /> 
    }}
</Foo>
```

### Custom Elements

```html
<element-foo>
    <element-bar slot="bar"></element-bar>
    <element-qux slot="qux"></element-qux>
</element-foo>
```

## Render Funcs with parameters

### Dojo

```tsx
<Foo>
{{
    bar: (active) => <Bar active={active} />
}}
</Foo>
```

### Custom Elements

```html
<element-foo>
    <element-bar id="bar" slot="bar"></element-bar>
</element-foo>

<script>
bar.addEventListener('render', function ({ detail: [active]}) {
    this.active = active;
});
</script>
```

Resolves #708 
