### PR TITLE
Support rendering multiple routes to an Outlet

### DIFF
--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -275,7 +275,7 @@ To take advantage of the code splitting there are 4 rules:
 1.  The routing configuration needs to be the default export in the `src/routes.ts` module.
 2.  The widgets must be the default export of their module.
 3.  The `renderer` property must be defined inline.
-4.  The `id` and `outlet` in the routing config and must be static and defined inline.
+4.  The `id` and `outlet` in the routing config must be static and defined inline.
 
 > src/routes.ts
 

--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -112,7 +112,7 @@ Path parameters are placeholders in the routing configuration that will match an
 ```ts
 export default [
 	{
-		id: 'home,
+		id: 'home',
 		path: 'home/{page}',
 		outlet: 'home'
 	}

--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -77,7 +77,7 @@ export default factory(function App() {
 });
 ```
 
-or using outlets and the `Outlet` widget, check out the [`Outlet` documentation](/learn/routing/outlets) for more information;
+or using outlets and the `Outlet` widget, check out the [`Outlet` documentation](/learn/routing/outlets) for more information:
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';

--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -56,7 +56,7 @@ const r = renderer(() => <App />);
 r.mount({ registry });
 ```
 
--   Add a `Route` widget to show the text "Home" when the `home` route is visited. `Route` is a widget that display something when the path for the route id is matched. The application's `src/routes.ts` file associates a route to an id via the `Route`'s `id` property.
+-   Add a `Route` widget to show the text "Home" when the `home` route is visited. `Route` is a widget that displays something when the path for the route id is matched. The application's `src/routes.ts` file associates a route to an id via the `Route`'s `id` property.
 
 > src/App.tsx
 
@@ -119,7 +119,7 @@ export default [
 ];
 ```
 
-The parameters values are injected into to matching `Route`'s `renderer` property.
+The parameter values are injected into the matching `Route`'s `renderer` property.
 
 > src/App.tsx
 
@@ -214,7 +214,7 @@ export default [
 
 ## Using link widgets
 
-The `Link` widget is a wrapper around an anchor tag that enables consumers to specify an route `id` to create a link to. If the generated link requires specific path or query parameters that are not in the route, they can be passed via the `params` property.
+The `Link` widget is a wrapper around an anchor tag that enables consumers to specify a route `id` to create a link to. If the generated link requires specific path or query parameters that are not in the route, they can be passed via the `params` property.
 
 Link Properties:
 

--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -12,15 +12,16 @@ Dojo's Routing package provides a first class declarative routing solution for w
 
 ## Adding routing to an application
 
--   Add an initial route configuration that defines a single url path that maps to an identifier referred to as an `outlet`. Outlets will be described later in the documentation.
+-   Add an initial route configuration that defines a single url path that maps to a route identifier and an `outlet` name.
 
 > src/routes.ts
 
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
-		outlet: 'home'
+		outlet: 'main'
 	}
 ];
 ```
@@ -45,20 +46,20 @@ const r = renderer(() => <App />);
 r.mount({ registry });
 ```
 
--   Add an `outlet` widget to show the text "Home" when the `home` route is visited. Outlets are widgets that display something when a route is matched. The application's `src/routes.ts` file associates a route to an outlet via the outlet's `id` property.
+-   Add a `Route` widget to show the text "Home" when the `home` route is visited. `Route` is a widget that display something when the path for the route id is matched. The application's `src/routes.ts` file associates a route to an id via the `Route`'s `id` property.
 
 > src/App.tsx
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Outlet from '@dojo/framework/routing/Outlet';
+import Route from '@dojo/framework/routing/Route';
 
 const factory = create();
 
 export default factory(function App() {
 	return (
 		<div>
-			<Outlet id="home" renderer={() => <div>Home</div>} />
+			<Route id="home" renderer={() => <div>Home</div>} />
 		</div>
 	);
 });
@@ -76,26 +77,27 @@ Path parameters are placeholders in the routing configuration that will match an
 ```ts
 export default [
 	{
+		id: 'home,
 		path: 'home/{page}',
 		outlet: 'home'
 	}
 ];
 ```
 
-The parameters values are injected into to matching `Outlets`'s `renderer` property.
+The parameters values are injected into to matching `Route`'s `renderer` property.
 
 > src/App.tsx
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Outlet from '@dojo/framework/routing/Outlet';
+import Route from '@dojo/framework/routing/Route';
 
 const factory = create();
 
 export default factory(function App() {
 	return (
 		<div>
-			<Outlet id="home" renderer={(matchDetails) => <div>{`Home ${matchDetails.params.page}`}</div>} />
+			<Route id="home" renderer={(matchDetails) => <div>{`Home ${matchDetails.params.page}`}</div>} />
 		</div>
 	);
 });
@@ -108,7 +110,8 @@ Query parameters can also be added to route URLs. As with normal query parameter
 ```ts
 export default [
 	{
-		path: 'home/{page}',
+		id: 'home',
+		path: 'home/{page}?{queryOne}&{queryTwo}',
 		outlet: 'home'
 	}
 ];
@@ -118,14 +121,14 @@ export default [
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Outlet from '@dojo/framework/routing/Outlet';
+import Route from '@dojo/framework/routing/Route';
 
 const factory = create();
 
 export default factory(function App() {
 	return (
 		<div>
-			<Outlet
+			<Route
 				id="home"
 				renderer={(matchDetails) => {
 					const { queryParams } = matchDetails;
@@ -137,7 +140,7 @@ export default factory(function App() {
 });
 ```
 
-If the browser is pointed to the URL path `/home/page?queryOne=modern&queryTwo=dojo`, then the query parameters are injected into the matching `Outlet`'s `renderer` method as an object of type `MatchDetails` and accessed via that object's `queryParams` property. Using this URL, the page would show "Hello modern-dojo". If a query parameter is not provided, then its value will be set to `undefined`.
+If the browser is pointed to the URL path `/home/page?queryOne=modern&queryTwo=dojo`, then the query parameters are injected into the matching `Route`'s `renderer` method as an object of type `MatchDetails` and accessed via that object's `queryParams` property. Using this URL, the page would show "Hello modern-dojo". If a query parameter is not provided, then its value will be set to `undefined`.
 
 ## Default route and parameters
 
@@ -148,6 +151,7 @@ If the browser is pointed to the URL path `/home/page?queryOne=modern&queryTwo=d
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
 		outlet: 'home',
 		defaultRoute: true
@@ -162,6 +166,7 @@ If the default route has path or query parameters a map of defaults need to be s
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home/{page}',
 		outlet: 'home',
 		defaultRoute: true,
@@ -174,12 +179,12 @@ export default [
 
 ## Using link widgets
 
-The `Link` widget is a wrapper around an anchor tag that enables consumers to specify an `outlet` to create a link to. If the generated link requires specific path or query parameters that are not in the route, they can be passed via the `params` property.
+The `Link` widget is a wrapper around an anchor tag that enables consumers to specify an route `id` to create a link to. If the generated link requires specific path or query parameters that are not in the route, they can be passed via the `params` property.
 
 Link Properties:
 
--   `to: string`: The `outlet` id.
--   `params: { [index: string]: string }`: Params to generate the link with for the outlet.
+-   `to: string`: The `route` id.
+-   `params: { [index: string]: string }`: Params to generate the link with for the route.
 -   `onClick: (event: MouseEvent) => void` (optional): Function that gets called when the `Link` is clicked.
 
 In addition to the `Link` specific properties, all the standard `VNodeProperties` are available for the `Link` widget as they would be creating an anchor tag.
@@ -207,7 +212,7 @@ The `ActiveLink` widget is a wrapper around the `Link` widget that conditionally
 
 ActiveLink Properties:
 
--   `activeClasses: string[]`: An array of classes to apply when the `Link`'s outlet is matched.
+-   `activeClasses: string[]`: An array of classes to apply when the `Link`'s route is matched.
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -228,51 +233,56 @@ export default factory(function App() {
 
 ## Code splitting by route
 
-When using `@dojo/cli-build-app`, Dojo supports automatic code splitting by default for all top level outlets. This means that all widgets referenced within the `Outlet`s `renderer` will include a specific bundle for the outlet that will be loaded lazily when a user accesses the route.
+When using `@dojo/cli-build-app`, Dojo supports automatic code splitting by default for all top level routes. This means that all widgets referenced within the `Route`s `renderer` will include a specific bundle for the route that will be loaded lazily when a user accesses the route.
 
 To take advantage of the code splitting there are 4 rules:
 
 1.  The routing configuration needs to be the default export in the `src/routes.ts` module.
 2.  The widgets must be the default export of their module.
 3.  The `renderer` property must be defined inline.
-4.  The outlet `id` must be static and defined inline.
+4.  The `id` and `outlet` in the routing config and must be static and defined inline.
 
 > src/routes.ts
 
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
 		outlet: 'home'
 	},
 	{
+		id: 'about',
 		path: 'about',
 		outlet: 'about',
 		children: [
 			{
+				id: 'company',
 				path: 'company',
 				outlet: 'about-company'
 			}
 		]
 	},
 	{
+		id: 'profile',
 		path: 'profile',
 		outlet: 'profile'
 	},
 	{
+		id: 'settings',
 		path: 'settings',
 		outlet: 'settings'
 	}
 ];
 ```
 
-With the routing configuration above the following example will generate 4 separate bundles for each of the widgets returned in the `Outlet`'s renderer, `Home`, `About`, `Profile` and `Settings`.
+With the routing configuration above the following example will generate 4 separate bundles for each of the widgets returned in the `Route`'s renderer, `Home`, `About`, `Profile` and `Settings`.
 
 > src/App.tsx
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Outlet from '@dojo/framework/routing/Outlet';
+import Route from '@dojo/framework/routing/Route';
 
 import Home from './Home';
 import About from './About';
@@ -284,10 +294,10 @@ const factory = create();
 export default factory(function App() {
 	return (
 		<div>
-			<Outlet id="home" renderer={() => <Home />} />
-			<Outlet id="about" renderer={() => <About />} />
-			<Outlet id="profile" renderer={() => <Profile />} />
-			<Outlet id="settings" renderer={() => <Settings />} />
+			<Route id="home" renderer={() => <Home />} />
+			<Route id="about" renderer={() => <About />} />
+			<Route id="profile" renderer={() => <Profile />} />
+			<Route id="settings" renderer={() => <Settings />} />
 		</div>
 	);
 });

--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -22,6 +22,16 @@ export default [
 		id: 'home',
 		path: 'home',
 		outlet: 'main'
+	},
+	{
+		id: 'about',
+		path: 'about',
+		outlet: 'main'
+	},
+	{
+		id: 'profile',
+		path: 'profile',
+		outlet: 'main'
 	}
 ];
 ```
@@ -60,6 +70,31 @@ export default factory(function App() {
 	return (
 		<div>
 			<Route id="home" renderer={() => <div>Home</div>} />
+			<Route id="about" renderer={() => <div>About</div>} />
+			<Route id="profile" renderer={() => <div>Profile</div>} />
+		</div>
+	);
+});
+```
+
+or using outlets and the `Outlet` widget, check out the [`Outlet` documentation](/learn/routing/outlets) for more information;
+
+```tsx
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Outlet from '@dojo/framework/routing/Outlet';
+
+const factory = create();
+
+export default factory(function App() {
+	return (
+		<div>
+			<Outlet id="main">
+				{{
+					home: <div>Home</div>,
+					about: <div>About</div>,
+					profile: <div>Profile</div>
+				}}
+			</Outlet>
 		</div>
 	);
 });

--- a/docs/en/routing/supplemental.md
+++ b/docs/en/routing/supplemental.md
@@ -59,6 +59,103 @@ This example would register the following paths and route ids:
 
 The `about-services` route has been registered to match any path after `/about` This is at odds with the other registered routes, `about-company` and `about-history`, however Dojo routing ensures that the correct routes is matched in these scenarios.
 
+# Outlets
+
+An outlet represents a visual location of an application that renderers different content depending which route has been matched. Using outlets reduces boilerplate required compared to using routes, multiple routes can be associated to the same outlet to more naturally and accurately structure the application output.
+
+Consider a typical application layout which includes a left side menu and a main content view that depending on the route has a right hand side bar:
+
+```
+-------------------------------------------------------------------
+|        |                                            |           |
+|        |                                            |           |
+|        |                                            |           |
+|        |                                            |           |
+|        |                                            |           |
+|  menu  |                   main                     | side-menu |
+|        |                                            |           |
+|        |                                            |           |
+|        |                                            |           |
+|        |                                            |           |
+|        |                                            |           |
+-------------------------------------------------------------------
+```
+
+With a route configuration below that specifies all the main pages to the main content outlet, but the `widget` to a `side-menu` outlet. This enables building an application that constantly renders the main content depending on route, but also include a right hand side menu for all children routes of the `widget` route.
+
+```tsx
+const routes = [
+	{
+		id: 'landing',
+		path: '/',
+		outlet: 'main',
+		defaultRoute: true
+	},
+	{
+		id: 'widget',
+		path: 'widget/{widget}',
+		outlet: 'side-menu',
+		children: [
+			{
+				id: 'tests',
+				path: 'tests',
+				outlet: 'main'
+			},
+			{
+				id: 'overview',
+				path: 'overview',
+				outlet: 'main'
+			},
+			{
+				id: 'example'
+				path: 'example/{example}',
+				outlet: 'main'
+			}
+		]
+	}
+];
+```
+
+In the routing configuration above, there are two outlets defined, `main` and `side-menu` and a simplified application layout using outlets is shown below. By default the `Outlet` will render any of the keys that equal a route id that has been match for the outlet, in this case `main`. If a function is passed to the `Outlet` then it will render whenever _any_ route is matched for the outlet specified.
+
+```tsx
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Outlet from '@dojo/framework/routing/Outlet';
+
+import Menu from './Menu';
+import SideMenu from './SideMenu';
+import Landing from './Landing';
+import Tests from './Tests';
+import Example from './Example';
+
+const factory = create();
+
+const App = factory(function App() {
+	return (
+		<div>
+			<Menu />
+			<main>
+				<div>
+					<Outlet id="main">
+						{{
+							landing: <Landing />,
+							tests: <Tests />,
+							example: ({ params: { example }}) => <Example example={example}/>,
+							overview: <Example example="overview"/>
+						}}
+					</Outlet>
+				</div>
+				<div>
+					<Outlet id="side-menu">
+						{({ params: { widget }}) => <SideMenu widget={widget}>}
+					</Outlet>
+				</div>
+			</main>
+		</div>
+	);
+});
+```
+
 # Router API
 
 The Dojo Router exposes an API that can be used to generate and navigate to links, get the params for the current route and check if an route id has been matched.

--- a/docs/en/routing/supplemental.md
+++ b/docs/en/routing/supplemental.md
@@ -61,7 +61,7 @@ The `about-services` route has been registered to match any path after `/about` 
 
 # Outlets
 
-An outlet represents a visual location of an application that renderers different content depending which route has been matched. Using outlets reduces boilerplate required compared to using routes, multiple routes can be associated to the same outlet to more naturally and accurately structure the application output.
+An outlet represents a visual location of an application that renderers different content depending on which route has been matched. Using outlets reduces boilerplate required compared to using routes, multiple routes can be associated to the same outlet to more naturally and accurately structure the application output.
 
 Consider a typical application layout which includes a left side menu and a main content view that depending on the route has a right hand side bar:
 
@@ -81,7 +81,7 @@ Consider a typical application layout which includes a left side menu and a main
 -------------------------------------------------------------------
 ```
 
-With a route configuration below that specifies all the main pages to the main content outlet, but the `widget` to a `side-menu` outlet. This enables building an application that constantly renders the main content depending on route, but also include a right hand side menu for all children routes of the `widget` route.
+The route configuration below specifies all the main pages to the main content outlet, but the `widget` to a `side-menu` outlet. This enables building an application that constantly renders the main content depending on route, but also include a right hand side menu for all children routes of the `widget` route.
 
 ```tsx
 const routes = [
@@ -116,7 +116,7 @@ const routes = [
 ];
 ```
 
-In the routing configuration above, there are two outlets defined, `main` and `side-menu` and a simplified application layout using outlets is shown below. By default the `Outlet` will render any of the keys that equal a route id that has been match for the outlet, in this case `main`. If a function is passed to the `Outlet` then it will render whenever _any_ route is matched for the outlet specified.
+In the routing configuration above, there are two outlets defined, `main` and `side-menu`, and a simplified application layout using outlets is shown below. By default the `Outlet` will render any of the keys that equal a route id that has been matched for the outlet, in this case `main`. If a function is passed to the `Outlet` then it will render whenever _any_ route is matched for the outlet specified.
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -156,7 +156,7 @@ const App = factory(function App() {
 });
 ```
 
-The node structure of the `App` looks good and succinctly represents the actual visual output for the user with minimal duplication, there still is a need to duplicate the the usage of the `Example` widget across to different routes. This can be solved by using the `matcher` property to override the default route matching rules. The `matcher` receives the `defaultMatches` and a `matchDetailsMap` in order to make custom matching decisions. In the final example below the usage of `Example` has been combined into a new `key`, `details` that does not exist as a route. This will never match for the outlet unless we override the default matches to set it to true when either the `example` or `overview` route has matched. Finally in the `details` renderer the example property has been defaulted to `overview` to maintain the same behavior as before.
+The node structure of the `App` looks good and succinctly represents the actual visual output for the user with minimal duplication, there still is a need to duplicate the usage of the `Example` widget across to different routes. This can be solved by using the `matcher` property to override the default route matching rules. The `matcher` receives the `defaultMatches` and a `matchDetailsMap` in order to make custom matching decisions. In the final example below the usage of `Example` has been combined into a new `key`, `details` that does not exist as a route. This will never match for the outlet unless we override the default matches to set it to true when either the `example` or `overview` route has matched. Finally in the `details` renderer the example property has been defaulted to `overview` to maintain the same behavior as before.
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -200,12 +200,12 @@ const App = factory(function App() {
 
 # Router API
 
-The Dojo Router exposes an API that can be used to generate and navigate to links, get the params for the current route and check if an route id has been matched.
+The Dojo Router exposes an API that can be used to generate and navigate to links, get the params for the current route and check if a route id has been matched.
 
 -   `link(route: string, params: Params = {}): string | undefined`: Generate a link based on the route id and optionally params. If no params are passed it will attempt to use the current routes parameters, then any default parameters provided in the routing configuration. If a link cannot be generated, `undefined` is returned.
 -   `setPath(path: string): void`: Sets the path in the router.
 -   `get currentParams(): { [string: index]: string }`: Returns parameters in the current route
--   `getRoute(id: string): RouteContext | undefined`: Returns the `RouteContext` for an route id if it is currently matched. If the route id is not matched, then return `undefined`.
+-   `getRoute(id: string): RouteContext | undefined`: Returns the `RouteContext` for a route id if it is currently matched. If the route id is not matched, then return `undefined`.
 
 ## Generating a link for a route
 
@@ -408,7 +408,7 @@ export default [
 ];
 ```
 
--   given the above route definition, if the URL path is set to `/#home/about`, then `isExact()` will evaluate to `false` for the `Route` with the id "home" and `true` for the an `Route` that is a child of the home `Route` with the id "about" as shown in the following file:
+-   given the above route definition, if the URL path is set to `/#home/about`, then `isExact()` will evaluate to `false` for the `Route` with the id "home" and `true` for a `Route` that is a child of the home `Route` with the id "about" as shown in the following file:
 
 > src/App.tsx
 
@@ -661,7 +661,7 @@ These history managers work like adapters, meaning that custom history managers 
 
 # Error route
 
-A special `route` called `errorRoute` is registered for that will match when the route doesn't match (`exact` or `partial`) any route in the routing configuration. You can use this `route` to render a widget to inform the user that the route does not exist.
+A special `route` called `errorRoute` is registered that will match when the route doesn't match (`exact` or `partial`) any route in the routing configuration. You can use this `route` to render a widget to inform the user that the route does not exist.
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';

--- a/docs/en/routing/supplemental.md
+++ b/docs/en/routing/supplemental.md
@@ -1,11 +1,12 @@
 # Route configuration
 
-The routing configuration is a hierarchical structure used to describe the entire Dojo application, associating `outlet` ids to a routing path. The routing path can be nested using children which enables building a routing structure that can accurately reflect the requirements of the application.
+The routing configuration is a hierarchical structure used to describe the entire Dojo application, associating `id`s and `outlet`s to a routing path. The routing path can be nested using children which enables building a routing structure that can accurately reflect the requirements of the application.
 
 The routing configuration API is constructed with the following properties:
 
+-   `id: string`: The unique id of the route.
 -   `path: string`: The routing path segment to match in the URL.
--   `outlet: string`: The `outlet` id used to render widgets to the associated routing path.
+-   `outlet: string`: The `outlet` name for the route. This is used by the `Outlet` widget to determine what needs to be rendered.
 -   `defaultRoute: boolean` (optional): Marks the outlet as default, the application will redirect to this route automatically if no route or an unknown route is found on application load.
 -   `defaultParams: { [index: string]: string }` (optional): Associated default parameters (`path` and `query`), required if the default route has required params.
 -   `children: RouteConfig[]` (optional): Nested child routing configuration.
@@ -15,34 +16,39 @@ The routing configuration API is constructed with the following properties:
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
 		outlet: 'home',
 		defaultRoute: true
 	},
 	{
+		id: 'about',
 		path: 'about',
 		outlet: 'about-overview',
 		children: [
 			{
+				id: 'about-services',
 				path: '{services}',
-				outlet: 'about-services'
+				outlet: 'about'
 			},
 			{
+				id: 'about-company',
 				path: 'company',
-				outlet: 'about-company'
+				outlet: 'about'
 			},
 			{
+				id: 'about-history',
 				path: 'history',
-				outlet: 'about-history'
+				outlet: 'about'
 			}
 		]
 	}
 ];
 ```
 
-This example would register the following routes and outlets:
+This example would register the following paths and route ids:
 
-| URL Path          | Outlet           |
+| URL Path          | Route            |
 | ----------------- | ---------------- |
 | `/home`           | `home`           |
 | `/about`          | `about-overview` |
@@ -51,45 +57,50 @@ This example would register the following routes and outlets:
 | `/about/knitting` | `about-services` |
 | `/about/sewing`   | `about-services` |
 
-The `about-services` outlet has been registered to match any path after `/about` This is at odds with the other registered outlets, `about-company` and `about-history`, however Dojo routing ensures that the correct outlet is matched in these scenarios.
+The `about-services` route has been registered to match any path after `/about` This is at odds with the other registered routes, `about-company` and `about-history`, however Dojo routing ensures that the correct routes is matched in these scenarios.
 
 # Router API
 
-The Dojo Router exposes an API that can be used to generate and navigate to links, get the params for the current route and check if an outlet id has been matched.
+The Dojo Router exposes an API that can be used to generate and navigate to links, get the params for the current route and check if an route id has been matched.
 
--   `link(outlet: string, params: Params = {}): string | undefined`: Generate a link based on the outlet id and optionally params. If no params are passed it will attempt to use the current routes parameters, then any default parameters provided in the routing configuration. If a link cannot be generated, `undefined` is returned.
+-   `link(route: string, params: Params = {}): string | undefined`: Generate a link based on the route id and optionally params. If no params are passed it will attempt to use the current routes parameters, then any default parameters provided in the routing configuration. If a link cannot be generated, `undefined` is returned.
 -   `setPath(path: string): void`: Sets the path in the router.
 -   `get currentParams(): { [string: index]: string }`: Returns parameters in the current route
--   `getOutlet(outletIdentifier: string): OutletContext | undefined`: Returns the `OutletContext` for an outlet id if it is currently matched. If the outlet id is not matched, then return `undefined`.
+-   `getRoute(id: string): RouteContext | undefined`: Returns the `RouteContext` for an route id if it is currently matched. If the route id is not matched, then return `undefined`.
 
-## Generating a link for an outlet
+## Generating a link for a route
 
 > src/routes.ts
 
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
 		outlet: 'home'
 	},
 	{
+		id: 'about',
 		path: 'about',
 		outlet: 'about-overview',
 		children: [
 			{
+				id: 'about-services',
 				path: '{services}',
-				outlet: 'about-services',
+				outlet: 'about',
 				defaultParams: {
 					services: 'sewing'
 				}
 			},
 			{
+				id: 'about-company',
 				path: 'company',
-				outlet: 'about-company'
+				outlet: 'about'
 			},
 			{
+				id: 'about-history',
 				path: 'history',
-				outlet: 'about-history'
+				outlet: 'about'
 			}
 		]
 	}
@@ -155,17 +166,18 @@ const router = new Router(routes);
 const params = router.currentParams;
 ```
 
-## Get a matched outlet
+## Get a matched route
 
-Use the `getOutlet` to return the `OutletContext` for a matched outlet, or `undefined` if the outlet is not matched.
+Use the `getRoute` to return the `RouteContext` for a matched route id, or `undefined` if the route id's path is not matched.
 
-`OutletContext`:
+`RouteContext`:
 
--   `id: string`: The outlet id
+-   `id: string`: The route id
+-   `outlet: string`: The outlet id
 -   `queryParams: { [index: string]: string }`: The query params from the matched routing.
 -   `params: { [index: string]: string }`: The path params from the matched routing.
--   `isExact(): boolean`: A function indicates if the outlet is an exact match for the path.
--   `isError(): boolean`: A function indicates if the outlet is an error match for the path.
+-   `isExact(): boolean`: A function indicates if the route is an exact match for the path.
+-   `isError(): boolean`: A function indicates if the route is an error match for the path.
 -   `type: 'index' | 'partial' | 'error'`: The type of match for the route, either `index`, `partial` or `error`.
 
 ```ts
@@ -175,13 +187,13 @@ import routes from './routes';
 
 const router = new Router(routes);
 
-// returns the outlet context if the `home` outlet is matched, otherwise `undefined`
-const outletContext = router.getOutlet('home');
+// returns the route context if the `home` route is matched, otherwise `undefined`
+const routeContext = router.getRoute('home');
 ```
 
-# Using the outlet MatchDetails
+# Using MatchDetails
 
-For every `outlet` that is matched on a route change, `MatchDetails` are injected into the `Outlet` widget's `renderer` property. The `MatchDetails` object contains specific details for the matched outlet.
+For every `route` that is matched on a route change, `MatchDetails` are injected into the both the `Route` and the `Outlet` widget. The `MatchDetails` object contains specific details for a matched route.
 
 Note: All examples assume that the default [HashHistory](#hashhistory) history manager is being used.
 
@@ -194,6 +206,7 @@ Note: All examples assume that the default [HashHistory](#hashhistory) history m
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
 		outlet: 'home'
 	}
@@ -218,6 +231,7 @@ export default [
 ```ts
 export default [
 	{
+		id: 'home,
 		path: 'home/{page}',
 		outlet: 'home'
 	}
@@ -234,17 +248,19 @@ export default [
 
 ## `isExact()`
 
--   `isExact(): boolean`: A function that indicates if the outlet is an exact match for the path. This can be used to conditionally render different widgets or nodes.
+-   `isExact(): boolean`: A function that indicates if the route is an exact match for the path. This can be used to conditionally render different widgets or nodes.
 
 > src/routes.ts
 
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
 		outlet: 'home',
 		children: [
 			{
+				id: 'about',
 				path: 'about',
 				outlet: 'about'
 			}
@@ -253,25 +269,25 @@ export default [
 ];
 ```
 
--   given the above route definition, if the URL path is set to `/#home/about`, then `isExact()` will evaluate to `false` for the `Outlet` with the id "home" and `true` for the an `Outlet` that is a child of the home `Outlet` with the id "about" as shown in the following file:
+-   given the above route definition, if the URL path is set to `/#home/about`, then `isExact()` will evaluate to `false` for the `Route` with the id "home" and `true` for the an `Route` that is a child of the home `Route` with the id "about" as shown in the following file:
 
 > src/App.tsx
 
 ```ts
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Outlet from '@dojo/framework/routing/Outlet';
+import Route from '@dojo/framework/routing/Route';
 
 const factory = create();
 
 export default factory(function App() {
 	return (
 		<div>
-			<Outlet
+			<Route
 				id="home"
 				renderer={(homeMatchDetails) => {
 					console.log('home', homeMatchDetails.isExact()); // home false
 					return (
-						<Outlet
+						<Route
 							id="about"
 							renderer={(aboutMatchDetails) => {
 								console.log('about', aboutMatchDetails.isExact()); // about true
@@ -288,16 +304,18 @@ export default factory(function App() {
 
 ## `isError()`
 
--   `isError(): boolean`: A function indicates if the outlet is an error match for the path. This indicates after this outlet was matched, no other matches were found.
+-   `isError(): boolean`: A function indicates if the route is an error match for the path. This indicates after this route was matched, no other matches were found.
 
 > src/routes.ts
 
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
 		outlet: 'home',
 		children: [
+			id: 'about',
 			path: 'about',
 			outlet: 'about'
 		]
@@ -305,7 +323,7 @@ export default [
 ];
 ```
 
--   given this route definition, if the URL path is set to `/#home/foo` then there is no exact route match, so the `isError()` method on the home `Outlet`'s `martchDetails` object will yield `true`. Navigating to `/#home` or `/#home/about` however will cause the same method to return `false` since both routes are defined.
+-   given this route definition, if the URL path is set to `/#home/foo` then there is no exact route match, so the `isError()` method on the home `Route`'s `matchDetails` object will yield `true`. Navigating to `/#home` or `/#home/about` however will cause the same method to return `false` since both routes are defined.
 
 ## `type`
 
@@ -314,9 +332,11 @@ export default [
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
 		outlet: 'home',
 		children: [
+			id: 'about',
 			path: 'about',
 			outlet: 'about'
 		]
@@ -324,13 +344,13 @@ export default [
 ];
 ```
 
--   given the above route definition, the following values of `type` would be provided to each outlet:
+-   given the above route definition, the following values of `type` would be provided to each route:
 
-| URL path       | Home outlet | About outlet |
-| -------------- | :---------: | :----------: |
-| `/#home`       |   'index'   |     N/A      |
-| `/#home/about` |  'partial'  |   'index'    |
-| `/#home/foo`   |   'error'   |     N/A      |
+| URL path       | Home route | About route |
+| -------------- | :--------: | :---------: |
+| `/#home`       |  'index'   |     N/A     |
+| `/#home/about` | 'partial'  |   'index'   |
+| `/#home/foo`   |  'error'   |     N/A     |
 
 ## `router`
 
@@ -341,10 +361,12 @@ export default [
 ```ts
 export default [
 	{
+		id: 'home',
 		path: 'home',
 		outlet: 'home',
 		children: [
 			{
+				id: 'home-details',
 				path: 'details',
 				outlet: 'home-details'
 			}
@@ -357,14 +379,14 @@ export default [
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Outlet from '@dojo/framework/routing/Outlet';
+import Route from '@dojo/framework/routing/Route';
 
 const factory = create();
 
 export default factory(function App() {
 	return (
 		<div>
-			<Outlet
+			<Route
 				id="home"
 				renderer={(matchDetails) => {
 					const { params, queryParams, isExact, isError, router } = matchDetails;
@@ -498,21 +520,21 @@ r.mount({ registry });
 
 These history managers work like adapters, meaning that custom history managers can be implemented by fulfilling the history manager interface.
 
-# Error outlet
+# Error route
 
-A special `outlet` called `errorOutlet` is registered for that will match when the route doesn't match (`exact` or `partial`) any outlet in the routing configuration. You can use this `outlet` to render a widget to inform the user that the route does not exist.
+A special `route` called `errorRoute` is registered for that will match when the route doesn't match (`exact` or `partial`) any route in the routing configuration. You can use this `route` to render a widget to inform the user that the route does not exist.
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Outlet from '@dojo/framework/routing/Outlet';
+import Route from '@dojo/framework/routing/Route';
 
 const factory = create();
 
 export default factory(function App() {
 	return (
 		<div>
-			<Outlet
-				id="errorOutlet"
+			<Route
+				id="errorRoute"
 				renderer={() => {
 					return <div>Unknown Page</div>;
 				}}
@@ -522,4 +544,4 @@ export default factory(function App() {
 });
 ```
 
-If there is a default route registered, this will take precedence over the error outlet on the initial application load.
+If there is a default route registered, this will take precedence over the error route on the initial application load.

--- a/docs/en/routing/supplemental.md
+++ b/docs/en/routing/supplemental.md
@@ -328,7 +328,7 @@ export default [
 ```ts
 export default [
 	{
-		id: 'home,
+		id: 'home',
 		path: 'home/{page}',
 		outlet: 'home'
 	}

--- a/docs/en/routing/supplemental.md
+++ b/docs/en/routing/supplemental.md
@@ -156,7 +156,7 @@ const App = factory(function App() {
 });
 ```
 
-More words on the outlets and matcher capabilities.
+The node structure of the `App` looks good and succinctly represents the actual visual output for the user with minimal duplication, there still is a need to duplicate the the usage of the `Example` widget across to different routes. This can be solved by using the `matcher` property to override the default route matching rules. The `matcher` receives the `defaultMatches` and a `matchDetailsMap` in order to make custom matching decisions. In the final example below the usage of `Example` has been combined into a new `key`, `details` that does not exist as a route. This will never match for the outlet unless we override the default matches to set it to true when either the `example` or `overview` route has matched. Finally in the `details` renderer the example property has been defaulted to `overview` to maintain the same behavior as before.
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -177,13 +177,13 @@ const App = factory(function App() {
 			<main>
 				<div>
 					<Outlet id="main" matcher={(defaultMatches, matchDetailsMap) => {
-						defaultMatches.widget = matchDetailsMap.has('example') || matchDetailsMap.has('overview');
+						defaultMatches.details = matchDetailsMap.has('example') || matchDetailsMap.has('overview');
 						return defaultMatches;
 					}}>
 						{{
 							landing: <Landing />,
 							tests: <Tests />,
-							widget: ({ params: { example = "overview" }}) => <Example example={example}/>,
+							details: ({ params: { example = "overview" }}) => <Example example={example}/>,
 						}}
 					</Outlet>
 				</div>

--- a/docs/en/routing/supplemental.md
+++ b/docs/en/routing/supplemental.md
@@ -156,6 +156,48 @@ const App = factory(function App() {
 });
 ```
 
+More words on the outlets and matcher capabilities.
+
+```tsx
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Outlet from '@dojo/framework/routing/Outlet';
+
+import Menu from './Menu';
+import SideMenu from './SideMenu';
+import Landing from './Landing';
+import Tests from './Tests';
+import Example from './Example';
+
+const factory = create();
+
+const App = factory(function App() {
+	return (
+		<div>
+			<Menu />
+			<main>
+				<div>
+					<Outlet id="main" matcher={(defaultMatches, matchDetailsMap) => {
+						defaultMatches.widget = matchDetailsMap.has('example') || matchDetailsMap.has('overview');
+						return defaultMatches;
+					}}>
+						{{
+							landing: <Landing />,
+							tests: <Tests />,
+							widget: ({ params: { example = "overview" }}) => <Example example={example}/>,
+						}}
+					</Outlet>
+				</div>
+				<div>
+					<Outlet id="side-menu">
+						{({ params: { widget }}) => <SideMenu widget={widget}>}
+					</Outlet>
+				</div>
+			</main>
+		</div>
+	);
+});
+```
+
 # Router API
 
 The Dojo Router exposes an API that can be used to generate and navigate to links, get the params for the current route and check if an route id has been matched.

--- a/src/routing/ActiveLink.ts
+++ b/src/routing/ActiveLink.ts
@@ -33,8 +33,8 @@ export const ActiveLink = factory(function ActiveLink({
 				currentHandle.destroy();
 			}
 			if (router) {
-				const handle = router.on('outlet', ({ outlet }) => {
-					if (outlet.id === to) {
+				const handle = router.on('route', ({ route }) => {
+					if (route.id === to) {
 						invalidator();
 					}
 				});
@@ -47,14 +47,14 @@ export const ActiveLink = factory(function ActiveLink({
 	const router = injector.get<Router>(routerKey);
 	if (router) {
 		if (!icache.get('handle')) {
-			const handle = router.on('outlet', ({ outlet }) => {
-				if (outlet.id === to) {
+			const handle = router.on('route', ({ route }) => {
+				if (route.id === to) {
 					invalidator();
 				}
 			});
 			icache.set('handle', () => handle);
 		}
-		const context = router.getOutlet(to);
+		const context = router.getRoute(to);
 		const isActive = context && paramsEqual(params, { ...context.params, ...context.queryParams });
 		const contextIsExact = context && context.isExact();
 

--- a/src/routing/Outlet.tsx
+++ b/src/routing/Outlet.tsx
@@ -1,0 +1,110 @@
+import { create, tsx, diffProperty, invalidator } from '../core/vdom';
+import injector from '../core/middleware/injector';
+import icache from '../core/middleware/icache';
+import { RenderResult } from '../core/interfaces';
+import { MatchDetails, RouteContext } from './interfaces';
+import Router from './Router';
+import { RouteProperties } from './Route';
+
+const ROUTER_KEY = 'router';
+
+export interface RouteMatch {
+	[index: string]: boolean;
+}
+
+export interface Matches {
+	[index: string]: boolean;
+}
+
+export interface Matcher {
+	(defaultMatches: Matches, matchDetails: Map<string, RouteContext>): Matches;
+}
+
+export interface OutletProperties {
+	id: string;
+	matcher?: Matcher;
+	routerKey?: string;
+}
+
+export interface OutletChildren {
+	[index: string]: RenderResult | ((matchDetails: MatchDetails) => RenderResult);
+}
+
+export interface OutletFunctionChild {
+	(matchDetails: MatchDetails): RenderResult;
+}
+
+const factory = create({ icache, injector, diffProperty, invalidator })
+	.properties<OutletProperties>()
+	.children<OutletChildren | OutletFunctionChild>();
+
+export const Outlet = factory(function Outlet({
+	middleware: { icache, injector, diffProperty, invalidator },
+	properties,
+	children
+}) {
+	diffProperty('routerKey', (current: RouteProperties, next: RouteProperties) => {
+		const { routerKey: currentRouterKey = ROUTER_KEY } = current;
+		const { routerKey = 'router' } = next;
+		if (routerKey !== currentRouterKey) {
+			const currentHandle = icache.get<Function>('handle');
+			if (currentHandle) {
+				currentHandle();
+			}
+			const handle = injector.subscribe(routerKey);
+			if (handle) {
+				icache.set('handle', () => handle);
+			}
+		}
+		invalidator();
+	});
+	const { id, matcher, routerKey = ROUTER_KEY } = properties();
+	const [outletChildren] = children();
+
+	const currentHandle = icache.get<Function>('handle');
+	if (!currentHandle) {
+		const handle = injector.subscribe(routerKey);
+		if (handle) {
+			icache.set('handle', () => handle);
+		}
+	}
+
+	const router = injector.get<Router>(routerKey);
+
+	if (router) {
+		const currentRouteContext = router.getMatchedRoute();
+		const routeContextMap = router.getOutlet(id);
+		if (routeContextMap && currentRouteContext) {
+			if (typeof outletChildren === 'function') {
+				return outletChildren({ ...currentRouteContext, router });
+			}
+			let matches = Object.keys(outletChildren).reduce(
+				(matches, key) => {
+					matches[key] = !!routeContextMap.get(key);
+					return matches;
+				},
+				{} as Matches
+			);
+			if (matcher) {
+				matches = matcher(matches, routeContextMap);
+			}
+			return (
+				<virtual>
+					{Object.keys(matches)
+						.filter((key) => matches[key])
+						.map((key) => {
+							const renderer = outletChildren[key];
+							if (typeof renderer === 'function') {
+								const context = routeContextMap.get(key) || currentRouteContext;
+								return renderer({ ...context, router });
+							}
+							return renderer;
+						})}
+				</virtual>
+			);
+		}
+	}
+	return null;
+});
+
+export default Outlet;

--- a/src/routing/Outlet.tsx
+++ b/src/routing/Outlet.tsx
@@ -45,7 +45,7 @@ export const Outlet = factory(function Outlet({
 }) {
 	diffProperty('routerKey', (current: RouteProperties, next: RouteProperties) => {
 		const { routerKey: currentRouterKey = ROUTER_KEY } = current;
-		const { routerKey = 'router' } = next;
+		const { routerKey = ROUTER_KEY } = next;
 		if (routerKey !== currentRouterKey) {
 			const currentHandle = icache.get<Function>('handle');
 			if (currentHandle) {

--- a/src/routing/Route.ts
+++ b/src/routing/Route.ts
@@ -5,15 +5,15 @@ import { DNode } from '../core/interfaces';
 import { MatchDetails } from './interfaces';
 import Router from './Router';
 
-export interface OutletProperties {
+export interface RouteProperties {
 	renderer: (matchDetails: MatchDetails) => DNode | DNode[];
 	id: string;
 	routerKey?: string;
 }
 
-const factory = create({ icache, injector, diffProperty, invalidator }).properties<OutletProperties>();
+const factory = create({ icache, injector, diffProperty, invalidator }).properties<RouteProperties>();
 
-export const Outlet = factory(function Outlet({
+export const Route = factory(function Route({
 	middleware: { icache, injector, diffProperty, invalidator },
 	properties
 }) {
@@ -25,7 +25,7 @@ export const Outlet = factory(function Outlet({
 			icache.set('handle', () => handle);
 		}
 	}
-	diffProperty('routerKey', (current: OutletProperties, next: OutletProperties) => {
+	diffProperty('routerKey', (current: RouteProperties, next: RouteProperties) => {
 		const { routerKey: currentRouterKey = 'router' } = current;
 		const { routerKey = 'router' } = next;
 		if (routerKey !== currentRouterKey) {
@@ -43,9 +43,9 @@ export const Outlet = factory(function Outlet({
 	const router = injector.get<Router>(routerKey);
 
 	if (router) {
-		const outletContext = router.getOutlet(id);
-		if (outletContext) {
-			const { queryParams, params, type, isError, isExact } = outletContext;
+		const routeContext = router.getRoute(id);
+		if (routeContext) {
+			const { queryParams, params, type, isError, isExact } = routeContext;
 			const result = renderer({ queryParams, params, type, isError, isExact, router });
 			if (result) {
 				return result;
@@ -55,4 +55,4 @@ export const Outlet = factory(function Outlet({
 	return null;
 });
 
-export default Outlet;
+export default Route;

--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -85,7 +85,7 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 	public start() {
 		const { HistoryManager = HashHistory, base, window } = this._options;
 		this._history = new HistoryManager({ onChange: this._onChange, base, window });
-		if (this._matchedRoutes.errorOutlet && this._defaultRoute) {
+		if (this._matchedRoutes.errorRoute && this._defaultRoute) {
 			const path = this.link(this._defaultRoute);
 			if (path) {
 				this.setPath(path);
@@ -187,7 +187,7 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 			const segments: string[] = parsedPath.split('/');
 			const route: Route = {
 				params: [],
-				id: id || outlet,
+				id,
 				outlet,
 				path: parsedPath,
 				segments,
@@ -222,7 +222,7 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 			if (children && children.length > 0) {
 				this._register(children, route.children, route);
 			}
-			this._routeMap[id || outlet] = route;
+			this._routeMap[id] = route;
 			routes.push(route);
 		}
 	}
@@ -350,9 +350,9 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 				matchedRoute = parent;
 			}
 		} else {
-			this._matchedRoutes.errorOutlet = {
-				id: 'errorOutlet',
-				outlet: 'errorOutlet',
+			this._matchedRoutes.errorRoute = {
+				id: 'errorRoute',
+				outlet: 'errorRoute',
 				queryParams: {},
 				params: {},
 				isError: () => true,

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -29,7 +29,7 @@ export interface Route {
  * Route configuration
  */
 export interface RouteConfig {
-	id?: string;
+	id: string;
 	path: string;
 	outlet: string;
 	children?: RouteConfig[];

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -12,6 +12,7 @@ import { WidgetBase } from '../core/WidgetBase';
  * Description of a registered route
  */
 export interface Route {
+	id: string;
 	path: string;
 	outlet: string;
 	params: string[];
@@ -28,6 +29,7 @@ export interface Route {
  * Route configuration
  */
 export interface RouteConfig {
+	id?: string;
 	path: string;
 	outlet: string;
 	children?: RouteConfig[];
@@ -50,11 +52,16 @@ export type MatchType = 'error' | 'index' | 'partial';
 /**
  * Context stored for matched outlets
  */
-export interface OutletContext {
+export interface RouteContext {
+	/**
+	 * Route id
+	 */
+	id: string;
+
 	/**
 	 * Outlet id
 	 */
-	id: string;
+	outlet: string;
 	/**
 	 * The type of match for the outlet
 	 */
@@ -98,7 +105,12 @@ export interface RouterInterface {
 	/**
 	 * Returns the outlet context if matched
 	 */
-	getOutlet(outletId: string): OutletContext | undefined;
+	getRoute(outletId: string): RouteContext | undefined;
+
+	/**
+	 * Returns the outlet context if matched
+	 */
+	getOutlet(outletId: string): undefined | Map<string, RouteContext>;
 
 	/**
 	 * The current params for matched routes

--- a/tests/routing/unit/ActiveLink.ts
+++ b/tests/routing/unit/ActiveLink.ts
@@ -16,27 +16,33 @@ const router = new Router(
 		{
 			path: 'foo',
 			outlet: 'foo',
+			id: 'foo',
 			children: [
 				{
 					path: 'bar',
-					outlet: 'bar'
+					outlet: 'bar',
+					id: 'bar'
 				}
 			]
 		},
 		{
 			path: 'other',
-			outlet: 'other'
+			outlet: 'other',
+			id: 'other'
 		},
 		{
 			path: 'query/{path}?{query}',
-			outlet: 'query'
+			outlet: 'query',
+			id: 'query'
 		},
 		{
 			path: 'param',
 			outlet: 'param',
+			id: 'param',
 			children: [
 				{
 					path: '{suffix}',
+					id: 'suffixed-param',
 					outlet: 'suffixed-param'
 				}
 			]

--- a/tests/routing/unit/Link.ts
+++ b/tests/routing/unit/Link.ts
@@ -15,11 +15,13 @@ const router = new Router(
 	[
 		{
 			path: 'foo',
-			outlet: 'foo'
+			outlet: 'foo',
+			id: 'foo'
 		},
 		{
 			path: 'foo/{foo}',
-			outlet: 'foo2'
+			outlet: 'foo2',
+			id: 'foo2'
 		}
 	],
 	{ HistoryManager: MemoryHistory }

--- a/tests/routing/unit/Outlet.tsx
+++ b/tests/routing/unit/Outlet.tsx
@@ -1,0 +1,249 @@
+const { beforeEach, describe, it } = intern.getInterface('bdd');
+
+import { MemoryHistory as HistoryManager } from '../../../src/routing/history/MemoryHistory';
+import { Registry } from '../../../src/core/Registry';
+import { registerRouterInjector } from '../../../src/routing/RouterInjector';
+import { create, getRegistry, tsx } from '../../../src/core/vdom';
+import harness from '../../../src/testing/harness';
+import assertionTemplate from '../../../src/testing/assertionTemplate';
+import Outlet from '../../../src/routing/Outlet';
+
+let registry: Registry;
+
+const routeConfig = [
+	{
+		path: '/',
+		id: 'landing',
+		outlet: 'main',
+		defaultRoute: true
+	},
+	{
+		path: 'widget/{widget}',
+		id: 'widget',
+		outlet: 'side-menu',
+		children: [
+			{
+				path: 'tests',
+				outlet: 'main',
+				id: 'tests'
+			},
+			{
+				path: 'overview',
+				outlet: 'main',
+				id: 'overview',
+				children: [
+					{
+						path: 'type',
+						outlet: 'main',
+						id: 'type'
+					}
+				]
+			},
+			{
+				path: 'example/{example}',
+				outlet: 'main',
+				id: 'example'
+			}
+		]
+	}
+];
+
+const factory = create();
+
+const mockGetRegistry = factory(() => {
+	return () => {
+		return registry;
+	};
+});
+
+describe('Outlet', () => {
+	beforeEach(() => {
+		registry = new Registry();
+	});
+
+	it('should match all routes for an outlet by default', () => {
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
+		const template = assertionTemplate(() => (
+			<virtual>
+				<div>overview</div>
+				<div>type</div>
+			</virtual>
+		));
+		router.setPath('/widget/widget/overview/type');
+		const h = harness(
+			() => (
+				<Outlet id="main">
+					{{
+						overview: <div>overview</div>,
+						type: <div>type</div>
+					}}
+				</Outlet>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
+		h.expect(template);
+	});
+
+	it('should restrict matches using matcher property based on match details', () => {
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
+		const template = assertionTemplate(() => (
+			<virtual>
+				<div>type</div>
+			</virtual>
+		));
+		router.setPath('/widget/widget/overview/type');
+		const h = harness(
+			() => (
+				<Outlet
+					id="main"
+					matcher={(defaultMatches, routeMap) => {
+						defaultMatches.overview = Boolean(
+							routeMap.get('overview') && routeMap.get('overview')!.isExact()
+						);
+						defaultMatches.type = Boolean(routeMap.get('type') && routeMap.get('type')!.isExact());
+						return defaultMatches;
+					}}
+				>
+					{{
+						overview: <div>overview</div>,
+						type: <div>type</div>
+					}}
+				</Outlet>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
+		h.expect(template);
+		router.setPath('/widget/widget/overview');
+		h.expect(
+			assertionTemplate(() => (
+				<virtual>
+					<div>overview</div>
+				</virtual>
+			))
+		);
+	});
+
+	it('should be able to use custom keys with a matcher property', () => {
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
+		const template = assertionTemplate(() => (
+			<virtual>
+				<div>custom</div>
+			</virtual>
+		));
+		router.setPath('/widget/widget/overview/type');
+		const h = harness(
+			() => (
+				<Outlet
+					id="main"
+					matcher={(defaultMatches) => {
+						defaultMatches.custom = true;
+						return defaultMatches;
+					}}
+				>
+					{{
+						custom: () => <div>custom</div>
+					}}
+				</Outlet>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
+		h.expect(template);
+	});
+
+	it('should render function child if there is any route matches for the outlet', () => {
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
+		const template = assertionTemplate(() => <div>function</div>);
+		router.setPath('/widget/widget/overview/type');
+		const h = harness(() => <Outlet id="main">{() => <div>function</div>}</Outlet>, {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
+		h.expect(template);
+	});
+
+	it('should be able to access match details in children functions', () => {
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
+		const template = assertionTemplate(() => (
+			<virtual>
+				<div>widget</div>
+				<div>widget</div>
+			</virtual>
+		));
+		router.setPath('/widget/widget/overview/type');
+		const h = harness(
+			() => (
+				<Outlet id="main">
+					{{
+						overview: ({ params: { widget } }) => <div>{widget}</div>,
+						type: ({ params: { widget } }) => <div>{widget}</div>
+					}}
+				</Outlet>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
+		h.expect(template);
+	});
+
+	it('should return null if no router has been registered', () => {
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
+		const template = assertionTemplate(() => null);
+		router.setPath('/widget/widget/overview/type');
+		const h = harness(() => (
+			<Outlet id="main">
+				{{
+					overview: ({ params: { widget } }) => <div>{widget}</div>,
+					type: ({ params: { widget } }) => <div>{widget}</div>
+				}}
+			</Outlet>
+		));
+		h.expect(template);
+	});
+
+	it('should return null if no routes match for the outlet', () => {
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
+		const template = assertionTemplate(() => null);
+		router.setPath('/other/widget/overview/type');
+		const h = harness(() => (
+			<Outlet id="main">
+				{{
+					overview: ({ params: { widget } }) => <div>{widget}</div>,
+					type: ({ params: { widget } }) => <div>{widget}</div>
+				}}
+			</Outlet>
+		));
+		h.expect(template);
+	});
+
+	it('should be able to use a custom router key', () => {
+		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
+
+		const properties: any = {
+			id: 'main'
+		};
+		const template = assertionTemplate(() => (
+			<virtual>
+				<div>overview</div>
+				<div assertion-key="type">type</div>
+			</virtual>
+		));
+		router.setPath('/widget/widget/overview/type');
+		const h = harness(
+			() => (
+				<Outlet {...properties}>
+					{{
+						overview: <div>overview</div>,
+						type: <div>type</div>
+					}}
+				</Outlet>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
+		h.expect(template);
+		const customRouter = registerRouterInjector(routeConfig, registry, { HistoryManager, key: 'custom' });
+		properties.routerKey = 'custom';
+		customRouter.setPath('/widget/widget/overview');
+		h.expect(template.remove('@type'));
+		properties.routerKey = undefined;
+		router.setPath('/widget/widget/overview/type');
+		h.expect(template);
+	});
+});

--- a/tests/routing/unit/Route.ts
+++ b/tests/routing/unit/Route.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import { WidgetBase } from '../../../src/core/WidgetBase';
 import { MemoryHistory as HistoryManager } from '../../../src/routing/history/MemoryHistory';
-import { Outlet } from '../../../src/routing/Outlet';
+import { Route } from '../../../src/routing/Route';
 import { Registry } from '../../../src/core/Registry';
 import { registerRouterInjector } from '../../../src/routing/RouterInjector';
 import { w, create, getRegistry } from '../../../src/core/vdom';
@@ -42,18 +42,18 @@ const mockGetRegistry = factory(() => {
 	};
 });
 
-describe('Outlet', () => {
+describe('Route', () => {
 	beforeEach(() => {
 		registry = new Registry();
 	});
 
-	it('Should render the result of the renderer when the outlet matches', () => {
+	it('Should render the result of the renderer when the Route matches', () => {
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 
 		router.setPath('/foo');
 		const h = harness(
 			() =>
-				w(Outlet, {
+				w(Route, {
 					id: 'foo',
 					renderer() {
 						return w(Widget, {});
@@ -70,7 +70,7 @@ describe('Outlet', () => {
 		router.setPath('/foo');
 		const h = harness(
 			() =>
-				w(Outlet, {
+				w(Route, {
 					id: 'foo',
 					renderer(details: any) {
 						matchType = details.type;
@@ -89,7 +89,7 @@ describe('Outlet', () => {
 		router.setPath('/foo/other');
 		const h = harness(
 			() =>
-				w(Outlet, {
+				w(Route, {
 					id: 'foo',
 					renderer(details: any) {
 						matchType = details.type;
@@ -114,7 +114,7 @@ describe('Outlet', () => {
 		router.setPath('/other');
 		const h = harness(
 			() =>
-				w(Outlet, {
+				w(Route, {
 					id: 'foo',
 					renderer(details: any) {
 						if (details.type === 'index') {

--- a/tests/routing/unit/Route.ts
+++ b/tests/routing/unit/Route.ts
@@ -21,15 +21,18 @@ const routeConfig = [
 	{
 		path: '/foo',
 		outlet: 'foo',
+		id: 'foo',
 		children: [
 			{
 				path: '/bar',
-				outlet: 'bar'
+				outlet: 'bar',
+				id: 'bar'
 			}
 		]
 	},
 	{
 		path: 'baz/{baz}',
+		id: 'baz',
 		outlet: 'baz'
 	}
 ];
@@ -106,7 +109,8 @@ describe('Route', () => {
 		const routeConfig = [
 			{
 				path: '/foo',
-				outlet: 'foo'
+				outlet: 'foo',
+				id: 'foo'
 			}
 		];
 

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -7,23 +7,28 @@ import { MemoryHistory as HistoryManager } from '../../../src/routing/history/Me
 const routeConfig = [
 	{
 		path: '/',
-		outlet: 'home'
+		outlet: 'home',
+		id: 'home'
 	},
 	{
 		path: '/foo',
 		outlet: 'foo',
+		id: 'foo',
 		children: [
 			{
 				path: '/bar',
-				outlet: 'bar'
+				outlet: 'bar',
+				id: 'bar'
 			},
 			{
 				path: '/{baz}/baz',
 				outlet: 'baz',
+				id: 'baz',
 				children: [
 					{
 						path: '/{qux}/qux',
-						outlet: 'qux'
+						outlet: 'qux',
+						id: 'qux'
 					}
 				]
 			}
@@ -34,7 +39,8 @@ const routeConfig = [
 const routeConfigNoRoot = [
 	{
 		path: '/foo',
-		outlet: 'foo'
+		outlet: 'foo',
+		id: 'foo'
 	}
 ];
 
@@ -42,6 +48,7 @@ const routeConfigDefaultRoute = [
 	{
 		path: '/foo/{bar}',
 		outlet: 'foo',
+		id: 'foo',
 		defaultRoute: true,
 		defaultParams: {
 			bar: 'defaultBar'
@@ -50,6 +57,7 @@ const routeConfigDefaultRoute = [
 			{
 				path: 'bar/{foo}',
 				outlet: 'bar',
+				id: 'bar',
 				defaultParams: {
 					foo: 'defaultFoo'
 				}
@@ -62,6 +70,7 @@ const routeConfigDefaultRouteNoDefaultParams = [
 	{
 		path: '/foo/{bar}',
 		outlet: 'foo',
+		id: 'foo',
 		defaultRoute: true
 	}
 ];
@@ -70,14 +79,17 @@ const routeWithChildrenAndMultipleParams = [
 	{
 		path: '/foo/{foo}',
 		outlet: 'foo',
+		id: 'foo',
 		children: [
 			{
 				path: '/bar/{bar}',
 				outlet: 'bar',
+				id: 'bar',
 				children: [
 					{
 						path: '/baz/{baz}',
-						outlet: 'baz'
+						outlet: 'baz',
+						id: 'baz'
 					}
 				]
 			}
@@ -89,6 +101,7 @@ const routeConfigWithParamsAndQueryParams = [
 	{
 		path: '/foo/{foo}?{fooQuery}',
 		outlet: 'foo',
+		id: 'foo',
 		defaultParams: {
 			foo: 'foo',
 			fooQuery: 'fooQuery'
@@ -97,6 +110,7 @@ const routeConfigWithParamsAndQueryParams = [
 			{
 				path: '/bar/{bar}?{barQuery}',
 				outlet: 'bar',
+				id: 'bar',
 				defaultParams: {
 					bar: 'bar',
 					barQuery: 'barQuery'
@@ -110,66 +124,76 @@ const orderIndependentRouteConfig = [
 	{
 		path: '{foo}',
 		outlet: 'partial',
+		id: 'partial',
 		children: [
 			{
 				path: 'bar/{bar}',
-				outlet: 'bar-with-param'
+				outlet: 'bar-with-param',
+				id: 'bar-with-param'
 			},
 			{
 				path: 'bar/bar',
-				outlet: 'bar'
+				outlet: 'bar',
+				id: 'bar'
 			}
 		]
 	},
 	{
 		path: 'foo',
+		id: 'foo',
 		outlet: 'foo'
 	},
 	{
 		path: '/',
-		outlet: 'home'
+		outlet: 'home',
+		id: 'home'
 	}
 ];
 
 const config = [
 	{
 		path: 'foo',
-		outlet: 'foo-one'
+		outlet: 'foo-one',
+		id: 'foo-one'
 	},
 	{
 		path: 'foo',
 		outlet: 'foo-two',
+		id: 'foo-two',
 		children: [
 			{
 				path: 'baz',
-				outlet: 'baz'
+				outlet: 'baz',
+				id: 'baz'
 			}
 		]
 	},
 	{
 		path: '{bar}',
-		outlet: 'param'
+		outlet: 'param',
+		id: 'param'
 	},
 	{
 		path: 'bar',
-		outlet: 'bar'
+		outlet: 'bar',
+		id: 'bar'
 	}
 ];
 
 describe('Router', () => {
-	it('Navigates to current route if matches against a registered outlet', () => {
+	it('Navigates to current path if matches against a registered route', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		const context = router.getRoute('home');
 		assert.isOk(context);
 	});
 
-	it('Navigates to default route if current route does not matches against a registered outlet', () => {
+	it('Navigates to default route if current path does not matches against a registered route', () => {
 		const router = new Router(routeConfigDefaultRoute, { HistoryManager });
 		const context = router.getRoute('foo');
 		assert.isOk(context);
 	});
 
-	it('should match against the most exact outlet specified in the configuration based on the outlets score', () => {
+	it('should match against the most exact route specified in the configuration based on the routes score', () => {
 		const router = new Router(config, { HistoryManager });
 		router.setPath('/bar');
 		assert.isOk(router.getRoute('bar'));
@@ -180,9 +204,9 @@ describe('Router', () => {
 		assert.isUndefined(router.getRoute('foo-one'));
 	});
 
-	it('Navigates to global "errorOutlet" if current route does not match a registered outlet and no default route is configured', () => {
+	it('Navigates to global "errorRoute" if current route does not match a registered route and no default route is configured', () => {
 		const router = new Router(routeConfigNoRoot, { HistoryManager });
-		const context = router.getRoute('errorOutlet');
+		const context = router.getRoute('errorRoute');
 		assert.isOk(context);
 		assert.deepEqual(context!.params, {});
 		assert.deepEqual(context!.queryParams, {});
@@ -191,11 +215,11 @@ describe('Router', () => {
 		assert.strictEqual(context!.isExact(), false);
 	});
 
-	it('Should navigates to global "errorOutlet" if default route requires params but none have been provided', () => {
+	it('Should navigates to global "errorRoute" if default route requires params but none have been provided', () => {
 		const router = new Router(routeConfigDefaultRouteNoDefaultParams, { HistoryManager });
 		const fooContext = router.getRoute('foo');
 		assert.isNotOk(fooContext);
-		const errorContext = router.getRoute('errorOutlet');
+		const errorContext = router.getRoute('errorRoute');
 		assert.isOk(errorContext);
 		assert.deepEqual(errorContext!.params, {});
 		assert.deepEqual(errorContext!.queryParams, {});
@@ -204,7 +228,7 @@ describe('Router', () => {
 		assert.strictEqual(errorContext!.isExact(), false);
 	});
 
-	it('Should register as an index match for an outlet that index matches the route', () => {
+	it('Should register as an index match for an route that index matches the route', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo');
 		const context = router.getRoute('foo');
@@ -239,7 +263,7 @@ describe('Router', () => {
 		assert.strictEqual(partialContext!.isExact(), false);
 	});
 
-	it('Should register as a partial match for an outlet that matches a section of the route', () => {
+	it('Should register as a partial match for a route that matches a section of the path', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/bar');
 		const fooContext = router.getRoute('foo');
@@ -256,7 +280,7 @@ describe('Router', () => {
 		assert.strictEqual(barContext!.isExact(), true);
 	});
 
-	it('Should register as a error match for an outlet that matches a section of the route with no further matching registered outlets', () => {
+	it('Should register as a error match for an route that matches a section of the path with no further matching registered routes', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/unknown');
 		const fooContext = router.getRoute('foo');
@@ -269,7 +293,7 @@ describe('Router', () => {
 		assert.isNotOk(barContext);
 	});
 
-	it('Matches routes against outlets with params', () => {
+	it('Matches against routes with params', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/baz/baz');
 		const fooContext = router.getRoute('foo');
@@ -288,7 +312,7 @@ describe('Router', () => {
 		assert.strictEqual(context!.isError(), false);
 	});
 
-	it('Should return params from all matching outlets', () => {
+	it('Should return params from all matching routes', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/baz/baz/qux/qux?hello=world');
 		const fooContext = router.getRoute('foo');
@@ -314,7 +338,7 @@ describe('Router', () => {
 		assert.strictEqual(quxContext!.isError(), false);
 	});
 
-	it('Should pass query params to all matched outlets', () => {
+	it('Should pass query params to all matched routes', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/bar?query=true');
 		const fooContext = router.getRoute('foo');
@@ -331,11 +355,12 @@ describe('Router', () => {
 		assert.strictEqual(barContext!.isError(), false);
 	});
 
-	it('Should pass params and query params to all matched outlets', () => {
+	it('Should pass params and query params to all matched routes', () => {
 		const config = [
 			{
 				path: 'view/{view}?{filter}',
-				outlet: 'foo'
+				outlet: 'foo',
+				id: 'foo'
 			}
 		];
 		const router = new Router(config, { HistoryManager });
@@ -348,9 +373,9 @@ describe('Router', () => {
 		assert.strictEqual(fooContext!.isError(), false);
 	});
 
-	it('should emit outlet event when a route is entered and exited', () => {
+	it('should emit route event when a route is entered and exited', () => {
 		const router = new Router(routeConfig, { HistoryManager });
-		let handle = router.on('outlet', () => {});
+		let handle = router.on('route', () => {});
 		handle.destroy();
 		handle = router.on('route', ({ route, action }) => {
 			if (action === 'exit') {
@@ -368,9 +393,9 @@ describe('Router', () => {
 		router.setPath('/foo/bar');
 	});
 
-	it('should emit outlet event when a routes param changes', () => {
+	it('should emit route event when a routes param changes', () => {
 		const router = new Router(routeConfig, { HistoryManager });
-		let handle = router.on('outlet', () => {});
+		let handle = router.on('route', () => {});
 		handle.destroy();
 		handle = router.on('route', ({ route, action }) => {
 			if (action === 'exit') {
@@ -409,6 +434,15 @@ describe('Router', () => {
 		});
 	});
 
+	it('should return the current, most exact route context', () => {
+		const router = new Router(routeConfig, { HistoryManager });
+		router.setPath('/foo/');
+		const routerContext = router.getMatchedRoute();
+		assert.isOk(routerContext);
+		assert.strictEqual(routerContext!.id, 'foo');
+		assert.strictEqual(routerContext!.outlet, 'foo');
+	});
+
 	it('Should prefix links based on the history manager', () => {
 		class TestHistoryManager extends HistoryManager {
 			prefix(value: string) {
@@ -434,6 +468,7 @@ describe('Router', () => {
 				{
 					path: 'foo/{foo}/{bar}?{baz}&{qux}',
 					outlet: 'foo',
+					id: 'foo',
 					defaultParams: {
 						foo: 'defaultFoo',
 						bar: 'defaultBar',
@@ -509,7 +544,7 @@ describe('Router', () => {
 		);
 	});
 
-	it('Cannot generate link for an unknown outlet', () => {
+	it('Cannot generate link for an unknown route', () => {
 		const router = new Router(routeConfigDefaultRoute, { HistoryManager });
 		const link = router.link('unknown');
 		assert.isUndefined(link);
@@ -542,5 +577,36 @@ describe('Router', () => {
 		router.start();
 		assert.strictEqual(historyManagerCount, 1);
 		assert.isTrue(initialNavEvent);
+	});
+
+	describe('outlets', () => {
+		it('should match against all routes for an outlet', () => {
+			const router = new Router(
+				[
+					{
+						path: 'foo',
+						id: 'foo',
+						outlet: 'main',
+						children: [
+							{
+								path: 'bar',
+								id: 'bar',
+								outlet: 'main'
+							},
+							{
+								path: 'qux',
+								id: 'qux',
+								outlet: 'other'
+							}
+						]
+					}
+				],
+				{ HistoryManager }
+			);
+			router.setPath('foo/bar');
+			const contextMap = router.getOutlet('main');
+			assert.isOk(contextMap);
+			assert.strictEqual(contextMap!.size, 2);
+		});
 	});
 });

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -159,30 +159,30 @@ const config = [
 describe('Router', () => {
 	it('Navigates to current route if matches against a registered outlet', () => {
 		const router = new Router(routeConfig, { HistoryManager });
-		const context = router.getOutlet('home');
+		const context = router.getRoute('home');
 		assert.isOk(context);
 	});
 
 	it('Navigates to default route if current route does not matches against a registered outlet', () => {
 		const router = new Router(routeConfigDefaultRoute, { HistoryManager });
-		const context = router.getOutlet('foo');
+		const context = router.getRoute('foo');
 		assert.isOk(context);
 	});
 
 	it('should match against the most exact outlet specified in the configuration based on the outlets score', () => {
 		const router = new Router(config, { HistoryManager });
 		router.setPath('/bar');
-		assert.isOk(router.getOutlet('bar'));
-		assert.isUndefined(router.getOutlet('param'));
+		assert.isOk(router.getRoute('bar'));
+		assert.isUndefined(router.getRoute('param'));
 		router.setPath('/foo/baz');
-		assert.isOk(router.getOutlet('baz'));
-		assert.isOk(router.getOutlet('foo-two'));
-		assert.isUndefined(router.getOutlet('foo-one'));
+		assert.isOk(router.getRoute('baz'));
+		assert.isOk(router.getRoute('foo-two'));
+		assert.isUndefined(router.getRoute('foo-one'));
 	});
 
 	it('Navigates to global "errorOutlet" if current route does not match a registered outlet and no default route is configured', () => {
 		const router = new Router(routeConfigNoRoot, { HistoryManager });
-		const context = router.getOutlet('errorOutlet');
+		const context = router.getRoute('errorOutlet');
 		assert.isOk(context);
 		assert.deepEqual(context!.params, {});
 		assert.deepEqual(context!.queryParams, {});
@@ -193,9 +193,9 @@ describe('Router', () => {
 
 	it('Should navigates to global "errorOutlet" if default route requires params but none have been provided', () => {
 		const router = new Router(routeConfigDefaultRouteNoDefaultParams, { HistoryManager });
-		const fooContext = router.getOutlet('foo');
+		const fooContext = router.getRoute('foo');
 		assert.isNotOk(fooContext);
-		const errorContext = router.getOutlet('errorOutlet');
+		const errorContext = router.getRoute('errorOutlet');
 		assert.isOk(errorContext);
 		assert.deepEqual(errorContext!.params, {});
 		assert.deepEqual(errorContext!.queryParams, {});
@@ -207,7 +207,7 @@ describe('Router', () => {
 	it('Should register as an index match for an outlet that index matches the route', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo');
-		const context = router.getOutlet('foo');
+		const context = router.getRoute('foo');
 		assert.isOk(context);
 		assert.deepEqual(context!.params, {});
 		assert.deepEqual(context!.queryParams, {});
@@ -218,20 +218,20 @@ describe('Router', () => {
 	it('should find the most specific match from the routing configuration', () => {
 		const router = new Router(orderIndependentRouteConfig, { HistoryManager });
 		router.setPath('/foo');
-		const fooContext = router.getOutlet('foo');
+		const fooContext = router.getRoute('foo');
 		assert.isOk(fooContext);
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, {});
 		assert.deepEqual(fooContext!.type, 'index');
 		assert.strictEqual(fooContext!.isExact(), true);
 		router.setPath('/foo/bar/bar');
-		const barContext = router.getOutlet('bar');
+		const barContext = router.getRoute('bar');
 		assert.isOk(barContext);
 		assert.deepEqual(barContext!.params, { foo: 'foo' });
 		assert.deepEqual(barContext!.queryParams, {});
 		assert.deepEqual(barContext!.type, 'index');
 		assert.strictEqual(barContext!.isExact(), true);
-		const partialContext = router.getOutlet('partial');
+		const partialContext = router.getRoute('partial');
 		assert.isOk(partialContext);
 		assert.deepEqual(partialContext!.params, { foo: 'foo' });
 		assert.deepEqual(partialContext!.queryParams, {});
@@ -242,13 +242,13 @@ describe('Router', () => {
 	it('Should register as a partial match for an outlet that matches a section of the route', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/bar');
-		const fooContext = router.getOutlet('foo');
+		const fooContext = router.getRoute('foo');
 		assert.isOk(fooContext);
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, {});
 		assert.deepEqual(fooContext!.type, 'partial');
 		assert.strictEqual(fooContext!.isExact(), false);
-		const barContext = router.getOutlet('bar');
+		const barContext = router.getRoute('bar');
 		assert.isOk(barContext);
 		assert.deepEqual(barContext!.params, {});
 		assert.deepEqual(barContext!.queryParams, {});
@@ -259,27 +259,27 @@ describe('Router', () => {
 	it('Should register as a error match for an outlet that matches a section of the route with no further matching registered outlets', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/unknown');
-		const fooContext = router.getOutlet('foo');
+		const fooContext = router.getRoute('foo');
 		assert.isOk(fooContext);
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, {});
 		assert.deepEqual(fooContext!.type, 'error');
 		assert.strictEqual(fooContext!.isError(), true);
-		const barContext = router.getOutlet('bar');
+		const barContext = router.getRoute('bar');
 		assert.isNotOk(barContext);
 	});
 
 	it('Matches routes against outlets with params', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/baz/baz');
-		const fooContext = router.getOutlet('foo');
+		const fooContext = router.getRoute('foo');
 		assert.isOk(fooContext);
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, {});
 		assert.deepEqual(fooContext!.type, 'partial');
 		assert.strictEqual(fooContext!.isExact(), false);
 		assert.strictEqual(fooContext!.isError(), false);
-		const context = router.getOutlet('baz');
+		const context = router.getRoute('baz');
 		assert.isOk(context);
 		assert.deepEqual(context!.params, { baz: 'baz' });
 		assert.deepEqual(context!.queryParams, {});
@@ -291,21 +291,21 @@ describe('Router', () => {
 	it('Should return params from all matching outlets', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/baz/baz/qux/qux?hello=world');
-		const fooContext = router.getOutlet('foo');
+		const fooContext = router.getRoute('foo');
 		assert.isOk(fooContext);
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, { hello: 'world' });
 		assert.deepEqual(fooContext!.type, 'partial');
 		assert.strictEqual(fooContext!.isExact(), false);
 		assert.strictEqual(fooContext!.isError(), false);
-		const bazContext = router.getOutlet('baz');
+		const bazContext = router.getRoute('baz');
 		assert.isOk(bazContext);
 		assert.deepEqual(bazContext!.params, { baz: 'baz' });
 		assert.deepEqual(bazContext!.queryParams, { hello: 'world' });
 		assert.deepEqual(bazContext!.type, 'partial');
 		assert.strictEqual(bazContext!.isExact(), false);
 		assert.strictEqual(bazContext!.isError(), false);
-		const quxContext = router.getOutlet('qux');
+		const quxContext = router.getRoute('qux');
 		assert.isOk(quxContext);
 		assert.deepEqual(quxContext!.params, { baz: 'baz', qux: 'qux' });
 		assert.deepEqual(quxContext!.queryParams, { hello: 'world' });
@@ -317,13 +317,13 @@ describe('Router', () => {
 	it('Should pass query params to all matched outlets', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		router.setPath('/foo/bar?query=true');
-		const fooContext = router.getOutlet('foo');
+		const fooContext = router.getRoute('foo');
 		assert.deepEqual(fooContext!.params, {});
 		assert.deepEqual(fooContext!.queryParams, { query: 'true' });
 		assert.deepEqual(fooContext!.type, 'partial');
 		assert.strictEqual(fooContext!.isExact(), false);
 		assert.strictEqual(fooContext!.isError(), false);
-		const barContext = router.getOutlet('bar');
+		const barContext = router.getRoute('bar');
 		assert.deepEqual(barContext!.params, {});
 		assert.deepEqual(barContext!.queryParams, { query: 'true' });
 		assert.deepEqual(barContext!.type, 'index');
@@ -340,7 +340,7 @@ describe('Router', () => {
 		];
 		const router = new Router(config, { HistoryManager });
 		router.setPath('/view/bar?filter=true');
-		const fooContext = router.getOutlet('foo');
+		const fooContext = router.getRoute('foo');
 		assert.deepEqual(fooContext!.params, { view: 'bar' });
 		assert.deepEqual(fooContext!.queryParams, { filter: 'true' });
 		assert.deepEqual(fooContext!.type, 'index');
@@ -352,17 +352,17 @@ describe('Router', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		let handle = router.on('outlet', () => {});
 		handle.destroy();
-		handle = router.on('outlet', ({ outlet, action }) => {
+		handle = router.on('route', ({ route, action }) => {
 			if (action === 'exit') {
-				assert.strictEqual(outlet.id, 'home');
+				assert.strictEqual(route.id, 'home');
 			} else {
-				assert.strictEqual(outlet.id, 'foo');
+				assert.strictEqual(route.id, 'foo');
 			}
 		});
 		router.setPath('/foo');
 		handle.destroy();
-		handle = router.on('outlet', ({ outlet, action }) => {
-			assert.strictEqual(outlet.id, 'bar');
+		handle = router.on('route', ({ route, action }) => {
+			assert.strictEqual(route.id, 'bar');
 			assert.strictEqual(action, 'enter');
 		});
 		router.setPath('/foo/bar');
@@ -372,28 +372,28 @@ describe('Router', () => {
 		const router = new Router(routeConfig, { HistoryManager });
 		let handle = router.on('outlet', () => {});
 		handle.destroy();
-		handle = router.on('outlet', ({ outlet, action }) => {
+		handle = router.on('route', ({ route, action }) => {
 			if (action === 'exit') {
-				assert.strictEqual(outlet.id, 'home');
+				assert.strictEqual(route.id, 'home');
 			} else {
-				assert.strictEqual(outlet.id, 'foo');
+				assert.strictEqual(route.id, 'foo');
 			}
 		});
 		router.setPath('/foo');
 		handle.destroy();
-		handle = router.on('outlet', ({ outlet, action }) => {
-			assert.strictEqual(outlet.id, 'baz');
+		handle = router.on('route', ({ route, action }) => {
+			assert.strictEqual(route.id, 'baz');
 			assert.strictEqual(action, 'enter');
 		});
 		router.setPath('/foo/baz/baz');
 		handle.destroy();
-		handle = router.on('outlet', ({ outlet, action }) => {
+		handle = router.on('route', ({ route, action }) => {
 			if (action === 'exit') {
-				assert.strictEqual(outlet.id, 'baz');
-				assert.deepEqual(outlet.params, { baz: 'baz' });
+				assert.strictEqual(route.id, 'baz');
+				assert.deepEqual(route.params, { baz: 'baz' });
 			} else {
-				assert.strictEqual(outlet.id, 'baz');
-				assert.deepEqual(outlet.params, { baz: 'baaz' });
+				assert.strictEqual(route.id, 'baz');
+				assert.deepEqual(route.params, { baz: 'baaz' });
 			}
 		});
 		router.setPath('/foo/baaz/baz');

--- a/tests/routing/unit/RouterInjector.ts
+++ b/tests/routing/unit/RouterInjector.ts
@@ -8,7 +8,7 @@ import { MemoryHistory } from '../../../src/routing/history/MemoryHistory';
 suite('RouterInjector', () => {
 	test('registerRouterInjector', () => {
 		const registry = new Registry();
-		const router = registerRouterInjector([{ path: 'path', outlet: 'path' }], registry, {
+		const router = registerRouterInjector([{ path: 'path', outlet: 'path', id: 'path' }], registry, {
 			HistoryManager: MemoryHistory
 		});
 		const { injector, invalidator } = registry.getInjector('router')!;
@@ -21,7 +21,7 @@ suite('RouterInjector', () => {
 
 	test('registerRouterInjector with custom key', () => {
 		const registry = new Registry();
-		const router = registerRouterInjector([{ path: 'path', outlet: 'path' }], registry, {
+		const router = registerRouterInjector([{ path: 'path', outlet: 'path', id: 'path' }], registry, {
 			HistoryManager: MemoryHistory,
 			key: 'custom-key'
 		});
@@ -36,10 +36,14 @@ suite('RouterInjector', () => {
 
 	test('throws error if a second router is registered for the same key', () => {
 		const registry = new Registry();
-		registerRouterInjector([{ path: 'path', outlet: 'path' }], registry, { HistoryManager: MemoryHistory });
+		registerRouterInjector([{ path: 'path', outlet: 'path', id: 'path' }], registry, {
+			HistoryManager: MemoryHistory
+		});
 		assert.throws(
 			() => {
-				registerRouterInjector([{ path: 'path', outlet: 'path' }], registry, { HistoryManager: MemoryHistory });
+				registerRouterInjector([{ path: 'path', outlet: 'path', id: 'path' }], registry, {
+					HistoryManager: MemoryHistory
+				});
 			},
 			Error,
 			'Router has already been defined'

--- a/tests/routing/unit/all.ts
+++ b/tests/routing/unit/all.ts
@@ -1,6 +1,7 @@
 import './ActiveLink';
 import './Link';
 import './Route';
+import './Outlet';
 import './Router';
 import './RouterInjector';
 import './history/all';

--- a/tests/routing/unit/all.ts
+++ b/tests/routing/unit/all.ts
@@ -1,6 +1,6 @@
 import './ActiveLink';
 import './Link';
-import './Outlet';
+import './Route';
 import './Router';
 import './RouterInjector';
 import './history/all';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changes the concept of an `Outlet` to support rendering multiple matching "routes" to a single outlet. Now using an outlet gives flexibility to render views for an application's routes in a more natural layout, reduces repetitive uses of an `Outlet` that duplicate layout and logic.

The existing `Outlet` behaviour has been moved to `Route` that more accurately describes its behaviour.

Resolves #715 
