### PR TITLE
use theme injector for custom elements

### DIFF
--- a/src/core/ThemeInjector.ts
+++ b/src/core/ThemeInjector.ts
@@ -34,3 +34,5 @@ export class ThemeInjector extends Injector {
 		super.set(createThemeInjectorPayload(theme, variant));
 	}
 }
+
+export default ThemeInjector;

--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -10,7 +10,7 @@ import {
 } from './vdom';
 import { from } from '../shim/array';
 import global from '../shim/global';
-import Injector from './Injector';
+import ThemeInjector from './ThemeInjector';
 import { DomVNode, WNode } from './interfaces';
 
 const RESERVED_PROPS = ['focus'];
@@ -97,8 +97,8 @@ export function DomToWidgetWrapper(domNode: HTMLElement): any {
 	return wrapper;
 }
 
-function registerThemeInjector(theme: any, themeRegistry: Registry): Injector {
-	const themeInjector = new Injector(theme);
+function registerThemeInjector(theme: any, themeRegistry: Registry): ThemeInjector {
+	const themeInjector = new ThemeInjector(theme);
 	themeRegistry.defineInjector('__theme_injector', (invalidator) => {
 		themeInjector.setInvalidator(invalidator);
 		return () => themeInjector;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

To support themes with variants in custom elements it needs to use the theme injector. At the moment support is restricted to the default variant.
