### PR TITLE
Allow i18n to be reset to an empty state

### DIFF
--- a/src/core/I18nInjector.ts
+++ b/src/core/I18nInjector.ts
@@ -1,0 +1,31 @@
+import { LocaleData } from './interfaces';
+import { setLocale, getComputedLocale } from '../i18n/i18n';
+import { Injector } from './Injector';
+import Registry from './Registry';
+import { isThenable } from '../shim/Promise';
+
+export const INJECTOR_KEY = '__i18n_injector';
+
+export class I18nInjector extends Injector {
+	set(localeData: LocaleData = {}) {
+		const result = setLocale({ locale: localeData.locale || getComputedLocale() });
+		if (isThenable(result)) {
+			result.then(() => {
+				super.set(localeData);
+			});
+			return;
+		}
+		super.set(localeData);
+	}
+}
+
+export function registerI18nInjector(localeData: LocaleData, registry: Registry): I18nInjector {
+	const injector = new I18nInjector(localeData);
+	registry.defineInjector(INJECTOR_KEY, (invalidator) => {
+		injector.setInvalidator(invalidator);
+		return () => injector;
+	});
+	return injector;
+}
+
+export default I18nInjector;

--- a/src/core/middleware/i18n.ts
+++ b/src/core/middleware/i18n.ts
@@ -1,21 +1,11 @@
-import { localizeBundle, Bundle, Messages, setLocale, getCurrentLocale, getComputedLocale } from '../../i18n/i18n';
+import { localizeBundle, Bundle, Messages, setLocale, getCurrentLocale } from '../../i18n/i18n';
 import { create, invalidator, getRegistry, diffProperty } from '../vdom';
 import injector from './injector';
-import Injector from '../Injector';
-import Registry from '../Registry';
 import { I18nProperties, LocalizedMessages, LocaleData } from '../interfaces';
 import { isThenable } from '../../shim/Promise';
+import I18nInjector, { INJECTOR_KEY, registerI18nInjector } from '../I18nInjector';
 
-export const INJECTOR_KEY = '__i18n_injector';
-
-export function registerI18nInjector(localeData: LocaleData, registry: Registry): Injector {
-	const injector = new Injector(localeData);
-	registry.defineInjector(INJECTOR_KEY, (invalidator) => {
-		injector.setInvalidator(invalidator);
-		return () => injector;
-	});
-	return injector;
-}
+export { INJECTOR_KEY, registerI18nInjector } from '../I18nInjector';
 
 const factory = create({ invalidator, injector, getRegistry, diffProperty }).properties<I18nProperties>();
 
@@ -29,7 +19,7 @@ export const i18n = factory(({ properties, middleware: { invalidator, injector, 
 	}
 
 	diffProperty('locale', properties, (current, next) => {
-		const localeDataInjector = injector.get<Injector<LocaleData | undefined>>(INJECTOR_KEY);
+		const localeDataInjector = injector.get<I18nInjector>(INJECTOR_KEY);
 		let injectedLocale: string | undefined;
 		if (localeDataInjector) {
 			const injectLocaleData = localeDataInjector.get();
@@ -67,20 +57,13 @@ export const i18n = factory(({ properties, middleware: { invalidator, injector, 
 			return localizeBundle(bundle, { locale, invalidator });
 		},
 		set(localeData: LocaleData = {}) {
-			const localeDataInjector = injector.get<Injector<LocaleData | undefined>>(INJECTOR_KEY);
+			const localeDataInjector = injector.get<I18nInjector>(INJECTOR_KEY);
 			if (localeDataInjector) {
-				const result = setLocale({ locale: localeData.locale || getComputedLocale() });
-				if (isThenable(result)) {
-					result.then(() => {
-						localeDataInjector.set(localeData);
-					});
-					return;
-				}
 				localeDataInjector.set(localeData);
 			}
 		},
 		get() {
-			const localeDataInjector = injector.get<Injector<LocaleData | undefined>>(INJECTOR_KEY);
+			const localeDataInjector = injector.get<I18nInjector>(INJECTOR_KEY);
 			if (localeDataInjector) {
 				return localeDataInjector.get();
 			}

--- a/src/core/middleware/i18n.ts
+++ b/src/core/middleware/i18n.ts
@@ -1,4 +1,4 @@
-import { localizeBundle, Bundle, Messages, setLocale, getCurrentLocale } from '../../i18n/i18n';
+import { localizeBundle, Bundle, Messages, setLocale, getCurrentLocale, getComputedLocale } from '../../i18n/i18n';
 import { create, invalidator, getRegistry, diffProperty } from '../vdom';
 import injector from './injector';
 import Injector from '../Injector';
@@ -66,17 +66,15 @@ export const i18n = factory(({ properties, middleware: { invalidator, injector, 
 			}
 			return localizeBundle(bundle, { locale, invalidator });
 		},
-		set(localeData?: LocaleData) {
+		set(localeData: LocaleData = {}) {
 			const localeDataInjector = injector.get<Injector<LocaleData | undefined>>(INJECTOR_KEY);
 			if (localeDataInjector) {
-				if (localeData && localeData.locale) {
-					const result = setLocale({ locale: localeData.locale });
-					if (isThenable(result)) {
-						result.then(() => {
-							localeDataInjector.set(localeData);
-						});
-						return;
-					}
+				const result = setLocale({ locale: localeData.locale || getComputedLocale() });
+				if (isThenable(result)) {
+					result.then(() => {
+						localeDataInjector.set(localeData);
+					});
+					return;
 				}
 				localeDataInjector.set(localeData);
 			}

--- a/src/core/mixins/I18n.ts
+++ b/src/core/mixins/I18n.ts
@@ -5,15 +5,14 @@ import { afterRender } from './../decorators/afterRender';
 import { getInjector } from './../decorators/inject';
 import { Constructor, DNode, VNodeProperties, LocalizedMessages, I18nProperties, LocaleData } from './../interfaces';
 import { Injector } from './../Injector';
-import { Registry } from './../Registry';
 import { WidgetBase } from './../WidgetBase';
 import { decorate } from '../util';
 import { isThenable } from '../../shim/Promise';
 import beforeProperties from '../decorators/beforeProperties';
+import { INJECTOR_KEY } from '../I18nInjector';
 
 export { LocalizedMessages, I18nProperties, LocaleData } from './../interfaces';
-
-export const INJECTOR_KEY = '__i18n_injector';
+export { INJECTOR_KEY, registerI18nInjector } from '../I18nInjector';
 
 /**
  * interface for I18n functionality
@@ -43,30 +42,6 @@ export interface I18nMixin {
 interface I18nVNodeProperties extends VNodeProperties {
 	dir: string;
 	lang: string;
-}
-
-class I18nInjector extends Injector {
-	set(localeData: LocaleData) {
-		if (localeData.locale) {
-			const result = setLocale({ locale: localeData.locale });
-			if (isThenable(result)) {
-				result.then(() => {
-					super.set(localeData);
-				});
-				return;
-			}
-			super.set(localeData);
-		}
-	}
-}
-
-export function registerI18nInjector(localeData: LocaleData, registry: Registry): I18nInjector {
-	const injector = new I18nInjector(localeData);
-	registry.defineInjector(INJECTOR_KEY, (invalidator) => {
-		injector.setInvalidator(invalidator);
-		return () => injector;
-	});
-	return injector;
 }
 
 const previousLocaleMap: WeakMap<WidgetBase, string> = new WeakMap();

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -329,6 +329,7 @@ function registerBundle<T extends Messages>(bundle: Bundle<T>): string {
 		Globalize.loadMessages({
 			root: { [bundleId]: bundle.messages },
 			[computedLocale]: { [bundleId]: bundle.messages },
+			[defaultLocale]: { [bundleId]: bundle.messages },
 			...messageBundles
 		});
 		Cldr.load({ dojo: lookup });

--- a/tests/core/unit/middleware/i18n.tsx
+++ b/tests/core/unit/middleware/i18n.tsx
@@ -264,10 +264,11 @@ describe('i18n middleware', () => {
 				es: overrideEs.loader
 			}
 		};
-		const App = factory(({ middleware: { i18n } }) => {
+		const App = factory(({ properties, middleware: { i18n } }) => {
 			const { messages, format, isPlaceholder } = i18n.localize(bundle);
 			return (
 				<div>
+					<div>{properties().locale}</div>
 					<div>{JSON.stringify(messages)}</div>
 					<div>{format('foo', { name: 'John' })}</div>
 					<div>{`${isPlaceholder}`}</div>
@@ -279,6 +280,13 @@ describe('i18n middleware', () => {
 					>
 						es
 					</button>
+					<button
+						onclick={() => {
+							i18n.set();
+						}}
+					>
+						reset
+					</button>
 				</div>
 			);
 		});
@@ -288,21 +296,27 @@ describe('i18n middleware', () => {
 		r.mount({ domNode: root });
 		assert.strictEqual(
 			root.innerHTML,
-			'<div><div>{"foo":"Oi, {name}"}</div><div>Oi, John</div><div>false</div><div>{}</div><button>es</button></div>'
+			'<div><div>en</div><div>{"foo":"Oi, {name}"}</div><div>Oi, John</div><div>false</div><div>{}</div><button>es</button><button>reset</button></div>'
 		);
-		root.children[0].children[4].click();
+		root.children[0].children[5].click();
 		await localeLoader;
 		resolvers.resolveRAF();
 		assert.strictEqual(
 			root.innerHTML,
-			'<div><div>{"foo":""}</div><div></div><div>true</div><div>{"locale":"es"}</div><button>es</button></div>'
+			'<div><div>es</div><div>{"foo":""}</div><div></div><div>true</div><div>{"locale":"es"}</div><button>es</button><button>reset</button></div>'
 		);
 		overrideEs.resolver({ default: { foo: 'bonjour, {name}' } });
 		await overrideEs.promise;
 		resolvers.resolveRAF();
 		assert.strictEqual(
 			root.innerHTML,
-			'<div><div>{"foo":"bonjour, {name}"}</div><div>bonjour, John</div><div>false</div><div>{"locale":"es"}</div><button>es</button></div>'
+			'<div><div>es</div><div>{"foo":"bonjour, {name}"}</div><div>bonjour, John</div><div>false</div><div>{"locale":"es"}</div><button>es</button><button>reset</button></div>'
+		);
+		root.children[0].children[6].click();
+		resolvers.resolveRAF();
+		assert.strictEqual(
+			root.innerHTML,
+			'<div><div>en</div><div>{"foo":"Oi, {name}"}</div><div>Oi, John</div><div>false</div><div>{}</div><button>es</button><button>reset</button></div>'
 		);
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

When i18n is set to an empty state it should clear the injected values and reset the locale back to the computed locale. Currently the injector is being cleared but the actual locale is not being reset to the initial locale.