### PR TITLE
Adding custom element reference guide (#723)

### DIFF
--- a/docs/en/custom-elements/introduction.md
+++ b/docs/en/custom-elements/introduction.md
@@ -9,11 +9,10 @@ Each widget is bundled into a JavaScript file and a CSS file, both of which are 
 ```html
 <html>
   <head>
-    <link rel="stylesheet" href="ref-email-signup.css">
+    <link rel="stylesheet" href="ref-hero.css">
   </head>
   <body>
-    <ref-email-signup></ref-email-signup>
-    <script async src="ref-email-signup.js"></script>
+    <script async src="ref-hero.js"></script>
   </body>
 </html>
 ```
@@ -26,51 +25,27 @@ Each widget is bundled into a JavaScript file and a CSS file, both of which are 
 
 ## Building Custom Elements
 
-Dojo widgets can be built as custom elements using @dojo/cli-build-widget. For this example, we're going to use a simple email subscription widget.
+Dojo widgets can be built as custom elements using @dojo/cli-build-widget.
 
-> src/widgets/EmailSignup.tsx
+> src/widgets/Hero.tsx
 
 ```tsx
-import { tsx, create } from '@dojo/framework/core/vdom';
-import * as css from './styles/EmailSignup.m.css';
-import icache from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import * as css from './styles/Hero.m.css';
 
-export interface EmailSignupProperties {
-	title?: string;
-	onSignUp?: () => void;
-	signUpBonusDate?: Date;
+export interface HeroProperties {
+	title: string;
+	image: string;
 }
 
-const factory = create({ icache }).properties<EmailSignupProperties>();
-
-export default factory(function EmailSignup({ middleware: { icache }, properties }) {
-	const { title, signUpBonusDate } = properties();
-
-	const signedUp = icache.getOrSet('signedUp', false);
-	const signUp = () => {
-		const { onSignUp } = properties();
-
-		// post email address to a server
-		icache.set('signedUp', true);
-		onSignUp && onSignUp();
-	};
+const factory = create().properties<HeroProperties>();
+export default factory(function Hero({ properties }) {
+	const { title, image } = properties();
 
 	return (
-		<div key="root" classes={css.root}>
-			<div key="title" classes={css.title}>
-				{title || 'Subscribe Now'}
-			</div>
-			{signedUp ? (
-				<div key="confirmation" classes={css.thanks}>
-					Thank you for signing up!
-				</div>
-			) : (
-				<div key="signup" classes={css.signup}>
-					{signUpBonusDate && <div>Sign up by {signUpBonusDate.toLocaleDateString()}</div>}
-					<input type="text" />
-					<button onclick={signUp}>Sign Up</button>
-				</div>
-			)}
+		<div classes={css.hero}>
+			<img classes={css.image} src={image} />
+			<h1 classes={css.title}>{title}</h1>
 		</div>
 	);
 });
@@ -84,10 +59,12 @@ To build a widget as a custom element, add a `build-widget` property to your `.d
 {
 	"build-widget": {
 		"prefix": "ref",
-		"widgets": ["src/widgets/EmailSignup"]
+		"widgets": ["src/widgets/Hero"]
 	}
 }
 ```
+
+Custom Elements are required to contain dash characters. During the build process, Dojo will take the widget name, `MyWidget` and add dashes on uppercase letter boundaries, `my-widget`. As this is sometimes not enough, a prefix is added to each widget that guarantees the element contains a dash. By default, the `name` field from `package.json` is used as the prefix, but this can be overriden using the `prefix` option in your `.dojorc`. Because the prefix is `ref`, the EmailSignup widget will be built into a custom element named `ref-my-widget`.
 
 With this configuration in place, build the widgets using the Dojo CLI.
 
@@ -97,17 +74,13 @@ $ dojo build widget
 
 The `output/dist/` directory now contains the built custom elements.
 
-| Filename                  | Description                                                                                                                                                                             |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ref-email-signup.js`     | This file includes all of the code required to hydrate your custom element. Loading this script in your HTML file is what makes your Dojo widget come alive as a custom element.        |
-| `ref-email-signup.js.map` | A JavaScript source map file for making debugging easier. These files are used only during debugging and do not need to be uploaded to a production environment.                        |
-| `ref-email-signup.css`    | The CSS used by the widget. Note that this includes the styles only for this one widget. If you are using a theme, you will need to separately include the theme CSS in your HTML page. |
-
-Note that that the `prefix` we added to `.dojorc` is used in the custom element tag name.
+-   `ref-hero.js` -All of the code required to hydrate your custom element. Loading this script in your HTML file is what makes your Dojo widget come alive as a custom element.
+-   `ref-hero.js.map` - A JavaScript source map file for making debugging easier. These files are used only during debugging and do not need to be uploaded to a production environment.
+-   `ref-hero.css` - The CSS used by the widget. Note that this includes the styles only for this one widget.
 
 ## Using Custom Elements
 
-Using Custom Elements built with Dojo is as simple as including the generated files in your HTML. To use the email subscription widget, import the files.
+Using Custom Elements built with Dojo is as simple as including the generated files in your HTML. To use the hero widget, import the files.
 
 ```html
 <!DOCTYPE html>
@@ -115,50 +88,15 @@ Using Custom Elements built with Dojo is as simple as including the generated fi
 <head>
 	<meta charset="utf-8">
     <title>Using Custom Elements</title>
-    <link rel="stylesheet" href="./output/dist/email-signup-1.0.0.css">
+    <link rel="stylesheet" href="./output/dist/hero-1.0.0.css">
 </head>
 <body>
-    <ref-email-signup id="emailSignup"></ref-email-signup>
-    <script async src="./output/dist/email-signup-1.0.0.js"></script>
+    <ref-hero image="hero.jpg" title="Make Custom Elements the Easy Way!"></ref-hero>
+    <script async src="./output/dist/hero-1.0.0.js"></script>
 </body>
 </html>
 ```
 
 If you have more than one custom element, include `link` and `script` tags for each element you are using.
 
-> On some browsers, you may have to include a custom elements shim. We recommend INSERT SHIM HERE
-
-### Attributes
-
-`string` typed widget properties are automatically added as HTML attributes to your custom element. Continuing with the email subscription example, the title property (`{ title?: string }`) can be customized by adding a `title` attribute to the HTML.
-
-```html
-<ref-email-signup id="emailSignup" title="Subscribe to Our Newsletter"></ref-email-signup>
-```
-
-### Events
-
-All widget properties that start with `on` and have a function signature are exposed as events. The emitted event is the lower cased part of the property name without the "on." Listening for the onSignUp property (`{ onSignUp?: () => void }`) would look like this.
-
-```html
-<script>
-    emailSignup.addEventListener('signup', () => {
-        // start confetti animation 🎉
-    });
-</script>
-```
-
-### Properties
-
-All non-event widget properties are automatically created as properties on the custom element. These properties can be fully controlled by JavaScript. In the email subscription widget, both the title and signUpBonusDate properties can be set programmatically as properties.
-
-```html
-<script>
-        const now = new Date();
-        emailSignup.signUpBonusDate = new Date(
-            now.getFullYear(),
-            now.getMonth(),
-            now.getDate() + 1
-        );
-    </script>
-```
+> On some browsers, you may have to include a custom elements polyfill. We recommend including [@webcomponents/custom-elements](https://github.com/webcomponents/polyfills/tree/master/packages/custom-elements)

--- a/docs/en/custom-elements/introduction.md
+++ b/docs/en/custom-elements/introduction.md
@@ -25,7 +25,7 @@ Each widget is bundled into a JavaScript file and a CSS file, both of which are 
 
 ## Building Custom Elements
 
-Dojo widgets can be built as custom elements using @dojo/cli-build-widget.
+Dojo widgets can be built as custom elements using the `@dojo/cli-build-widget` command.
 
 > src/widgets/Hero.tsx
 
@@ -64,7 +64,7 @@ To build a widget as a custom element, add a `build-widget` property to your `.d
 }
 ```
 
-Custom Elements are required to contain dash characters. During the build process, Dojo will take the widget name, `MyWidget` and add dashes on uppercase letter boundaries, `my-widget`. As this is sometimes not enough, a prefix is added to each widget that guarantees the element contains a dash. By default, the `name` field from `package.json` is used as the prefix, but this can be overriden using the `prefix` option in your `.dojorc`. Because the prefix is `ref`, the EmailSignup widget will be built into a custom element named `ref-my-widget`.
+Custom Elements are required to contain dash characters. During the build process, Dojo will take the widget name, `MyWidget` and add dashes on uppercase letter boundaries, `my-widget`. As this is sometimes not enough, a prefix is added to each widget that guarantees the element contains a dash. By default, the `name` field from `package.json` is used as the prefix, but this can be overriden using the `prefix` option in your `.dojorc`. Because the prefix is `ref`, the `MyWidget` widget will be built into a custom element named `ref-my-widget`.
 
 With this configuration in place, build the widgets using the Dojo CLI.
 
@@ -74,7 +74,7 @@ $ dojo build widget
 
 The `output/dist/` directory now contains the built custom elements.
 
--   `ref-hero.js` -All of the code required to hydrate your custom element. Loading this script in your HTML file is what makes your Dojo widget come alive as a custom element.
+-   `ref-hero.js` - All of the code required to hydrate your custom element. Loading this script in your HTML file is what makes your Dojo widget come alive as a custom element.
 -   `ref-hero.js.map` - A JavaScript source map file for making debugging easier. These files are used only during debugging and do not need to be uploaded to a production environment.
 -   `ref-hero.css` - The CSS used by the widget. Note that this includes the styles only for this one widget.
 

--- a/docs/en/custom-elements/introduction.md
+++ b/docs/en/custom-elements/introduction.md
@@ -1,0 +1,164 @@
+# Introduction
+
+Dojo widgets can be compiled into custom elements and therefore be used like any other type of HTML tag. The widget's properties will be automatically converted into HTML attributes, properties, or events.
+
+Each widget is bundled into a JavaScript file and a CSS file, both of which are imported into your HTML.
+
+> index.html
+
+```html
+<html>
+  <head>
+    <link rel="stylesheet" href="ref-email-signup.css">
+  </head>
+  <body>
+    <ref-email-signup></ref-email-signup>
+    <script async src="ref-email-signup.js"></script>
+  </body>
+</html>
+```
+
+| Feature           | Description                                                                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Widget Properties | Based on the type and name of the property, Dojo will decide if the property should be an attribute, property, or event on the custom element.                           |
+| Child Renderers   | Widgets that use child objects or renderers are supported in custom elements by using slots.                                                                             |
+| Lazy Loading      | The custom element script does not need to be loaded before the custom element is referenced on the page. Elements will be hydrated automatically when the script loads. |
+
+## Building Custom Elements
+
+Dojo widgets can be built as custom elements using @dojo/cli-build-widget. For this example, we're going to use a simple email subscription widget.
+
+> src/widgets/EmailSignup.tsx
+
+```tsx
+import { tsx, create } from '@dojo/framework/core/vdom';
+import * as css from './styles/EmailSignup.m.css';
+import icache from '@dojo/framework/core/middleware/icache';
+
+export interface EmailSignupProperties {
+	title?: string;
+	onSignUp?: () => void;
+	signUpBonusDate?: Date;
+}
+
+const factory = create({ icache }).properties<EmailSignupProperties>();
+
+export default factory(function EmailSignup({ middleware: { icache }, properties }) {
+	const { title, signUpBonusDate } = properties();
+
+	const signedUp = icache.getOrSet('signedUp', false);
+	const signUp = () => {
+		const { onSignUp } = properties();
+
+		// post email address to a server
+		icache.set('signedUp', true);
+		onSignUp && onSignUp();
+	};
+
+	return (
+		<div key="root" classes={css.root}>
+			<div key="title" classes={css.title}>
+				{title || 'Subscribe Now'}
+			</div>
+			{signedUp ? (
+				<div key="confirmation" classes={css.thanks}>
+					Thank you for signing up!
+				</div>
+			) : (
+				<div key="signup" classes={css.signup}>
+					{signUpBonusDate && <div>Sign up by {signUpBonusDate.toLocaleDateString()}</div>}
+					<input type="text" />
+					<button onclick={signUp}>Sign Up</button>
+				</div>
+			)}
+		</div>
+	);
+});
+```
+
+To build a widget as a custom element, add a `build-widget` property to your `.dojorc` file and include the path to any widgets you want to expose as custom elements.
+
+> .dojorc
+
+```json
+{
+	"build-widget": {
+		"prefix": "ref",
+		"widgets": ["src/widgets/EmailSignup"]
+	}
+}
+```
+
+With this configuration in place, build the widgets using the Dojo CLI.
+
+```shell
+$ dojo build widget
+```
+
+The `output/dist/` directory now contains the built custom elements.
+
+| Filename                  | Description                                                                                                                                                                             |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ref-email-signup.js`     | This file includes all of the code required to hydrate your custom element. Loading this script in your HTML file is what makes your Dojo widget come alive as a custom element.        |
+| `ref-email-signup.js.map` | A JavaScript source map file for making debugging easier. These files are used only during debugging and do not need to be uploaded to a production environment.                        |
+| `ref-email-signup.css`    | The CSS used by the widget. Note that this includes the styles only for this one widget. If you are using a theme, you will need to separately include the theme CSS in your HTML page. |
+
+Note that that the `prefix` we added to `.dojorc` is used in the custom element tag name.
+
+## Using Custom Elements
+
+Using Custom Elements built with Dojo is as simple as including the generated files in your HTML. To use the email subscription widget, import the files.
+
+```html
+<!DOCTYPE html>
+<html lang="en-us" dir="ltr">
+<head>
+	<meta charset="utf-8">
+    <title>Using Custom Elements</title>
+    <link rel="stylesheet" href="./output/dist/email-signup-1.0.0.css">
+</head>
+<body>
+    <ref-email-signup id="emailSignup"></ref-email-signup>
+    <script async src="./output/dist/email-signup-1.0.0.js"></script>
+</body>
+</html>
+```
+
+If you have more than one custom element, include `link` and `script` tags for each element you are using.
+
+> On some browsers, you may have to include a custom elements shim. We recommend INSERT SHIM HERE
+
+### Attributes
+
+`string` typed widget properties are automatically added as HTML attributes to your custom element. Continuing with the email subscription example, the title property (`{ title?: string }`) can be customized by adding a `title` attribute to the HTML.
+
+```html
+<ref-email-signup id="emailSignup" title="Subscribe to Our Newsletter"></ref-email-signup>
+```
+
+### Events
+
+All widget properties that start with `on` and have a function signature are exposed as events. The emitted event is the lower cased part of the property name without the "on." Listening for the onSignUp property (`{ onSignUp?: () => void }`) would look like this.
+
+```html
+<script>
+    emailSignup.addEventListener('signup', () => {
+        // start confetti animation 🎉
+    });
+</script>
+```
+
+### Properties
+
+All non-event widget properties are automatically created as properties on the custom element. These properties can be fully controlled by JavaScript. In the email subscription widget, both the title and signUpBonusDate properties can be set programmatically as properties.
+
+```html
+<script>
+        const now = new Date();
+        emailSignup.signUpBonusDate = new Date(
+            now.getFullYear(),
+            now.getMonth(),
+            now.getDate() + 1
+        );
+    </script>
+```

--- a/docs/en/custom-elements/supplemental.md
+++ b/docs/en/custom-elements/supplemental.md
@@ -219,7 +219,7 @@ export interface WidgetChildren {
 
 # Using Themes
 
-A Dojo Theme can be used with a custom element by including the theme's JavaScript and CSS files.
+Themes can be used with custom elements by including the theme's JavaScript and CSS files.
 
 ```html
 <!DOCTYPE html>

--- a/docs/en/custom-elements/supplemental.md
+++ b/docs/en/custom-elements/supplemental.md
@@ -2,7 +2,7 @@
 
 A widget's properties are exposed from a custom element automatically as either attributes, events, or properties.
 
-The following EmailSignup widget contains several different property types.
+The following `EmailSignup` widget contains several different property types.
 
 > src/widgets/EmailSignup.tsx
 
@@ -62,7 +62,7 @@ export default factory(function EmailSignup({ middleware: { icache }, properties
 
 ### Events
 
-All widget properties that start with `on` and have a function signature are exposed as events. The emitted event is the lower cased part of the property name without the "on." Listening for the onSignUp property (`{ onSignUp?: () => void }`) would look like this.
+Widget properties that start with `on` and have a function signature are exposed as events. The emitted event is the lower cased part of the property name without the "on." Listening for the onSignUp property (`{ onSignUp?: () => void }`) would look like this.
 
 ```html
 <script>
@@ -74,7 +74,7 @@ All widget properties that start with `on` and have a function signature are exp
 
 ### Properties
 
-All non-event widget properties are automatically created as properties on the custom element. These properties can be fully controlled by JavaScript. In the email subscription widget, both the title and signUpBonusDate properties can be set programmatically as properties.
+All non-event widget properties are automatically created as properties on the custom element. These properties can be fully controlled by JavaScript. In the email subscription widget, both the `title` and `signUpBonusDate` properties can be set programmatically as properties.
 
 ```html
 <script>
@@ -89,7 +89,7 @@ All non-event widget properties are automatically created as properties on the c
 
 # Custom Element Slots
 
-Some Dojo widgets utilize child objects rather than child widgets. These child objects are supported as custom elements by using "slots." A `slot` attribute is added to a child of the custom element, and the child gets passed in as the value of the slot.
+Dojo widgets can support child objects, these children are supported as custom elements by using "slots." A `slot` attribute is added to a child of the custom element, and the child gets passed in as the value of the slot.
 
 The most common child object scenarios are supported by Dojo custom elements.
 
@@ -147,6 +147,8 @@ export interface WidgetChildren {
 
 ## Named Array of Children
 
+If multiple children have the same slot name, they are bundled together in an array and passed to the custom element.
+
 > Widget.tsx
 
 ```tsx
@@ -161,6 +163,15 @@ export interface WidgetChildren {
 		foo: [<Label>Label 1</Label>, <Label>Label 2</Label>]
 	}}
 </Widget>
+```
+
+> index.html
+
+```html
+<dojo-widget>
+  <dojo-label slot="foo">Label 1</dojo-label>
+  <dojo-label slot="foo">Label 2</dojo-label>
+</dojo-widget>
 ```
 
 ## Named Array of Child Renderers
@@ -192,6 +203,8 @@ export interface WidgetChildren {
 
 ## Named Child Renderers with Arguments
 
+If the widget passes arguments to a child render function, the arguments get sent to the child in the slot via a "render" event.
+
 > Widget.tsx
 
 ```tsx
@@ -212,9 +225,19 @@ export interface WidgetChildren {
 
 ```html
 <dojo-widget>
-  <dojo-label slot="foo">Label 1</dojo-label>
-  <dojo-label slot="foo">Label 2</dojo-label>
+  <dojo-label slot="foo" id="label1">Label 1</dojo-label>
+  <dojo-label slot="foo" id="label2">Label 2</dojo-label>
 </dojo-widget>
+
+<script>
+  function setActive(event) {
+    const { detail: [active] } = event;
+    event.target.active = active;
+  }
+
+  label1.addEventListener('render', setActive);
+  label2.addEventListener('render', setActive);
+</script>
 ```
 
 # Using Themes

--- a/docs/en/custom-elements/supplemental.md
+++ b/docs/en/custom-elements/supplemental.md
@@ -1,15 +1,90 @@
-# Custom Element Events
+# Setting a Widget's Properties
 
-Function based properties that are prefixed with "on" are automatically converted to events when building a widget as a custom element. This allows you to use the standard browser event listeners to handle those properties.
+A widget's properties are exposed from a custom element automatically as either attributes, events, or properties.
 
-In addition to being added as events, event properties are also exposed as regular properties on the custom element. This allows you to assign a function callback directly, without using an event handler.
+The following EmailSignup widget contains several different property types.
+
+> src/widgets/EmailSignup.tsx
+
+```tsx
+import { tsx, create } from '@dojo/framework/core/vdom';
+import * as css from './styles/EmailSignup.m.css';
+import icache from '@dojo/framework/core/middleware/icache';
+
+export interface EmailSignupProperties {
+	title?: string;
+	onSignUp?: () => void;
+	signUpBonusDate?: Date;
+}
+
+const factory = create({ icache }).properties<EmailSignupProperties>();
+
+export default factory(function EmailSignup({ middleware: { icache }, properties }) {
+	const { title, signUpBonusDate } = properties();
+
+	const signedUp = icache.getOrSet('signedUp', false);
+	const signUp = () => {
+		const { onSignUp } = properties();
+
+		// post email address to a server
+		icache.set('signedUp', true);
+		onSignUp && onSignUp();
+	};
+
+	return (
+		<div key="root" classes={css.root}>
+			<div key="title" classes={css.title}>
+				{title || 'Subscribe Now'}
+			</div>
+			{signedUp ? (
+				<div key="confirmation" classes={css.thanks}>
+					Thank you for signing up!
+				</div>
+			) : (
+				<div key="signup" classes={css.signup}>
+					{signUpBonusDate && <div>Sign up by {signUpBonusDate.toLocaleDateString()}</div>}
+					<input type="text" />
+					<button onclick={signUp}>Sign Up</button>
+				</div>
+			)}
+		</div>
+	);
+});
+```
+
+### Attributes
+
+`string` typed widget properties are automatically added as HTML attributes to your custom element. Continuing with the email subscription example, the title property (`{ title?: string }`) can be customized by adding a `title` attribute to the HTML.
+
+```html
+<ref-email-signup id="emailSignup" title="Subscribe to Our Newsletter"></ref-email-signup>
+```
+
+### Events
+
+All widget properties that start with `on` and have a function signature are exposed as events. The emitted event is the lower cased part of the property name without the "on." Listening for the onSignUp property (`{ onSignUp?: () => void }`) would look like this.
 
 ```html
 <script>
-    emailSignup.__onSignUp = () => {
+    emailSignup.addEventListener('signup', () => {
         // start confetti animation 🎉
-    };
+    });
 </script>
+```
+
+### Properties
+
+All non-event widget properties are automatically created as properties on the custom element. These properties can be fully controlled by JavaScript. In the email subscription widget, both the title and signUpBonusDate properties can be set programmatically as properties.
+
+```html
+<script>
+        const now = new Date();
+        emailSignup.signUpBonusDate = new Date(
+            now.getFullYear(),
+            now.getMonth(),
+            now.getDate() + 1
+        );
+    </script>
 ```
 
 # Custom Element Slots
@@ -140,4 +215,25 @@ export interface WidgetChildren {
   <dojo-label slot="foo">Label 1</dojo-label>
   <dojo-label slot="foo">Label 2</dojo-label>
 </dojo-widget>
+```
+
+# Using Themes
+
+A Dojo Theme can be used with a custom element by including the theme's JavaScript and CSS files.
+
+```html
+<!DOCTYPE html>
+<html lang="en-us" dir="ltr">
+<head>
+	<meta charset="utf-8">
+    <title>Using Custom Elements</title>
+    <link rel="stylesheet" href="./output/dist/hero-1.0.0.css">
+    <link rel="stylesheet" href"./output/theme/my-theme.css">
+</head>
+<body>
+    <ref-hero image="hero.jpg" title="Make Custom Elements the Easy Way!"></ref-hero>
+    <script async src="./output/dist/hero-1.0.0.js"></script>
+    <script async src="./output/theme/my-theme.js"></script>
+</body>
+</html>
 ```

--- a/docs/en/custom-elements/supplemental.md
+++ b/docs/en/custom-elements/supplemental.md
@@ -1,0 +1,143 @@
+# Custom Element Events
+
+Function based properties that are prefixed with "on" are automatically converted to events when building a widget as a custom element. This allows you to use the standard browser event listeners to handle those properties.
+
+In addition to being added as events, event properties are also exposed as regular properties on the custom element. This allows you to assign a function callback directly, without using an event handler.
+
+```html
+<script>
+    emailSignup.__onSignUp = () => {
+        // start confetti animation 🎉
+    };
+</script>
+```
+
+# Custom Element Slots
+
+Some Dojo widgets utilize child objects rather than child widgets. These child objects are supported as custom elements by using "slots." A `slot` attribute is added to a child of the custom element, and the child gets passed in as the value of the slot.
+
+The most common child object scenarios are supported by Dojo custom elements.
+
+## Named Children
+
+> Widget.tsx
+
+```tsx
+export interface WidgetChildren {
+	foo: RenderResult;
+}
+```
+
+```tsx
+<Widget>
+	{{
+		foo: <Label>My Label</Label>
+	}}
+</Widget>
+```
+
+> index.html
+
+```html
+<dojo-widget>
+  <dojo-label slot="foo">My Label</dojo-label>
+</dojo-widget>
+```
+
+## Named Child Renderers
+
+> Widget.tsx
+
+```tsx
+export interface WidgetChildren {
+	foo: () => RenderResult;
+}
+```
+
+```tsx
+<Widget>
+	{{
+		foo: () => <Label>My Label</Label>
+	}}
+</Widget>
+```
+
+> index.html
+
+```html
+<dojo-widget>
+  <dojo-label slot="foo">My Label</dojo-label>
+</dojo-widget>
+```
+
+## Named Array of Children
+
+> Widget.tsx
+
+```tsx
+export interface WidgetChildren {
+	foo: RenderResult[];
+}
+```
+
+```tsx
+<Widget>
+	{{
+		foo: [<Label>Label 1</Label>, <Label>Label 2</Label>]
+	}}
+</Widget>
+```
+
+## Named Array of Child Renderers
+
+> Widget.tsx
+
+```tsx
+export interface WidgetChildren {
+	foo: (() => RenderResult)[];
+}
+```
+
+```tsx
+<Widget>
+	{{
+		foo: [() => <Label>Label 1</Label>, () => <Label>Label 2</Label>]
+	}}
+</Widget>
+```
+
+> index.html
+
+```html
+<dojo-widget>
+  <dojo-label slot="foo">Label 1</dojo-label>
+  <dojo-label slot="foo">Label 2</dojo-label>
+</dojo-widget>
+```
+
+## Named Child Renderers with Arguments
+
+> Widget.tsx
+
+```tsx
+export interface WidgetChildren {
+	foo: (active: boolean) => RenderResult;
+}
+```
+
+```tsx
+<Widget>
+	{{
+		foo: (active) => <Label active={active}>My Label</Label>
+	}}
+</Widget>
+```
+
+> index.html
+
+```html
+<dojo-widget>
+  <dojo-label slot="foo">Label 1</dojo-label>
+  <dojo-label slot="foo">Label 2</dojo-label>
+</dojo-widget>
+```


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding a custom element reference guide for new Dojo 7 features.

Resolves #723 
