### PR TITLE
Small fix to the testing introduction

### DIFF
--- a/docs/en/testing/introduction.md
+++ b/docs/en/testing/introduction.md
@@ -168,7 +168,7 @@ describe('Profile', () => {
 });
 ```
 
-To work with assertion, wrapped nodes can get created using `@dojo/framework/testing/renderer#wrap` in order to use the assertion API. Note: when using wrapped `VNode`s with `v()`, the `.tag` property needs to get used, for example `v(WrappedDiv.tag, {} [])`.
+Wrapped test nodes, created using `@dojo/framework/testing/renderer#wrap` need to be specified in the assertion's expected output in place of the standard widget to interact with assertion's API. Note: when using wrapped `VNode`s with `v()`, the `.tag` property needs to get used, for example `v(WrappedDiv.tag, {} [])`.
 
 > tests/unit/widgets/Profile.tsx
 


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Small fix to the grammar of the testing intro docs