### PR TITLE
Let the browser deal with url changes when in BTR and using the CLI serve

### DIFF
--- a/src/routing/Link.ts
+++ b/src/routing/Link.ts
@@ -1,4 +1,5 @@
 import { create, v } from '../core/vdom';
+import has from '../core/has';
 import injector from '../core/middleware/injector';
 import { VNodeProperties } from '../core/interfaces';
 import { Params } from './interfaces';
@@ -29,8 +30,10 @@ export const Link = factory(function Link({ middleware: { injector }, properties
 			onClick && onClick(event);
 
 			if (!event.defaultPrevented && event.button === 0 && !event.metaKey && !event.ctrlKey && !target) {
-				event.preventDefault();
-				href !== undefined && router.setPath(href);
+				if (!has('build-serve') || !has('build-time-rendered')) {
+					event.preventDefault();
+					href !== undefined && router.setPath(href);
+				}
 			}
 		};
 		linkProps = { ...props, onclick, href };

--- a/tests/routing/unit/Link.ts
+++ b/tests/routing/unit/Link.ts
@@ -2,6 +2,7 @@ const { beforeEach, afterEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { spy, SinonSpy } from 'sinon';
 
+import { add } from '../../../src/core/has';
 import { v, w, create, getRegistry } from '../../../src/core/vdom';
 import { Registry } from '../../../src/core/Registry';
 import { Link } from '../../../src/routing/Link';
@@ -68,6 +69,8 @@ describe('Link', () => {
 
 	afterEach(() => {
 		routerSetPathSpy.restore();
+		add('build-serve', false, true);
+		add('build-time-rendered', false, true);
 	});
 
 	it('Generate link component for basic outlet', () => {
@@ -159,6 +162,20 @@ describe('Link', () => {
 		const template = assertion(() => v(WrappedAnchor.tag, { href: 'foo', onclick: noop }));
 		r.expect(template);
 		r.property(WrappedAnchor, 'onclick', createMockEvent({ isRightClick: true }));
+		r.expect(template);
+		assert.isTrue(routerSetPathSpy.notCalled);
+	});
+
+	it('does not call router when build serve and build time rendered is detected', () => {
+		add('build-serve', true, true);
+		add('build-time-rendered', true, true);
+		const WrappedAnchor = wrap('a');
+		const r = renderer(() => w(Link, { to: '#foo/static', isOutlet: false }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
+		const template = assertion(() => v(WrappedAnchor.tag, { href: '#foo/static', onclick: noop }));
+		r.expect(template);
+		r.property(WrappedAnchor, 'onclick', createMockEvent());
 		r.expect(template);
 		assert.isTrue(routerSetPathSpy.notCalled);
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

In order to support on-demand BTR when not in static mode the link should let the browser deal with the routing navigation.

Related to https://github.com/dojo/cli-build-app/issues/367
