### PR TITLE
Fix default route

### DIFF
--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -201,7 +201,7 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 				score: parentRoute ? parentRoute.score : 0
 			};
 			if (defaultRoute) {
-				this._defaultRoute = outlet;
+				this._defaultRoute = id;
 			}
 			for (let i = 0; i < segments.length; i++) {
 				const segment = segments[i];

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -49,7 +49,7 @@ const routeConfigNoRoot = [
 const routeConfigDefaultRoute = [
 	{
 		path: '/foo/{bar}',
-		outlet: 'foo',
+		outlet: 'main',
 		id: 'foo',
 		defaultRoute: true,
 		defaultParams: {
@@ -58,7 +58,7 @@ const routeConfigDefaultRoute = [
 		children: [
 			{
 				path: 'bar/{foo}',
-				outlet: 'bar',
+				outlet: 'main',
 				id: 'bar',
 				defaultParams: {
 					foo: 'defaultFoo'
@@ -71,7 +71,7 @@ const routeConfigDefaultRoute = [
 const routeConfigDefaultRouteNoDefaultParams = [
 	{
 		path: '/foo/{bar}',
-		outlet: 'foo',
+		outlet: 'main',
 		id: 'foo',
 		defaultRoute: true
 	}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Use the route id and not outlet for the default route.

Resolves #736 