### PR TITLE
Inject current value to icache on when set when passed a function

### DIFF
--- a/src/testing/mocks/middleware/icache.ts
+++ b/src/testing/mocks/middleware/icache.ts
@@ -14,7 +14,7 @@ export function createICacheMock() {
 			properties,
 			children
 		});
-		const setter = icacheMiddleware.set;
+		const setter = icacheMiddleware.set.bind(icacheMiddleware);
 
 		icacheMiddleware.set = (key: any, value: any) => {
 			if (typeof value === 'function') {

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -148,6 +148,27 @@ describe('icache middleware', () => {
 		assert.isTrue(icache.has('test'));
 	});
 
+	it('should inject current value into function', () => {
+		const icache = callback({
+			id: 'test',
+			middleware: {
+				destroy: sb.stub(),
+				invalidator: invalidatorStub
+			},
+			properties: () => ({}),
+			children: () => []
+		});
+		let value = icache.set('test', (value) => {
+			return `${value}-next`;
+		});
+		assert.strictEqual(value, 'undefined-next');
+		value = icache.set('test', (value) => {
+			return `${value}-next`;
+		});
+		assert.strictEqual(value, 'undefined-next-next');
+		assert.strictEqual(icache.get('test'), 'undefined-next-next');
+	});
+
 	it('should remove value for the specified key from the cache', () => {
 		const icache = callback({
 			id: 'test',
@@ -228,6 +249,28 @@ describe('icache middleware', () => {
 			await promise;
 			assert.strictEqual(icache.get('foo'), 'hello, typed world!');
 			assert.strictEqual(icache.get('bar'), 34);
+		});
+
+		it('should inject current value into function', () => {
+			const typedICache = createICacheMiddleware<CacheContents>();
+			const icache = typedICache().callback({
+				id: 'test',
+				middleware: {
+					destroy: sb.stub(),
+					invalidator: invalidatorStub
+				},
+				properties: () => ({}),
+				children: () => []
+			});
+			let value = icache.set('bar', (value) => {
+				return value === undefined ? 0 : value + 1;
+			});
+			assert.strictEqual(value, 0);
+			value = icache.set('bar', (value) => {
+				return value === undefined ? 0 : value + 1;
+			});
+			assert.strictEqual(value, 1);
+			assert.strictEqual(icache.get('bar'), 1);
 		});
 	});
 });

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -379,7 +379,9 @@ describe('test renderer', () => {
 						<Widget key="widget">{{ leading: strings, trailing: () => strings }}</Widget>
 						<button
 							key="clicker"
-							onclick={() => icache.set('strings', [...(icache.get<any[]>('strings') || []), 'string'])}
+							onclick={() => {
+								icache.set('strings', [...(icache.get<any[]>('strings') || []), 'string']);
+							}}
 						>
 							Add String
 						</button>


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Enhances the `icache` set behaviour to inject the current cache value if passed a function, and always returns the value from set.

Resolves #739 
Resolves #738 
