### PR TITLE
Fix typings for the resource property

### DIFF
--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -28,12 +28,12 @@ interface ResourceWithData {
 export type ResourceOrResourceWrapper = Resource | ResourceWrapper | ResourceWithData;
 
 export interface DataProperties {
-	resource: ResourceOrResourceWrapper | any[];
+	resource: ResourceOrResourceWrapper;
 }
 
 export interface DataTransformProperties<T = void> {
 	transform: TransformConfig<T>;
-	resource: ResourceOrResourceWrapper | T[];
+	resource: ResourceOrResourceWrapper;
 }
 
 export interface DataInitialiserOptions {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fixes the typings of the `resource` property on the data middleware. It should not accept an array of data.

Resolves #740 
