### PR TITLE
Support changing variants for custom element themes

### DIFF
--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -247,8 +247,18 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 			const renderChildren = () => this.__children__();
 			const Wrapper = factory(() => w(WidgetConstructor, widgetProperties, renderChildren()));
 			const registry = registryFactory();
-			const themeContext = registerThemeInjector(this._getTheme(), registry);
-			global.addEventListener('dojo-theme-set', () => themeContext.set(this._getTheme()));
+			const themeContext = registerThemeInjector(
+				this._getVariant() ? { theme: this._getTheme(), variant: this._getVariant() } : this._getTheme(),
+				registry
+			);
+			global.addEventListener('dojo-theme-set', () => {
+				const variant = this._getVariant();
+				if (variant !== 'noVariant') {
+					themeContext.set(this._getTheme(), variant);
+				} else {
+					themeContext.set(this._getTheme());
+				}
+			});
 			const r = renderer(() => w(Wrapper, {}));
 			this._renderer = r;
 			r.mount({ domNode: this, merge: false, registry });
@@ -269,6 +279,12 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 		private _getTheme() {
 			if (global && global.dojoce && global.dojoce.theme) {
 				return global.dojoce.themes[global.dojoce.theme];
+			}
+		}
+
+		private _getVariant() {
+			if (global && global.dojoce && global.dojoce.variant) {
+				return global.dojoce.variant;
 			}
 		}
 

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -119,7 +119,7 @@ function createTestWidget(options: any) {
 @theme({ ' _key': 'themedWidget', foo: 'bar' })
 class ThemedWidget extends ThemedMixin(WidgetBase) {
 	render() {
-		return v('div', { classes: ['root'] }, [this.theme('bar')]);
+		return v('div', { classes: ['root'] }, [this.theme('bar'), this.variant()]);
 	}
 }
 
@@ -149,6 +149,7 @@ describe('registerCustomElement', () => {
 		}
 		element = undefined;
 		delete global.dojo;
+		global.dojoce = {};
 	});
 
 	it('throws error when no descriptor found', () => {
@@ -379,6 +380,71 @@ describe('registerCustomElement', () => {
 		assert.equal(root.innerHTML, 'bar');
 		resolvers.resolve();
 		assert.equal(root.innerHTML, 'baz');
+	});
+
+	it('custom element with global theme and default variant', () => {
+		const CustomElement = create((ThemedWidget as any).__customElementDescriptor, ThemedWidget);
+		customElements.define('themed-element-default-variant', CustomElement);
+		element = document.createElement('themed-element-default-variant');
+		document.body.appendChild(element);
+		global.dojoce = {
+			theme: 'dojo',
+			themes: {
+				dojo: {
+					theme: {
+						themedWidget: {
+							foo: 'baz'
+						}
+					},
+					variants: {
+						default: {
+							root: 'default variant'
+						},
+						light: {
+							root: 'light variant'
+						}
+					}
+				}
+			}
+		};
+		global.dispatchEvent(new CustomEvent('dojo-theme-set', {}));
+		const root = element.querySelector('.root') as HTMLElement;
+		assert.equal(root.innerHTML, 'bar');
+		resolvers.resolve();
+		assert.equal(root.innerHTML, 'bazdefault variant');
+	});
+
+	it('custom element with global theme and custom variant', () => {
+		const CustomElement = create((ThemedWidget as any).__customElementDescriptor, ThemedWidget);
+		customElements.define('themed-element-custom-variant', CustomElement);
+		element = document.createElement('themed-element-custom-variant');
+		document.body.appendChild(element);
+		global.dojoce = {
+			theme: 'dojo',
+			variant: 'light',
+			themes: {
+				dojo: {
+					theme: {
+						themedWidget: {
+							foo: 'baz'
+						}
+					},
+					variants: {
+						default: {
+							root: 'default variant'
+						},
+						light: {
+							root: 'light variant'
+						}
+					}
+				}
+			}
+		};
+		global.dispatchEvent(new CustomEvent('dojo-theme-set', {}));
+		const root = element.querySelector('.root') as HTMLElement;
+		assert.equal(root.innerHTML, 'bar');
+		resolvers.resolve();
+		assert.equal(root.innerHTML, 'bazlight variant');
 	});
 
 	it('custom element with registry factory', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support setting a theme variant for custom elements.