### PR TITLE
Normalise the theme context

### DIFF
--- a/src/core/ThemeInjector.ts
+++ b/src/core/ThemeInjector.ts
@@ -1,37 +1,70 @@
-import { Theme, ThemeWithVariants, ThemeWithVariant, Variant } from './interfaces';
+import { Theme, ThemeWithVariants, ThemeWithVariant, NamedVariant } from './interfaces';
 import Injector from './Injector';
 
-function isThemeVariantConfig(theme: Theme | ThemeWithVariants | ThemeWithVariant): theme is ThemeWithVariants {
-	return theme.hasOwnProperty('variants');
+export interface ThemeWithVariantsInjectorPayload {
+	theme: ThemeWithVariants;
+	variant: NamedVariant;
 }
 
-function isVariantModule(variant: string | Variant): variant is Variant {
+export interface ThemeInjectorPayload {
+	theme: Theme;
+}
+
+export function isVariantModule(variant: string | NamedVariant): variant is NamedVariant {
 	return typeof variant !== 'string';
 }
 
-function createThemeInjectorPayload(theme: Theme | ThemeWithVariants | ThemeWithVariant, variant?: string | Variant) {
-	if (isThemeVariantConfig(theme)) {
+export function isThemeWithVariant(theme: Theme | ThemeWithVariants | ThemeWithVariant): theme is ThemeWithVariant {
+	return theme && theme.hasOwnProperty('variant');
+}
+
+export function isThemeWithVariants(theme: Theme | ThemeWithVariants | ThemeWithVariant): theme is ThemeWithVariants {
+	return theme && theme.hasOwnProperty('variants');
+}
+
+export function isThemeInjectorPayloadWithVariant(
+	theme: ThemeInjectorPayload | ThemeWithVariantsInjectorPayload
+): theme is ThemeWithVariantsInjectorPayload {
+	return theme && theme.hasOwnProperty('variant');
+}
+
+function createThemeInjectorPayload(
+	theme: Theme | ThemeWithVariants | ThemeWithVariant,
+	variant?: string | NamedVariant
+): ThemeWithVariantsInjectorPayload | ThemeInjectorPayload {
+	if (isThemeWithVariant(theme)) {
+		if (typeof theme.variant === 'string') {
+			return {
+				theme: theme.theme,
+				variant: { name: theme.variant, variant: theme.theme.variants[theme.variant] }
+			};
+		}
+		return { theme: theme.theme, variant: theme.variant };
+	} else if (isThemeWithVariants(theme)) {
 		variant = variant || 'default';
 		if (isVariantModule(variant)) {
-			return { theme: theme.theme, variant };
+			return { theme, variant };
 		}
 
-		return { theme: theme.theme, variant: theme.variants[variant] };
+		return { theme: theme, variant: { name: variant, variant: theme.variants[variant] } };
 	}
-	return theme;
+	return { theme };
 }
 
 export class ThemeInjector extends Injector {
 	constructor(theme?: Theme | ThemeWithVariants | ThemeWithVariant) {
-		theme = theme ? createThemeInjectorPayload(theme) : theme;
-		super(theme);
+		super(theme ? createThemeInjectorPayload(theme) : theme);
 	}
 
-	set<T extends ThemeWithVariants>(theme: T, variant?: keyof T['variants'] | Variant): void;
+	set<T extends ThemeWithVariants>(theme: T, variant?: keyof T['variants'] | NamedVariant): void;
 	set(theme: ThemeWithVariant): void;
 	set(theme: Theme): void;
-	set(theme: Theme | ThemeWithVariants | ThemeWithVariant, variant?: string | Variant) {
+	set(theme: Theme | ThemeWithVariants | ThemeWithVariant, variant?: string | NamedVariant) {
 		super.set(createThemeInjectorPayload(theme, variant));
+	}
+
+	get(): ThemeWithVariantsInjectorPayload | ThemeInjectorPayload {
+		return super.get();
 	}
 }
 

--- a/src/core/ThemeInjector.ts
+++ b/src/core/ThemeInjector.ts
@@ -36,7 +36,7 @@ function createThemeInjectorPayload(
 		if (typeof theme.variant === 'string') {
 			return {
 				theme: theme.theme,
-				variant: { name: theme.variant, variant: theme.theme.variants[theme.variant] }
+				variant: { name: theme.variant, value: theme.theme.variants[theme.variant] }
 			};
 		}
 		return { theme: theme.theme, variant: theme.variant };
@@ -46,7 +46,7 @@ function createThemeInjectorPayload(
 			return { theme, variant };
 		}
 
-		return { theme: theme, variant: { name: variant, variant: theme.variants[variant] } };
+		return { theme: theme, variant: { name: variant, value: theme.variants[variant] } };
 	}
 	return { theme };
 }

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -130,9 +130,14 @@ export interface Variant {
 	root: string;
 }
 
+export interface NamedVariant {
+	name: string;
+	variant: Variant;
+}
+
 export interface ThemeWithVariant {
-	theme: Theme | ThemeWithVariants;
-	variant: Variant | string;
+	theme: ThemeWithVariants;
+	variant: NamedVariant;
 }
 
 export interface ThemeWithVariants {

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -132,7 +132,7 @@ export interface Variant {
 
 export interface NamedVariant {
 	name: string;
-	variant: Variant;
+	value: Variant;
 }
 
 export interface ThemeWithVariant {

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -140,7 +140,7 @@ export const theme = factory(
 			variant() {
 				const { theme } = properties();
 				if (theme && isThemeWithVariant(theme)) {
-					return theme.variant.variant.root;
+					return theme.variant.value.root;
 				}
 			},
 			set,

--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -1,12 +1,18 @@
-import { Theme, Classes, ClassNames, ThemeWithVariant, ThemeWithVariants, Variant } from './../interfaces';
+import { Theme, Classes, ClassNames, ThemeWithVariant, ThemeWithVariants, NamedVariant } from './../interfaces';
 import { create, invalidator, diffProperty, getRegistry } from '../vdom';
 import icache from './icache';
 import injector from './injector';
-import Injector from '../Injector';
 import Set from '../../shim/Set';
 import { shallow, auto } from '../diff';
 import Registry from '../Registry';
-import { ThemeInjector } from '../ThemeInjector';
+import {
+	ThemeInjector,
+	isThemeInjectorPayloadWithVariant,
+	isThemeWithVariants,
+	isThemeWithVariant,
+	ThemeInjectorPayload,
+	ThemeWithVariantsInjectorPayload
+} from '../ThemeInjector';
 
 export { Theme, Classes, ClassNames } from './../interfaces';
 
@@ -18,18 +24,6 @@ export interface ThemeProperties {
 export const THEME_KEY = ' _key';
 
 export const INJECTED_THEME_KEY = '__theme_injector';
-
-function isThemeWithVariant(theme: Theme | ThemeWithVariant): theme is ThemeWithVariant {
-	return theme && theme.hasOwnProperty('variant');
-}
-
-function isThemeWithVariants(theme: Theme | ThemeWithVariants | ThemeWithVariant): theme is ThemeWithVariants {
-	return theme && theme.hasOwnProperty('variants');
-}
-
-function isVariantModule(variant: string | Variant): variant is Variant {
-	return typeof variant !== 'string';
-}
 
 function registerThemeInjector(theme: Theme | ThemeWithVariant | undefined, themeRegistry: Registry): ThemeInjector {
 	const themeInjector = new ThemeInjector(theme);
@@ -47,7 +41,7 @@ export const theme = factory(
 		let themeKeys = new Set();
 
 		diffProperty('theme', properties, (current, next) => {
-			const themeInjector = injector.get<Injector<Theme | undefined>>(INJECTED_THEME_KEY);
+			const themeInjector = injector.get<ThemeInjector>(INJECTED_THEME_KEY);
 			const diffResult = auto(current.theme, next.theme);
 			if (diffResult.changed) {
 				icache.clear();
@@ -55,7 +49,12 @@ export const theme = factory(
 			}
 
 			if (!next.theme && themeInjector) {
-				return themeInjector.get();
+				const themePayload = themeInjector.get();
+				if (isThemeInjectorPayloadWithVariant(themePayload)) {
+					return { theme: themePayload.theme, variant: themePayload.variant };
+				} else if (themePayload) {
+					return themePayload.theme;
+				}
 			}
 		});
 		diffProperty('classes', (current: ThemeProperties, next: ThemeProperties) => {
@@ -91,8 +90,11 @@ export const theme = factory(
 		});
 
 		function set(theme: Theme): void;
-		function set<T extends ThemeWithVariants>(theme: T, variant?: keyof T['variants'] | Variant): void;
-		function set<T extends ThemeWithVariants>(theme: Theme | T, variant?: keyof T['variants'] | Variant): void {
+		function set<T extends ThemeWithVariants>(theme: T, variant?: keyof T['variants'] | NamedVariant): void;
+		function set<T extends ThemeWithVariants>(
+			theme: Theme | T,
+			variant?: keyof T['variants'] | NamedVariant
+		): void {
 			const currentTheme = injector.get<ThemeInjector>(INJECTED_THEME_KEY);
 			if (currentTheme) {
 				if (isThemeWithVariants(theme)) {
@@ -137,20 +139,13 @@ export const theme = factory(
 			},
 			variant() {
 				const { theme } = properties();
-
 				if (theme && isThemeWithVariant(theme)) {
-					if (isVariantModule(theme.variant)) {
-						return theme.variant.root;
-					}
-
-					if (isThemeWithVariants(theme.theme)) {
-						return theme.theme.variants[theme.variant].root;
-					}
+					return theme.variant.variant.root;
 				}
 			},
 			set,
-			get(): Theme | ThemeWithVariant | undefined {
-				const currentTheme = injector.get<Injector<Theme | ThemeWithVariant | undefined>>(INJECTED_THEME_KEY);
+			get(): ThemeWithVariantsInjectorPayload | ThemeInjectorPayload | undefined {
+				const currentTheme = injector.get<ThemeInjector>(INJECTED_THEME_KEY);
 				if (currentTheme) {
 					return currentTheme.get();
 				}

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -165,7 +165,7 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 			const { theme } = this.properties;
 
 			if (theme && isThemeWithVariant(theme)) {
-				return theme.variant.variant.root;
+				return theme.variant.value.root;
 			}
 		}
 

--- a/tests/core/unit/middleware/theme.tsx
+++ b/tests/core/unit/middleware/theme.tsx
@@ -52,7 +52,79 @@ jsdomDescribe('theme middleware', () => {
 		resolvers.resolve();
 		assert.strictEqual(
 			root.outerHTML,
-			'<div><div><div class="themed-root"></div><button></button><div>{"test-key":{"root":"themed-root"}}</div></div></div>'
+			'<div><div><div class="themed-root"></div><button></button><div>{"theme":{"test-key":{"root":"themed-root"}}}</div></div></div>'
+		);
+	});
+
+	it('should allow theme with variant to be set and return details in get', () => {
+		const factory = create({ theme });
+		const css = {
+			' _key': 'test-key',
+			root: 'root'
+		};
+		const widgetTheme = {
+			theme: {
+				'test-key': {
+					root: 'themed-root'
+				}
+			},
+			variants: {
+				default: {
+					root: 'default root'
+				},
+				light: {
+					root: 'light root'
+				}
+			}
+		};
+		const App = factory(function App({ middleware: { theme } }) {
+			const themedCss = theme.classes(css);
+			return (
+				<div>
+					<div classes={themedCss.root} />
+					<button
+						onclick={() => {
+							theme.set(widgetTheme);
+						}}
+					/>
+					<button
+						onclick={() => {
+							theme.set(widgetTheme, 'light');
+						}}
+					/>
+					<button
+						onclick={() => {
+							theme.set(widgetTheme, { name: 'custom', variant: { root: 'custom variant' } });
+						}}
+					/>
+					<div>{JSON.stringify(theme.get())}</div>
+				</div>
+			);
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App />);
+		r.mount({ domNode: root });
+		assert.strictEqual(
+			root.outerHTML,
+			'<div><div><div class="root"></div><button></button><button></button><button></button><div></div></div></div>'
+		);
+		(root.children[0].children[1] as HTMLButtonElement).click();
+		resolvers.resolve();
+		assert.strictEqual(
+			root.outerHTML,
+			'<div><div><div class="themed-root"></div><button></button><button></button><button></button><div>{"theme":{"theme":{"test-key":{"root":"themed-root"}},"variants":{"default":{"root":"default root"},"light":{"root":"light root"}}},"variant":{"name":"default","variant":{"root":"default root"}}}</div></div></div>'
+		);
+		(root.children[0].children[2] as HTMLButtonElement).click();
+		resolvers.resolve();
+		assert.strictEqual(
+			root.outerHTML,
+			'<div><div><div class="themed-root"></div><button></button><button></button><button></button><div>{"theme":{"theme":{"test-key":{"root":"themed-root"}},"variants":{"default":{"root":"default root"},"light":{"root":"light root"}}},"variant":{"name":"light","variant":{"root":"light root"}}}</div></div></div>'
+		);
+		(root.children[0].children[3] as HTMLButtonElement).click();
+		resolvers.resolve();
+		assert.strictEqual(
+			root.outerHTML,
+			'<div><div><div class="themed-root"></div><button></button><button></button><button></button><div>{"theme":{"theme":{"test-key":{"root":"themed-root"}},"variants":{"default":{"root":"default root"},"light":{"root":"light root"}}},"variant":{"name":"custom","variant":{"root":"custom variant"}}}</div></div></div>'
 		);
 	});
 
@@ -154,7 +226,7 @@ jsdomDescribe('theme middleware', () => {
 		resolvers.resolve();
 		assert.strictEqual(
 			root.outerHTML,
-			'<div><div><div class="themed-root classes-root"></div><button></button><div>{"test-key":{"root":"themed-root"}}</div></div></div>'
+			'<div><div><div class="themed-root classes-root"></div><button></button><div>{"theme":{"test-key":{"root":"themed-root"}}}</div></div></div>'
 		);
 	});
 
@@ -162,12 +234,22 @@ jsdomDescribe('theme middleware', () => {
 		const factory = create({ theme });
 		const themeWithVariant = {
 			theme: {
-				'test-key': {
-					root: 'themed-root'
+				theme: {
+					'test-key': {
+						root: 'themed-root'
+					}
+				},
+				variants: {
+					default: {
+						root: 'variant-root'
+					}
 				}
 			},
 			variant: {
-				root: 'variant-root'
+				name: 'default',
+				variant: {
+					root: 'variant-root'
+				}
 			}
 		};
 
@@ -277,7 +359,11 @@ jsdomDescribe('theme middleware', () => {
 			return <div classes={variantRoot} />;
 		});
 		const root = document.createElement('div');
-		const r = renderer(() => <App theme={{ theme: themeWithVariants, variant: themeWithVariants.variants.foo }} />);
+		const r = renderer(() => (
+			<App
+				theme={{ theme: themeWithVariants, variant: { name: 'foo', variant: themeWithVariants.variants.foo } }}
+			/>
+		));
 		r.mount({ domNode: root });
 		assert.strictEqual(root.innerHTML, '<div class="foo-variant-root"></div>');
 	});
@@ -305,7 +391,11 @@ jsdomDescribe('theme middleware', () => {
 			return <div classes={variantRoot} />;
 		});
 		const root = document.createElement('div');
-		const r = renderer(() => <App theme={{ theme: themeWithVariants, variant: 'bar' }} />);
+		const r = renderer(() => (
+			<App
+				theme={{ theme: themeWithVariants, variant: { name: 'bar', variant: themeWithVariants.variants.bar } }}
+			/>
+		));
 		r.mount({ domNode: root });
 		assert.strictEqual(root.innerHTML, '<div class="bar-variant-root"></div>');
 	});

--- a/tests/core/unit/middleware/theme.tsx
+++ b/tests/core/unit/middleware/theme.tsx
@@ -112,19 +112,19 @@ jsdomDescribe('theme middleware', () => {
 		resolvers.resolve();
 		assert.strictEqual(
 			root.outerHTML,
-			'<div><div><div class="themed-root"></div><button></button><button></button><button></button><div>{"theme":{"theme":{"test-key":{"root":"themed-root"}},"variants":{"default":{"root":"default root"},"light":{"root":"light root"}}},"variant":{"name":"default","variant":{"root":"default root"}}}</div></div></div>'
+			'<div><div><div class="themed-root"></div><button></button><button></button><button></button><div>{"theme":{"theme":{"test-key":{"root":"themed-root"}},"variants":{"default":{"root":"default root"},"light":{"root":"light root"}}},"variant":{"name":"default","value":{"root":"default root"}}}</div></div></div>'
 		);
 		(root.children[0].children[2] as HTMLButtonElement).click();
 		resolvers.resolve();
 		assert.strictEqual(
 			root.outerHTML,
-			'<div><div><div class="themed-root"></div><button></button><button></button><button></button><div>{"theme":{"theme":{"test-key":{"root":"themed-root"}},"variants":{"default":{"root":"default root"},"light":{"root":"light root"}}},"variant":{"name":"light","variant":{"root":"light root"}}}</div></div></div>'
+			'<div><div><div class="themed-root"></div><button></button><button></button><button></button><div>{"theme":{"theme":{"test-key":{"root":"themed-root"}},"variants":{"default":{"root":"default root"},"light":{"root":"light root"}}},"variant":{"name":"light","value":{"root":"light root"}}}</div></div></div>'
 		);
 		(root.children[0].children[3] as HTMLButtonElement).click();
 		resolvers.resolve();
 		assert.strictEqual(
 			root.outerHTML,
-			'<div><div><div class="themed-root"></div><button></button><button></button><button></button><div>{"theme":{"theme":{"test-key":{"root":"themed-root"}},"variants":{"default":{"root":"default root"},"light":{"root":"light root"}}},"variant":{"name":"custom","variant":{"root":"custom variant"}}}</div></div></div>'
+			'<div><div><div class="themed-root"></div><button></button><button></button><button></button><div>{"theme":{"theme":{"test-key":{"root":"themed-root"}},"variants":{"default":{"root":"default root"},"light":{"root":"light root"}}},"variant":{"name":"custom","value":{"root":"custom variant"}}}</div></div></div>'
 		);
 	});
 

--- a/tests/core/unit/middleware/theme.tsx
+++ b/tests/core/unit/middleware/theme.tsx
@@ -94,7 +94,7 @@ jsdomDescribe('theme middleware', () => {
 					/>
 					<button
 						onclick={() => {
-							theme.set(widgetTheme, { name: 'custom', variant: { root: 'custom variant' } });
+							theme.set(widgetTheme, { name: 'custom', value: { root: 'custom variant' } });
 						}}
 					/>
 					<div>{JSON.stringify(theme.get())}</div>
@@ -247,7 +247,7 @@ jsdomDescribe('theme middleware', () => {
 			},
 			variant: {
 				name: 'default',
-				variant: {
+				value: {
 					root: 'variant-root'
 				}
 			}
@@ -361,7 +361,7 @@ jsdomDescribe('theme middleware', () => {
 		const root = document.createElement('div');
 		const r = renderer(() => (
 			<App
-				theme={{ theme: themeWithVariants, variant: { name: 'foo', variant: themeWithVariants.variants.foo } }}
+				theme={{ theme: themeWithVariants, variant: { name: 'foo', value: themeWithVariants.variants.foo } }}
 			/>
 		));
 		r.mount({ domNode: root });
@@ -393,7 +393,7 @@ jsdomDescribe('theme middleware', () => {
 		const root = document.createElement('div');
 		const r = renderer(() => (
 			<App
-				theme={{ theme: themeWithVariants, variant: { name: 'bar', variant: themeWithVariants.variants.bar } }}
+				theme={{ theme: themeWithVariants, variant: { name: 'bar', value: themeWithVariants.variants.bar } }}
 			/>
 		));
 		r.mount({ domNode: root });

--- a/tests/core/unit/mixins/Themed.ts
+++ b/tests/core/unit/mixins/Themed.ts
@@ -372,7 +372,7 @@ registerSuite('ThemedMixin', {
 					theme: themeWithVariants,
 					variant: {
 						name: 'default',
-						variant: {
+						value: {
 							root: 'default-variant-root'
 						}
 					}
@@ -412,7 +412,7 @@ registerSuite('ThemedMixin', {
 					},
 					variant: {
 						name: 'default',
-						variant: {
+						value: {
 							root: 'variant-root'
 						}
 					}
@@ -512,7 +512,7 @@ registerSuite('ThemedMixin', {
 					},
 					variant: {
 						name: 'default',
-						variant: {
+						value: {
 							root: 'variant-root'
 						}
 					}
@@ -547,7 +547,7 @@ registerSuite('ThemedMixin', {
 					},
 					variant: {
 						name: 'default',
-						variant: {
+						value: {
 							root: 'variant-root'
 						}
 					}
@@ -568,7 +568,7 @@ registerSuite('ThemedMixin', {
 					},
 					variant: {
 						name: 'custom',
-						variant: {
+						value: {
 							root: 'second-variant-root'
 						}
 					}
@@ -605,7 +605,7 @@ registerSuite('ThemedMixin', {
 					},
 					variant: {
 						name: 'custom',
-						variant: {
+						value: {
 							root: 'variant-root'
 						}
 					}

--- a/tests/core/unit/mixins/Themed.ts
+++ b/tests/core/unit/mixins/Themed.ts
@@ -20,7 +20,7 @@ import testTheme1 from './../../support/styles/theme1.css';
 import testTheme2 from './../../support/styles/theme2.css';
 import testTheme3 from './../../support/styles/theme3.css';
 import { VNode } from '../../../../src/core/interfaces';
-import Injector from '../../../../src/core/Injector';
+import ThemeInjector from '../../../../src/core/ThemeInjector';
 
 (baseThemeClasses1 as any)[' _key'] = 'testPath1';
 (baseThemeClasses2 as any)[' _key'] = 'testPath2';
@@ -239,7 +239,7 @@ registerSuite('ThemedMixin', {
 		},
 		'injecting a theme': {
 			'theme can be injected by defining a ThemeInjector with registry'() {
-				const injector = () => () => new Injector(testTheme1);
+				const injector = () => () => new ThemeInjector(testTheme1);
 				testRegistry.defineInjector(INJECTED_THEME_KEY, injector);
 				class InjectedTheme extends TestWidget {
 					render() {
@@ -356,14 +356,25 @@ registerSuite('ThemedMixin', {
 		},
 		variants: {
 			'theme variant can be injected via a registry'() {
-				const themeWithVariant = {
+				const themeWithVariants = {
 					theme: {
 						'test-key': {
-							root: 'themed-root'
+							root: 'variant-themed-root'
 						}
 					},
+					variants: {
+						default: {
+							root: 'default-variant-root'
+						}
+					}
+				};
+				const themeWithVariant = {
+					theme: themeWithVariants,
 					variant: {
-						root: 'default-variant-root'
+						name: 'default',
+						variant: {
+							root: 'default-variant-root'
+						}
 					}
 				};
 
@@ -388,12 +399,22 @@ registerSuite('ThemedMixin', {
 
 				const themeWithVariant = {
 					theme: {
-						'test-key': {
-							root: 'variant-themed-root'
+						theme: {
+							'test-key': {
+								root: 'variant-themed-root'
+							}
+						},
+						variants: {
+							default: {
+								root: 'variant-root'
+							}
 						}
 					},
 					variant: {
-						root: 'variant-root'
+						name: 'default',
+						variant: {
+							root: 'variant-root'
+						}
 					}
 				};
 
@@ -478,12 +499,22 @@ registerSuite('ThemedMixin', {
 			'theme variant can be set at the widget level'() {
 				const themeWithVariant = {
 					theme: {
-						'test-key': {
-							root: 'themed-root'
+						theme: {
+							'test-key': {
+								root: 'variant-themed-root'
+							}
+						},
+						variants: {
+							default: {
+								root: 'variant-root'
+							}
 						}
 					},
 					variant: {
-						root: 'variant-root'
+						name: 'default',
+						variant: {
+							root: 'variant-root'
+						}
 					}
 				};
 
@@ -503,23 +534,43 @@ registerSuite('ThemedMixin', {
 			'theme property overrides injected property'() {
 				const themeWithVariant = {
 					theme: {
-						'test-key': {
-							root: 'themed-root'
+						theme: {
+							'test-key': {
+								root: 'variant-themed-root'
+							}
+						},
+						variants: {
+							default: {
+								root: 'variant-root'
+							}
 						}
 					},
 					variant: {
-						root: 'variant-root'
+						name: 'default',
+						variant: {
+							root: 'variant-root'
+						}
 					}
 				};
 
 				const secondThemeWithVariant = {
 					theme: {
-						'test-key': {
-							root: 'themed-root'
+						theme: {
+							'test-key': {
+								root: 'themed-root'
+							}
+						},
+						variants: {
+							default: {
+								root: 'variant-root'
+							}
 						}
 					},
 					variant: {
-						root: 'second-variant-root'
+						name: 'custom',
+						variant: {
+							root: 'second-variant-root'
+						}
 					}
 				};
 
@@ -553,7 +604,10 @@ registerSuite('ThemedMixin', {
 						}
 					},
 					variant: {
-						root: 'variant-root'
+						name: 'custom',
+						variant: {
+							root: 'variant-root'
+						}
 					}
 				};
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Normalise the `ThemePayload` API to ensure that enough information stored to be able to pass everything back when using `themeContext.get()` or the middleware `theme.get()`.

This now always stores the `theme` but also stores the current `variant` with the name and the variant contents.

If the theme does not have any variants then it will be just the theme stored under `theme`. This is a breaking change, as it never used to be wrapped in an object.
