### PR TITLE
Shim for `array.flat` and `array.flatMap` and use `flat` to spread tsx children

### DIFF
--- a/src/core/has.ts
+++ b/src/core/has.ts
@@ -223,6 +223,8 @@ add(
 
 add('es7-array', () => 'includes' in global.Array.prototype, true);
 
+add('es2019-array', () => 'flat' in global.Array.prototype, true);
+
 /* Map */
 add(
 	'es6-map',

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -3,6 +3,7 @@ import has from '../core/has';
 import WeakMap from '../shim/WeakMap';
 import Set from '../shim/Set';
 import Map from '../shim/Map';
+import { flat } from '../shim/array';
 import {
 	WNode,
 	VNode,
@@ -486,16 +487,8 @@ export function fromRegistry<P>(tag: string): Constructor<FromRegistry<P>> {
 	};
 }
 
-function spreadChildren(children: any[], child: any): any[] {
-	if (Array.isArray(child)) {
-		return child.reduce(spreadChildren, children);
-	} else {
-		return [...children, child];
-	}
-}
-
 export function tsx(tag: any, properties = {}, ...children: any[]): DNode {
-	children = children.reduce(spreadChildren, []);
+	children = flat(children, Infinity);
 	properties = properties === null ? {} : properties;
 	if (typeof tag === 'string') {
 		return v(tag, properties, children);

--- a/src/shim/array.ts
+++ b/src/shim/array.ts
@@ -435,7 +435,7 @@ if (!has('es7-array')) {
 	};
 }
 
-if (!has('es7-array')) {
+if (!has('es2019-array')) {
 	Array.prototype.flat = function flat(depth: number = 1) {
 		return depth > 0
 			? this.reduce((acc, val) => acc.concat(Array.isArray(val) ? val.flat(depth - 1) : val), [])

--- a/src/shim/array.ts
+++ b/src/shim/array.ts
@@ -133,6 +133,24 @@ export interface Flat {
 	<U>(arr: any[], depth?: number): any[];
 }
 
+export interface FlatMap {
+	/**
+	 * Calls a defined callback function on each element of an array. Then, flattens the result into
+	 * a new array.
+	 * This is identical to a map followed by flat with depth 1.
+	 *
+	 * @param callback A function that accepts up to three arguments. The flatMap method calls the
+	 * callback function one time for each element in the array.
+	 * @param thisArg An object to which the this keyword can refer in the callback function. If
+	 * thisArg is omitted, undefined is used as the this value.
+	 */
+	<U, T extends any, This = undefined>(
+		arr: T[],
+		callback: (this: This, value: T, index: number, array: T[]) => U | ReadonlyArray<U>,
+		thisArg?: This
+	): U[];
+}
+
 export let from: From;
 
 /**
@@ -207,6 +225,8 @@ export let includes: <T>(target: ArrayLike<T>, searchElement: T, fromIndex?: num
  * @param depth The depth to flatten too, defaults to 1.
  */
 export let flat: Flat;
+
+export let flatMap: FlatMap;
 
 // Util functions for filled implementations
 
@@ -421,6 +441,10 @@ if (!has('es7-array')) {
 			? this.reduce((acc, val) => acc.concat(Array.isArray(val) ? val.flat(depth - 1) : val), [])
 			: this.slice();
 	};
+
+	Array.prototype.flatMap = function flatMap(callback: any) {
+		return this.map(callback).flat();
+	};
 }
 
 from = Array.from;
@@ -429,6 +453,7 @@ copyWithin = wrapNative(Array.prototype.copyWithin);
 fill = wrapNative(Array.prototype.fill);
 find = wrapNative(Array.prototype.find);
 flat = wrapNative(Array.prototype.flat) as any;
+flatMap = wrapNative(Array.prototype.flatMap) as any;
 findIndex = wrapNative(Array.prototype.findIndex);
 includes = wrapNative(Array.prototype.includes);
 

--- a/src/shim/array.ts
+++ b/src/shim/array.ts
@@ -113,6 +113,14 @@ export let findIndex: <T>(target: ArrayLike<T>, callback: FindCallback<T>, thisA
  */
 export let includes: <T>(target: ArrayLike<T>, searchElement: T, fromIndex?: number) => boolean;
 
+/**
+ * Flattens arrays to the depth specified
+ *
+ * @param target An array-like object
+ * @param depth The depth to flatten too, defaults to 1.
+ */
+export let flat: (target: ArrayLike<any>, depth?: number) => any[];
+
 // Util functions for filled implementations
 
 let toLength: any;
@@ -320,11 +328,20 @@ if (!has('es7-array')) {
 	};
 }
 
+if (!has('es7-array')) {
+	Array.prototype.flat = function flat(depth: number = 1) {
+		return depth > 0
+			? this.reduce((acc, val) => acc.concat(Array.isArray(val) ? val.flat(depth - 1) : val), [])
+			: this.slice();
+	};
+}
+
 from = Array.from;
 of = Array.of;
 copyWithin = wrapNative(Array.prototype.copyWithin);
 fill = wrapNative(Array.prototype.fill);
 find = wrapNative(Array.prototype.find);
+flat = wrapNative(Array.prototype.flat);
 findIndex = wrapNative(Array.prototype.findIndex);
 includes = wrapNative(Array.prototype.includes);
 

--- a/src/shim/array.ts
+++ b/src/shim/array.ts
@@ -46,6 +46,93 @@ export interface From {
 	<T>(source: ArrayLike<T> | Iterable<T>): Array<T>;
 }
 
+export interface Flat {
+	/**
+	 * Returns a new array with all sub-array elements concatenated into it recursively up to the
+	 * specified depth.
+	 *
+	 * @param depth The maximum recursion depth
+	 */
+	<U>(
+		arr:
+			| ReadonlyArray<U[][][][]>
+			| ReadonlyArray<ReadonlyArray<U[][][]>>
+			| ReadonlyArray<ReadonlyArray<U[][]>[]>
+			| ReadonlyArray<ReadonlyArray<U[]>[][]>
+			| ReadonlyArray<ReadonlyArray<U>[][][]>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U[][]>>>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U>[][]>>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>[][]>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U>[]>[]>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U[]>>[]>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U[]>[]>>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U[]>>>>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>[]>>>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>[]>>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>[]>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>>>,
+		depth: 4
+	): U[];
+
+	/**
+	 * Returns a new array with all sub-array elements concatenated into it recursively up to the
+	 * specified depth.
+	 *
+	 * @param depth The maximum recursion depth
+	 */
+	<U>(
+		arr:
+			| ReadonlyArray<U[][][]>
+			| ReadonlyArray<ReadonlyArray<U>[][]>
+			| ReadonlyArray<ReadonlyArray<U[]>[]>
+			| ReadonlyArray<ReadonlyArray<U[][]>>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U[]>>>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U>[]>>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>[]>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>>,
+		depth: 3
+	): U[];
+
+	/**
+	 * Returns a new array with all sub-array elements concatenated into it recursively up to the
+	 * specified depth.
+	 *
+	 * @param depth The maximum recursion depth
+	 */
+	<U>(
+		arr:
+			| ReadonlyArray<U[][]>
+			| ReadonlyArray<ReadonlyArray<U[]>>
+			| ReadonlyArray<ReadonlyArray<U>[]>
+			| ReadonlyArray<ReadonlyArray<ReadonlyArray<U>>>,
+		depth: 2
+	): U[];
+
+	/**
+	 * Returns a new array with all sub-array elements concatenated into it recursively up to the
+	 * specified depth.
+	 *
+	 * @param depth The maximum recursion depth
+	 */
+	<U>(arr: ReadonlyArray<U[]> | ReadonlyArray<ReadonlyArray<U>>, depth?: 1): U[];
+
+	/**
+	 * Returns a new array with all sub-array elements concatenated into it recursively up to the
+	 * specified depth.
+	 *
+	 * @param depth The maximum recursion depth
+	 */
+	<U>(arr: ReadonlyArray<U>, depth: 0): U[];
+
+	/**
+	 * Returns a new array with all sub-array elements concatenated into it recursively up to the
+	 * specified depth. If no depth is provided, flat method defaults to the depth of 1.
+	 *
+	 * @param depth The maximum recursion depth
+	 */
+	<U>(arr: any[], depth?: number): any[];
+}
+
 export let from: From;
 
 /**
@@ -119,7 +206,7 @@ export let includes: <T>(target: ArrayLike<T>, searchElement: T, fromIndex?: num
  * @param target An array-like object
  * @param depth The depth to flatten too, defaults to 1.
  */
-export let flat: (target: ArrayLike<any>, depth?: number) => any[];
+export let flat: Flat;
 
 // Util functions for filled implementations
 
@@ -341,7 +428,7 @@ of = Array.of;
 copyWithin = wrapNative(Array.prototype.copyWithin);
 fill = wrapNative(Array.prototype.fill);
 find = wrapNative(Array.prototype.find);
-flat = wrapNative(Array.prototype.flat);
+flat = wrapNative(Array.prototype.flat) as any;
 findIndex = wrapNative(Array.prototype.findIndex);
 includes = wrapNative(Array.prototype.includes);
 

--- a/tests/shim/unit/array.ts
+++ b/tests/shim/unit/array.ts
@@ -552,7 +552,7 @@ registerSuite('array', {
 	),
 
 	'#flat': createNativeAndDojoArrayTests(
-		'es7-array',
+		'es2019-array',
 		(function() {
 			let arr: any[];
 			return {
@@ -582,7 +582,7 @@ registerSuite('array', {
 	),
 
 	'#flatMap': createNativeAndDojoArrayTests(
-		'es7-array',
+		'es2019-array',
 		(function() {
 			let arr: any[];
 			return {

--- a/tests/shim/unit/array.ts
+++ b/tests/shim/unit/array.ts
@@ -551,6 +551,36 @@ registerSuite('array', {
 		})()
 	),
 
+	'#flat': createNativeAndDojoArrayTests(
+		'es7-array',
+		(function() {
+			let arr: any[];
+			return {
+				beforeEach() {
+					arr = [1, '2', NaN, [3], [4, [5, [6]]], 7];
+				},
+
+				'flatten to default depth of 1'() {
+					const flattened = array.flat(arr);
+					assert.deepEqual(flattened, [1, '2', NaN, 3, 4, [5, [6]], 7]);
+					assert.deepEqual(arr, [1, '2', NaN, [3], [4, [5, [6]]], 7]);
+				},
+
+				'flatten to specific depth'() {
+					const flattened = array.flat(arr, 2);
+					assert.deepEqual(flattened, [1, '2', NaN, 3, 4, 5, [6], 7]);
+					assert.deepEqual(arr, [1, '2', NaN, [3], [4, [5, [6]]], 7]);
+				},
+
+				'flatten recursively'() {
+					const flattened = array.flat(arr, Infinity);
+					assert.deepEqual(flattened, [1, '2', NaN, 3, 4, 5, 6, 7]);
+					assert.deepEqual(arr, [1, '2', NaN, [3], [4, [5, [6]]], 7]);
+				}
+			};
+		})()
+	),
+
 	'extension support': createDojoTests('es6-array', {
 		'.from()': function() {
 			let actual = MyArray.from([1, 2, 3]);

--- a/tests/shim/unit/array.ts
+++ b/tests/shim/unit/array.ts
@@ -581,6 +581,30 @@ registerSuite('array', {
 		})()
 	),
 
+	'#flatMap': createNativeAndDojoArrayTests(
+		'es7-array',
+		(function() {
+			let arr: any[];
+			return {
+				beforeEach() {
+					arr = [1, 2, 3, 4];
+				},
+
+				'maps and flattens'() {
+					const flatMapped = array.flatMap(arr, (x) => [x * 2]);
+					assert.deepEqual(flatMapped, [2, 4, 6, 8]);
+					assert.deepEqual(arr, [1, 2, 3, 4]);
+				},
+
+				'only flattens to depth of 1'() {
+					const flatMapped = array.flatMap(arr, (x) => [[x * 2]]);
+					assert.deepEqual(flatMapped, [[2], [4], [6], [8]]);
+					assert.deepEqual(arr, [1, 2, 3, 4]);
+				}
+			};
+		})()
+	),
+
 	'extension support': createDojoTests('es6-array', {
 		'.from()': function() {
 			let actual = MyArray.from([1, 2, 3]);

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -13,7 +13,7 @@
 			"es2015.symbol",
 			"es2015.symbol.wellknown",
 			"es2015.proxy",
-			"ESNext.Array"
+			"ES2019.Array"
 		]
 	},
 	"include": [

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -12,7 +12,8 @@
 			"es2015.promise",
 			"es2015.symbol",
 			"es2015.symbol.wellknown",
-			"es2015.proxy"
+			"es2015.proxy",
+			"ESNext.Array"
 		]
 	},
 	"include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
 			"es2015.symbol",
 			"es2015.symbol.wellknown",
 			"es2015.proxy",
-			"ESNext.Array"
+			"ES2019.Array"
 		]
 	},
 	"include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
 			"es2015.promise",
 			"es2015.symbol",
 			"es2015.symbol.wellknown",
-			"es2015.proxy"
+			"es2015.proxy",
+			"ESNext.Array"
 		]
 	},
 	"include": [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

* Adds a shim for `array.flat` and `array.flatMap` in `@dojo/framework/shim`
* Uses `flat` in `tsx` to flatten the children passed.