### PR TITLE
Adding JSON deserialization to custom element properties (#748)

### DIFF
--- a/src/core/registerCustomElement.ts
+++ b/src/core/registerCustomElement.ts
@@ -107,10 +107,15 @@ function registerThemeInjector(theme: any, themeRegistry: Registry): ThemeInject
 }
 
 export function create(descriptor: any, WidgetConstructor: any): any {
-	const { attributes = [], registryFactory = () => new Registry() } = descriptor;
+	const { attributes = [], properties = [], registryFactory = () => new Registry() } = descriptor;
 	const attributeMap: any = {};
 
 	attributes.forEach((propertyName: string) => {
+		const attributeName = propertyName.toLowerCase();
+		attributeMap[attributeName] = propertyName;
+	});
+
+	properties.forEach((propertyName: string) => {
 		const attributeName = propertyName.toLowerCase();
 		attributeMap[attributeName] = propertyName;
 	});
@@ -164,7 +169,10 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 			const domProperties: any = {};
 			const { properties = [], events = [] } = descriptor;
 
-			this._properties = { ...this._properties, ...this._attributesToProperties(attributes) };
+			this._properties = {
+				...this._propertiesWithAttributes(properties),
+				...this._attributesToProperties(attributes)
+			};
 
 			[...attributes, ...properties].forEach((propertyName: string) => {
 				const isReservedProp = RESERVED_PROPS.indexOf(propertyName) !== -1;
@@ -351,7 +359,17 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 
 		public attributeChangedCallback(name: string, oldValue: string | null, value: string | null) {
 			const propertyName = attributeMap[name];
-			this._setProperty(propertyName, value);
+
+			if (attributes.indexOf(propertyName) >= 0) {
+				this._setProperty(propertyName, value);
+			} else {
+				try {
+					const parsedValue = value ? JSON.parse(value) : null;
+					this._setProperty(propertyName, parsedValue);
+				} catch (e) {
+					// if json parsing error, we do not set the property
+				}
+			}
 		}
 
 		private _setEventProperty(propertyName: string, value: any) {
@@ -369,6 +387,21 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 
 		private _getProperty(propertyName: string) {
 			return this._properties[propertyName];
+		}
+
+		private _propertiesWithAttributes(properties: string[]) {
+			return properties.reduce((properties: any, propertyName: string) => {
+				const attributeName = propertyName.toLowerCase();
+				const value = this.getAttribute(attributeName);
+				if (value !== null) {
+					try {
+						properties[propertyName] = JSON.parse(value);
+					} catch (e) {
+						// invalid json values do not get set
+					}
+				}
+				return properties;
+			}, {});
 		}
 
 		private _attributesToProperties(attributes: string[]) {

--- a/tests/core/unit/registerCustomElement.ts
+++ b/tests/core/unit/registerCustomElement.ts
@@ -937,4 +937,98 @@ describe('registerCustomElement', () => {
 		assert.isTrue(child.getAttribute('slot') === 'foo');
 		assert.isTrue(child.innerHTML === '<label>i am a child</label>');
 	});
+
+	it('parses initial properties as attributes', () => {
+		@customElement({
+			tag: 'attribute-properties-initial',
+			properties: ['bar'],
+			attributes: ['foo'],
+			events: []
+		})
+		class WidgetA extends WidgetBase<any> {
+			render() {
+				return v('div', {}, [JSON.stringify(this.properties.foo), JSON.stringify(this.properties.bar)]);
+			}
+		}
+
+		const CustomElementParent = create((WidgetA as any).__customElementDescriptor, WidgetA);
+
+		customElements.define('attribute-properties-initial', CustomElementParent);
+
+		const element = document.createElement('attribute-properties-initial');
+		element.setAttribute('foo', '[1,2,3]');
+		element.setAttribute('bar', '[1,2,3]');
+
+		document.body.appendChild(element);
+
+		resolvers.resolve();
+
+		assert.deepEqual(element.innerHTML, '<div>"[1,2,3]"[1,2,3]</div>');
+	});
+
+	it('parses observed property attributes', () => {
+		@customElement({
+			tag: 'attribute-properties-observed',
+			properties: ['bar'],
+			attributes: ['foo'],
+			events: []
+		})
+		class WidgetA extends WidgetBase<any> {
+			render() {
+				return v('div', {}, [
+					JSON.stringify(this.properties.foo),
+					JSON.stringify(this.properties.bar || false)
+				]);
+			}
+		}
+
+		const CustomElementParent = create((WidgetA as any).__customElementDescriptor, WidgetA);
+
+		customElements.define('attribute-properties-observed', CustomElementParent);
+
+		const element = document.createElement('attribute-properties-observed');
+		element.setAttribute('foo', '[1,2,3]');
+
+		document.body.appendChild(element);
+
+		resolvers.resolve();
+
+		assert.deepEqual(element.innerHTML, '<div>"[1,2,3]"false</div>');
+
+		element.setAttribute('bar', '[1,2,3]');
+		resolvers.resolve();
+
+		assert.deepEqual(element.innerHTML, '<div>"[1,2,3]"[1,2,3]</div>');
+	});
+
+	it('ignores improper json in property parsing', () => {
+		@customElement({
+			tag: 'attribute-properties-invalid',
+			properties: ['bar'],
+			events: []
+		})
+		class WidgetA extends WidgetBase<any> {
+			render() {
+				return v('div', {}, [JSON.stringify(this.properties.bar || false)]);
+			}
+		}
+
+		const CustomElementParent = create((WidgetA as any).__customElementDescriptor, WidgetA);
+
+		customElements.define('attribute-properties-invalid', CustomElementParent);
+
+		const element = document.createElement('attribute-properties-invalid');
+		element.setAttribute('bar', 'invalid');
+
+		document.body.appendChild(element);
+
+		resolvers.resolve();
+
+		assert.deepEqual(element.innerHTML, '<div>false</div>');
+
+		element.setAttribute('bar', '[1,2,3');
+		resolvers.resolve();
+
+		assert.deepEqual(element.innerHTML, '<div>false</div>');
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding JSON serialization to custom element properties. Any property that is not an attribute will have it's new value deserialized as JSON. If the result is valid, it will be set as the property value.  If the result is not valid, it will be ignored.

Resolves #748