### PR TITLE
Fix error when no theme is injected

### DIFF
--- a/src/core/ThemeInjector.ts
+++ b/src/core/ThemeInjector.ts
@@ -23,9 +23,9 @@ export function isThemeWithVariants(theme: Theme | ThemeWithVariants | ThemeWith
 }
 
 export function isThemeInjectorPayloadWithVariant(
-	theme: ThemeInjectorPayload | ThemeWithVariantsInjectorPayload
+	theme: ThemeInjectorPayload | ThemeWithVariantsInjectorPayload | undefined
 ): theme is ThemeWithVariantsInjectorPayload {
-	return theme && theme.hasOwnProperty('variant');
+	return !!theme && theme.hasOwnProperty('variant');
 }
 
 function createThemeInjectorPayload(
@@ -63,7 +63,7 @@ export class ThemeInjector extends Injector {
 		super.set(createThemeInjectorPayload(theme, variant));
 	}
 
-	get(): ThemeWithVariantsInjectorPayload | ThemeInjectorPayload {
+	get(): ThemeWithVariantsInjectorPayload | ThemeInjectorPayload | undefined {
 		return super.get();
 	}
 }

--- a/src/core/mixins/Themed.ts
+++ b/src/core/mixins/Themed.ts
@@ -110,8 +110,9 @@ export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties
 				const payload = theme.get();
 				if (isThemeInjectorPayloadWithVariant(payload)) {
 					return { theme: payload };
+				} else if (payload) {
+					return { theme: payload.theme };
 				}
-				return { theme: payload.theme };
 			}
 			return {};
 		}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Missed a scenario where the theme context could be undefined for the Themed mixin. Resolves the current failing test on master.