### PR TITLE
Simplify using memory resources and data with Dojo Resources

### DIFF
--- a/docs/en/resources/introduction.md
+++ b/docs/en/resources/introduction.md
@@ -1,11 +1,10 @@
 # Introduction
 
-Dojo **resource** provides a consistent means to make widgets data aware.
-
-A Dojo resource is initialized with a `DataTemplate` that describes how to read data, and enables creation of a single data store which can be passed into multiple widgets. It allows data to be cached, transformed and filtered to suit the needs of the widget using it. Coupled with the data middleware, resources allow consistent, source-agnostic data access for widgets, without the widgets being aware of the underlying data fetching implementation or the raw data format being used, as these are abstracted away by both the template read mechanism and the resource.
+Dojo **resource** provides a consistent means to make widgets data aware. A `resource` is initialized with a `DataTemplate` that describes how to read data, and enables creation of a single data store which can be passed into multiple widgets. It allows data to be cached, transformed and filtered to suit the needs of the widget using it. Coupled with the data middleware, resources allow consistent, source-agnostic data access for widgets, without the widgets being aware of the underlying data fetching implementation or the raw data format being used, as these are abstracted away by both the template read mechanism and the resource.
 
 | Feature                                   | Description                                                                                                                                                                                  |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Built in support for memory resources** | Default support for using resources with in-memory data.                                                                                                                                     |
 | **Single data source**                    | Resources allow creation of a single source of data for a given template that can be shared between multiple widgets using the data middleware.                                              |
 | **Data transforms**                       | Allows specifying the data format that a widget requires, and transparently transforms source data into the expected output format for the widget to consume                                 |
 | **Support for async and sync data reads** | Resource templates can read data in any way they like - once data becomes available, the data middleware reactively invalidates any affected widgets.                                        |
@@ -18,13 +17,47 @@ A Dojo resource can be created to fetch data in some way, and widgets are then a
 
 ## Creating a resource
 
-A basic resource requires only a `DataTemplate` to be created which specifies a `read` function.
+A basic resource can be created using the `createResource` factory from `@dojo/framework/core/resource` module, configured to work with in-memory data that can be passed within a widget.
+
+> resources.tsx
+
+```tsx
+const resource = createResource();
+```
+
+This `resource` can be used with any data aware widget, with any data that is passed.
+
+> MyWidget.tsx
+
+```tsx
+import { create, tsx } from '@dojo/framework/core/vdom';
+
+import MyDataAwareWidget from './MyDataAwareWidget';
+import myResource from './resources';
+
+const factory = create();
+
+const MyWidget = factory(function MyWidget() {
+	return (
+		<MyDataAwareWidget
+			resource={myResource([
+				/* array of data for the widget to use */
+			])}
+		/>
+	);
+});
+```
+
+## Custom Data Template
+
+To use a `resource` to use a data source instead of requiring data to be passed into the resource on usage, a custom `DataTemplate` is required. By default the `DataTemplate` provided is an in-memory one that needs `data` to be passed on usage. The following is an example of a `DataTemplate` that wires a resource to a remote REST API.
 
 > main.ts
 
 ```ts
-import { DataTemplate, createResource } from '@dojo/framework/core/resource';
-const template: DataTemplate = {
+import { createResource } from '@dojo/framework/core/resource';
+
+const resource = createResource({
 	read: async (options: ReadOptions) => {
 		const { offset, size } = options;
 		let url = `https://my.endpoint.com?offset=${offset}&size=${size}`;
@@ -37,12 +70,10 @@ const template: DataTemplate = {
 			total: data.total
 		};
 	}
-};
-
-const resource = createResource(template);
+});
 ```
 
-When a call is made to the resource api which requires data to be read, the `read` function will be called with the `ReadOptions`, a `put` function and a `get` function. The `ReadOptions` consist of the `offset`, the requested page `size` and a `query` for filtering. The two helper functions can be used to sideload data or to read existing data from the resource. More information on this can be found in the [supplemental documentation](/learn/resource/data-templates).
+When a call is made to the resource api which requires data to be read, the `read` function will be called with the `ReadOptions`, a `put` function and a `get` function. The `ReadOptions` consist of the `offset`, the requested page `size` and a `query` for filtering. The two helper functions can be used to side-load data or to read existing data from the resource. More information on this can be found in the [supplemental documentation](/learn/resource/data-templates).
 
 ## Transforming data
 

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -21,7 +21,7 @@ interface ResourceWrapper {
 }
 
 interface ResourceWithData {
-	resource: () => Resource;
+	resource: Resource;
 	data: any[];
 }
 
@@ -84,7 +84,7 @@ function createResourceWrapper(resource: Resource, options?: OptionsWrapper): Re
 }
 
 function isResourceWithData(resource: any): resource is ResourceWithData {
-	return !!resource.data;
+	return resource && !!resource.data;
 }
 
 function createResourceOptions(
@@ -161,8 +161,8 @@ export function createDataMiddleware<T = void>() {
 			});
 		});
 
-		diffProperty('resource', ({ resource: currentResource }, { resource: nextResource }) => {
-			if (currentResource && nextResource && nextResource.data) {
+		diffProperty('resource', properties, ({ resource: currentResource }, { resource: nextResource }) => {
+			if (isResourceWithData(currentResource) && isResourceWithData(nextResource)) {
 				if (
 					nextResource.data !== currentResource.data ||
 					nextResource.data.length !== currentResource.data.length
@@ -171,6 +171,7 @@ export function createDataMiddleware<T = void>() {
 					invalidator();
 				}
 			}
+			return nextResource;
 		});
 
 		return (dataOptions: DataInitialiserOptions = {}) => {
@@ -178,9 +179,8 @@ export function createDataMiddleware<T = void>() {
 			let resourceWrapperOrResource;
 
 			if (isResourceWithData(passedResourceProperty)) {
-				const { resource: resourceFactory, data } = passedResourceProperty;
+				const { resource, data } = passedResourceProperty;
 				if (!resourceWithDataMap.has(data)) {
-					const resource = resourceFactory();
 					resourceWithDataMap.set(data, resource);
 					resource.set(data);
 				}

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -56,7 +56,7 @@ function isAsyncResponse<S>(response: DataResponsePromise<S> | DataResponse<S>):
 	return (response as any).then !== undefined;
 }
 
-export function defaultFilter(query: ResourceQuery[], v: any) {
+export function defaultFilter(query: ResourceQuery[], item: any) {
 	let filterValue = '';
 
 	query.forEach((q) => {
@@ -69,7 +69,7 @@ export function defaultFilter(query: ResourceQuery[], v: any) {
 		return true;
 	}
 
-	let filterText = v.label || v.value;
+	let filterText = item.label || item.value;
 	return filterText.toLocaleLowerCase().indexOf(filterValue.toLocaleLowerCase()) >= 0;
 }
 

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -60,7 +60,7 @@ export function defaultFilter(query: ResourceQuery[], item: any) {
 	let filterValue = '';
 
 	query.forEach((q) => {
-		if (q.keys.indexOf('value') >= -1) {
+		if (q.keys.indexOf('value') !== -1) {
 			filterValue = q.value || '';
 		}
 	});

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -11,6 +11,7 @@ export interface ResourceOptions {
 export type ResourceQuery = { keys: string[]; value: string | undefined };
 
 export interface Resource<S = any> {
+	(data: S): { resource: Resource<S>; data: S };
 	getOrRead(options: ResourceOptions): any;
 	get(options: ResourceOptions): any;
 	getTotal(options: ResourceOptions): number | undefined;
@@ -280,17 +281,24 @@ export function createResource<S>(config: DataTemplate<S>): Resource<S> {
 		}
 	}
 
-	return {
-		getOrRead,
-		get,
-		getTotal,
-		subscribe,
-		unsubscribe,
-		isFailed,
-		isLoading,
-		set(data: S[]) {
-			setData(0, data, data.length);
-			totalMap.set(getQueryKey(), data.length);
-		}
+	function resource(data: any[]) {
+		return {
+			resource,
+			data
+		};
+	}
+
+	resource.getOrRead = getOrRead;
+	resource.get = get;
+	resource.getTotal = getTotal;
+	resource.subscribe = subscribe;
+	resource.unsubscribe = unsubscribe;
+	resource.isFailed = isFailed;
+	resource.isLoading = isLoading;
+	resource.set = function set(data: S[]) {
+		setData(0, data, data.length);
+		totalMap.set(getQueryKey(), data.length);
 	};
+
+	return resource as Resource<any>;
 }

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -10,7 +10,7 @@ export interface ResourceOptions {
 
 export type ResourceQuery = { keys: string[]; value: string | undefined };
 
-export interface Resource {
+export interface Resource<S = any> {
 	getOrRead(options: ResourceOptions): any;
 	get(options: ResourceOptions): any;
 	getTotal(options: ResourceOptions): number | undefined;
@@ -18,7 +18,7 @@ export interface Resource {
 	isFailed(options: ResourceOptions): boolean;
 	subscribe(type: SubscriptionType, options: ResourceOptions, invalidator: Invalidator): void;
 	unsubscribe(invalidator: Invalidator): void;
-	set(data: any[]): void;
+	set(data: S[]): void;
 }
 
 export type TransformConfig<T, S = void> = { [P in keyof T]: (S extends void ? string : keyof S)[] };
@@ -55,7 +55,7 @@ function isAsyncResponse<S>(response: DataResponsePromise<S> | DataResponse<S>):
 	return (response as any).then !== undefined;
 }
 
-export function createResource<S>(config: DataTemplate<S>): Resource {
+export function createResource<S>(config: DataTemplate<S>): Resource<S> {
 	const { read } = config;
 	let queryMap = new Map<string, S[]>();
 	let statusMap = new Map<string, { [key: string]: Status }>();

--- a/tests/core/unit/middleware/data.tsx
+++ b/tests/core/unit/middleware/data.tsx
@@ -14,16 +14,16 @@ const invalidatorStub = sb.stub();
 const destroyStub = sb.stub();
 const diffPropertyStub = sb.stub();
 
-let resourceStub = {
-	getOrRead: sb.stub(),
-	getTotal: sb.stub(),
-	subscribe: sb.stub(),
-	unsubscribe: sb.stub(),
-	isLoading: sb.stub(),
-	isFailed: sb.stub(),
-	get: sb.stub(),
-	set: sb.stub()
-};
+let resourceStub: any = sb.stub();
+
+resourceStub.getOrRead = sb.stub();
+resourceStub.getTotal = sb.stub();
+resourceStub.subscribe = sb.stub();
+resourceStub.unsubscribe = sb.stub();
+resourceStub.isLoading = sb.stub();
+resourceStub.isFailed = sb.stub();
+resourceStub.get = sb.stub();
+resourceStub.set = sb.stub();
 
 jsdomDescribe('data middleware', () => {
 	beforeEach(() => {
@@ -299,7 +299,7 @@ jsdomDescribe('data middleware', () => {
 	});
 
 	it('can have a resource passed via a different property', () => {
-		const otherResource = {
+		const otherResource: any = {
 			getOrRead: sb.stub(),
 			getTotal: sb.stub(),
 			subscribe: sb.stub(),
@@ -472,7 +472,7 @@ jsdomDescribe('data middleware', () => {
 			return <div>{JSON.stringify(get({}))}</div>;
 		});
 		const root = document.createElement('div');
-		const factoryStub = sb.stub().returns(resourceStub);
+		const factoryStub = resourceStub;
 		const r = renderer(() => (
 			<App resource={{ resource: factoryStub, data: [{ value: 'foo' }, { value: 'bar' }] }} />
 		));
@@ -480,7 +480,7 @@ jsdomDescribe('data middleware', () => {
 		resolvers.resolveRAF();
 		invalidate();
 		resolvers.resolveRAF();
-		assert.isTrue(factoryStub.calledOnce);
+		assert.isTrue(factoryStub.set.calledOnce);
 	});
 
 	it('should call create resource again if the data passed has changed', () => {
@@ -505,7 +505,7 @@ jsdomDescribe('data middleware', () => {
 		});
 
 		const root = document.createElement('div');
-		const factoryStub = sb.stub().returns(resourceStub);
+		const factoryStub = resourceStub;
 		const r = renderer(() => <App />);
 		r.mount({ domNode: root });
 		resolvers.resolveRAF();
@@ -514,6 +514,6 @@ jsdomDescribe('data middleware', () => {
 		invalidate();
 
 		resolvers.resolveRAF();
-		assert.isTrue(factoryStub.calledTwice);
+		assert.isTrue(factoryStub.set.calledTwice);
 	});
 });

--- a/tests/core/unit/resource.ts
+++ b/tests/core/unit/resource.ts
@@ -185,8 +185,10 @@ describe('resource', () => {
 		resource.set([{ value: 'one' }, { value: 'two' }]);
 		assert.deepEqual(resource.get({}), [{ value: 'one' }, { value: 'two' }]);
 		assert.equal(resource.getTotal({}), 2);
-		const results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: ['value'] }] });
+		let results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: ['value'] }] });
 		assert.deepEqual(results, [{ value: 'one' }]);
+		results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: ['other'] }] });
+		assert.deepEqual(results, [{ value: 'one' }, { value: 'two' }]);
 	});
 
 	it('Can provide a custom filter with memory resource', () => {

--- a/tests/core/unit/resource.ts
+++ b/tests/core/unit/resource.ts
@@ -1,7 +1,7 @@
 const { describe, it, afterEach, beforeEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { sandbox } from 'sinon';
-import { createResource } from '../../../src/core/resource';
+import { createResource, createMemoryTemplate, defaultFilter } from '../../../src/core/resource';
 
 const sb = sandbox.create();
 
@@ -15,7 +15,7 @@ describe('resource', () => {
 		sb.resetHistory();
 	});
 
-	it('creates a resouce given a template', () => {
+	it('creates a resource given a template', () => {
 		const resource = createResource(template);
 		assert.hasAllKeys(resource, [
 			'getOrRead',
@@ -27,6 +27,28 @@ describe('resource', () => {
 			'isLoading',
 			'set'
 		]);
+	});
+
+	it('returns resource an associated data', () => {
+		const resource = createResource()([1, 2, 3]);
+		assert.hasAllKeys(resource.resource, [
+			'getOrRead',
+			'get',
+			'getTotal',
+			'subscribe',
+			'unsubscribe',
+			'isFailed',
+			'isLoading',
+			'set'
+		]);
+		assert.deepEqual(resource.data, [1, 2, 3]);
+	});
+
+	it('provides an in-memory template by default', () => {
+		const resource = createResource();
+		resource.set([{ value: 1 }, { value: 2 }]);
+		assert.deepEqual(resource.get({}), [{ value: 1 }, { value: 2 }]);
+		assert.equal(resource.getTotal({}), 2);
 	});
 
 	it('calls the read template function with calculated offset when getOrRead is called', () => {
@@ -156,5 +178,32 @@ describe('resource', () => {
 		const secondPageGetOrRead = resource.getOrRead({ pageNumber: 2, pageSize: 2 });
 		assert.deepEqual(secondPageGetOrRead, ['foo', 'bar']);
 		assert.isTrue(template.read.notCalled);
+	});
+
+	it('Can use default filter with memory resource', () => {
+		const resource = createResource(createMemoryTemplate({ filter: defaultFilter }));
+		resource.set([{ value: 'one' }, { value: 'two' }]);
+		assert.deepEqual(resource.get({}), [{ value: 'one' }, { value: 'two' }]);
+		assert.equal(resource.getTotal({}), 2);
+		const results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: ['value'] }] });
+		assert.deepEqual(results, [{ value: 'one' }]);
+	});
+
+	it('Can provide a custom filter with memory resource', () => {
+		const resource = createResource<{ value: string }>(
+			createMemoryTemplate({
+				filter: (query, item) => {
+					if (item.value === 'two') {
+						return true;
+					}
+					return false;
+				}
+			})
+		);
+		resource.set([{ value: 'one' }, { value: 'two' }]);
+		assert.deepEqual(resource.get({}), [{ value: 'one' }, { value: 'two' }]);
+		assert.equal(resource.getTotal({}), 2);
+		const results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: ['value'] }] });
+		assert.deepEqual(results, [{ value: 'two' }]);
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Simplifies using memory resources with Dojo Resource and provides a built in mechanism using custom in memory data.

* Strongly types the resource type to the create resource and the shape of the data that can be passed
* By default creates a memory template for a resource when no custom template is passed
* Exports utility functions for creating memory template

Also includes a change to support this change in vdom's custom diffProperty process. Enables users to return back the original function, that will replace the default wrapped function that gets created.