### PR TITLE
Remove referencing `this` from icache api

### DIFF
--- a/src/testing/mocks/middleware/icache.ts
+++ b/src/testing/mocks/middleware/icache.ts
@@ -14,7 +14,7 @@ export function createICacheMock() {
 			properties,
 			children
 		});
-		const setter = icacheMiddleware.set.bind(icacheMiddleware);
+		const setter = icacheMiddleware.set;
 
 		icacheMiddleware.set = (key: any, value: any) => {
 			if (typeof value === 'function') {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This allows the icache api to be used after destructuring without binding scope.