### PR TITLE
Use theme injector payload if no theme property available

### DIFF
--- a/src/core/middleware/theme.ts
+++ b/src/core/middleware/theme.ts
@@ -141,6 +141,14 @@ export const theme = factory(
 				const { theme } = properties();
 				if (theme && isThemeWithVariant(theme)) {
 					return theme.variant.value.root;
+				} else {
+					const themeInjector = injector.get<ThemeInjector>(INJECTED_THEME_KEY);
+					if (themeInjector) {
+						const themePayload = themeInjector.get();
+						if (isThemeInjectorPayloadWithVariant(themePayload)) {
+							return themePayload.variant.value.root;
+						}
+					}
 				}
 			},
 			set,

--- a/tests/core/unit/middleware/theme.tsx
+++ b/tests/core/unit/middleware/theme.tsx
@@ -263,6 +263,34 @@ jsdomDescribe('theme middleware', () => {
 		assert.strictEqual(root.innerHTML, '<div class="variant-root"></div>');
 	});
 
+	it('returns injected theme variant class', () => {
+		const factory = create({ theme });
+		const themeWithVariant = {
+			theme: {
+				theme: {
+					'test-key': {
+						root: 'themed-root'
+					}
+				},
+				variants: {
+					default: {
+						root: 'variant-root'
+					}
+				}
+			}
+		};
+
+		const App = factory(function App({ middleware: { theme } }) {
+			theme.set(themeWithVariant.theme, 'default');
+			const variantRoot = theme.variant();
+			return <div classes={variantRoot} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, '<div class="variant-root"></div>');
+	});
+
 	it('selects default variant theme with variants is set', () => {
 		const factory = create({ theme });
 		const themeWithVariants = {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Uses theme injector payload for variant class when theme property not yet set / influenced by diffproperty.

Resolves #758 
