### PR TITLE
Reset scroll on route change

### DIFF
--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -389,6 +389,14 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 			outlet: matchedRouteId,
 			context: this._currentMatchedRoute
 		});
+		if (this._options.resetScroll) {
+			const { window = global.window } = this._options;
+			try {
+				window.scroll(0, 0);
+			} catch (e) {
+				// Catch errors if we're in an environment without window.scroll
+			}
+		}
 	};
 }
 

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -229,4 +229,5 @@ export interface RouterOptions {
 	base?: string;
 	HistoryManager?: HistoryConstructor;
 	setDocumentTitle?: SetDocumentTitle;
+	resetScroll?: boolean;
 }

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -1,6 +1,7 @@
 const { it } = intern.getInterface('bdd');
 const { describe } = intern.getPlugin('jsdom');
 const { assert } = intern.getPlugin('chai');
+import * as sinon from 'sinon';
 
 import global from '../../../src/shim/global';
 import { Router } from '../../../src/routing/Router';
@@ -393,6 +394,13 @@ describe('Router', () => {
 			assert.strictEqual(action, 'enter');
 		});
 		router.setPath('/foo/bar');
+	});
+
+	it('should reset scroll when emitting if resetScroll is true', () => {
+		const window: any = { scroll: sinon.stub() };
+		new Router(routeConfig, { HistoryManager, resetScroll: true, window });
+		assert.isTrue(window.scroll.calledOnce);
+		assert.deepEqual(window.scroll.args, [[0, 0]]);
 	});
 
 	it('should emit route event when a routes param changes', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds a `resetScroll` option that calls `scroll(0,0)` on the passed or global window when a route change is emitted.
Resolves #615 
