### PR TITLE
Add support to process variant css variables when not supported by the browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1596,6 +1596,11 @@
         "nth-check": "^1.0.1"
       }
     },
+    "css-vars-ponyfill": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.3.0.tgz",
+      "integrity": "sha512-3f8nyk9tLbpQMaSSMIQKTPplBNF44E/uxmbqq9LC3TETK5Q0eX1FabpDi6QdztDBGEkW7qBamxi/F6qOV90brA=="
+    },
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cldrjs": "^0.5.0",
     "cross-fetch": "3.0.2",
     "css-select-umd": "1.3.0-rc0",
+    "css-vars-ponyfill": "2.3.0",
     "diff": "3.5.0",
     "globalize": "1.4.0",
     "immutable": "3.8.2",

--- a/src/core/has.ts
+++ b/src/core/has.ts
@@ -189,6 +189,12 @@ add('dojo-debug', false);
 /* Detects if the environment is "browser like" */
 add('host-browser', typeof document !== 'undefined' && typeof location !== 'undefined');
 
+/* Detects if the environment is "jsdom" */
+add(
+	'host-jsdom',
+	has('host-browser') && typeof navigator !== 'undefined' && navigator.userAgent.indexOf('jsdom') !== -1
+);
+
 /* Detects if the environment appears to be NodeJS */
 add('host-node', function() {
 	if (typeof process === 'object' && process.versions && process.versions.node) {
@@ -474,6 +480,17 @@ add('dom-intersection-observer', () => has('host-browser') && global.Intersectio
 add('dom-resize-observer', () => has('host-browser') && global.ResizeObserver !== undefined, true);
 
 add('dom-pointer-events', () => has('host-browser') && global.onpointerdown !== undefined, true);
+
+add(
+	'dom-css-variables',
+	() =>
+		has('host-browser') &&
+		!has('host-jsdom') &&
+		global.window.CSS &&
+		global.window.CSS.supports &&
+		global.window.CSS.supports('(--a: 0)'),
+	true
+);
 
 add('dom-inert', () => has('host-browser') && Element.prototype.hasOwnProperty('inert'), true);
 

--- a/src/shim/cssVariables.ts
+++ b/src/shim/cssVariables.ts
@@ -1,0 +1,6 @@
+`!has('dom-css-variables')`;
+import * as cssVars from 'css-vars-ponyfill';
+
+export default (typeof cssVars !== 'undefined' && typeof cssVars.default === 'function'
+	? cssVars.default
+	: ((() => {}) as typeof cssVars.default));

--- a/src/shim/util/amd.ts
+++ b/src/shim/util/amd.ts
@@ -61,6 +61,12 @@ function shimAmdDependencies(config: any) {
 		location: 'node_modules/cldr-core'
 	});
 
+	addIfNotPresent(packages, {
+		name: 'css-vars-ponyfill',
+		location: 'node_modules/css-vars-ponyfill/dist',
+		main: 'css-vars-ponyfill.min'
+	});
+
 	config.packages = packages;
 
 	return config;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The recent theming system enhancement to support "variants" posed challenges to provide support for IE11 (with no native support for CSS variables). Initially these were thought to be solved by using a css variable polyfill for all legacy Dojo application builds, however through testing, this failed for at least a few major reasons:

1) The polyfill did not correctly support adding a new class that required CSS variables.
1) The polyfill added additional classes to the DOM nodes which is problematic Dojo's vdom, as it that takes control of node level changes (and does not know about the additional classes)
1) The polyfill is extremely slow due to the use of Mutation Observer, needed to detect changes to the DOM after the initial DOM node has been created.

With the polyfill not suitable for our use-case, we needed a mechanism that would enable using themes with CSS variables in IE11 without degrading performance significantly and without requiring integrated support in Dojo's vdom.

**Proposed Solution**

There is a CSS variables ponyfill (`css-vars-ponyfill`) that provides limited support for CSS variables in IE11 under certain constraints, for example only support variables in the `:root` select. This is not a direct fit for the theming system enhancement, as part of the enhancement is that the variables are exposed via a class instead of the `:root` selector. The benefits of this is that they are all scoped so that the variants can be changes at runtime. In order to support IE11 we needed to convert the CSS variables for the class selectors to`:root` and then run them through the polyfill, applying the resulting "calculated" styles to the DOM. 

We know the variant class selector name when an application is setting the theme, this is used in combination with the `css-vars-ponyfill` to find the CSS variables in the application's CSS and generate a `:root` selector with them before allowing the ponyfill to calculate all the variables and return the generated CSS that can then be applied to the DOM. 

This is only required in legacy builds and the CSS ponyfill dependency nor the supporting framework code will be included in the application bundles unless it was built using the legacy build flag. Additionally even if the application is built to target legacy browsers the CSS variables ponyfill will not be executed on any browsers that have native support (i.e. unless loaded on IE11).

**Note:** There is a small performance hit on IE11 (understandably) to ensure this support but it is no where close to the performance issues faced when using the previous polyfill.

![ie11-variants](https://user-images.githubusercontent.com/1982678/80698223-13500d00-8ad2-11ea-850c-4af9e1b0fba0.gif)
