### PR TITLE
Wildcard routing

### DIFF
--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -212,6 +212,53 @@ export default [
 ];
 ```
 
+## Wildcard Routes
+
+The `*` character can be used to indicate a wildcard route. The route will be matched normally up until the `*` and will match
+any path at that point. A wildcard route will never be preferred over another matching route without a wildcard. The `*` implicitly indicates the end of the
+match, and any segments specified after the `*` in the route config will be ignored. Any additional segments in the actual URL will be passed with
+the `matchDetails` in an array property called `wildcardSegments`.
+
+```ts
+export default [
+	{
+		id: 'catchall',
+		// Anything after the asterisk will be ignored in this config
+		path: '*',
+		outlet: 'catchall'
+	},
+	// This path will be preferred to the wildcard as long as it matches
+	{
+		id: 'home',
+		path: 'home',
+		outlet: 'home'
+	}
+];
+```
+
+All segments after and including the matched `*` will be injected into the matching `Route`'s `renderer` property as `wildcardSegments`.
+
+> src/App.tsx
+
+```tsx
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Route from '@dojo/framework/routing/Route';
+
+const factory = create();
+
+export default factory(function App() {
+	return (
+		<div>
+			<Route id="home" renderer={(matchDetails) => <div>{`Home ${matchDetails.params.page}`}</div>} />
+			<Route
+				id="catchall"
+				renderer={(matchDetails) => <div>{`Matched Route ${matchDetails.wildcardSegments.join(', ')}`}</div>}
+			/>
+		</div>
+	);
+});
+```
+
 ## Using link widgets
 
 The `Link` widget is a wrapper around an anchor tag that enables consumers to specify a route `id` to create a link to. If the generated link requires specific path or query parameters that are not in the route, they can be passed via the `params` property.

--- a/src/routing/Route.ts
+++ b/src/routing/Route.ts
@@ -45,8 +45,8 @@ export const Route = factory(function Route({
 	if (router) {
 		const routeContext = router.getRoute(id);
 		if (routeContext) {
-			const { queryParams, params, type, isError, isExact } = routeContext;
-			const result = renderer({ queryParams, params, type, isError, isExact, router });
+			const { queryParams, params, type, isError, isExact, wildcardSegments } = routeContext;
+			const result = renderer({ queryParams, params, type, isError, isExact, router, wildcardSegments });
 			if (result) {
 				return result;
 			}

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -49,7 +49,7 @@ export interface Params {
 /**
  * Type of outlet matches
  */
-export type MatchType = 'error' | 'index' | 'partial';
+export type MatchType = 'error' | 'index' | 'partial' | 'wildcard';
 
 /**
  * Context stored for matched outlets
@@ -78,6 +78,12 @@ export interface RouteContext {
 	 * The query params for the route
 	 */
 	queryParams: Params;
+
+	/**
+	 * If this route is a wildcard route, any segments that are part of the "wild" section
+	 * of the route
+	 */
+	wildcardSegments: string[];
 
 	/**
 	 * Returns `true` when the route is an error match
@@ -137,6 +143,12 @@ export interface MatchDetails {
 	 * Match type of the route for the outlet, either `index`, `partial` or `error`
 	 */
 	type: MatchType;
+
+	/**
+	 * If this route is a wildcard route, any segments that are part of the "wild" section
+	 * of the route
+	 */
+	wildcardSegments: string[];
 
 	/**
 	 * The router instance

--- a/tests/routing/unit/Route.ts
+++ b/tests/routing/unit/Route.ts
@@ -57,14 +57,16 @@ describe('Route', () => {
 	});
 
 	it('returns null if rendered without an available router', () => {
-		const r = renderer(() =>
-			w(Route, {
-				id: 'foo',
-				renderer() {
-					return w(Widget, {});
-				},
-				routerKey: 'Does not exist'
-			})
+		const r = renderer(
+			() =>
+				w(Route, {
+					id: 'foo',
+					renderer() {
+						return w(Widget, {});
+					},
+					routerKey: 'Does not exist'
+				}),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
 		);
 		r.expect(assertion(() => null));
 	});

--- a/tests/routing/unit/Route.ts
+++ b/tests/routing/unit/Route.ts
@@ -56,6 +56,19 @@ describe('Route', () => {
 		registry = new Registry();
 	});
 
+	it('returns null if rendered without an available router', () => {
+		const r = renderer(() =>
+			w(Route, {
+				id: 'foo',
+				renderer() {
+					return w(Widget, {});
+				},
+				routerKey: 'Does not exist'
+			})
+		);
+		r.expect(assertion(() => null));
+	});
+
 	it('Should render the result of the renderer when the Route matches', () => {
 		const router = registerRouterInjector(routeConfig, registry, { HistoryManager });
 

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -36,6 +36,11 @@ const routeConfig = [
 				]
 			}
 		]
+	},
+	{
+		path: '/bar/*',
+		outlet: 'bar',
+		id: 'bar'
 	}
 ];
 
@@ -432,6 +437,36 @@ describe('Router', () => {
 			}
 		});
 		router.setPath('/foo/baaz/baz');
+	});
+
+	it('should emit route event when wildcard paths change', () => {
+		const router = new Router(routeConfig, { HistoryManager });
+		let handle = router.on('route', () => {});
+		handle.destroy();
+		handle = router.on('route', ({ route, action }) => {
+			if (action === 'exit') {
+				assert.strictEqual(route.id, 'home');
+			} else {
+				assert.strictEqual(route.id, 'bar');
+			}
+		});
+		router.setPath('/bar/baz');
+		handle.destroy();
+		let count = 0;
+		handle = router.on('route', ({ route, action }) => {
+			if (!count) {
+				assert.strictEqual(action, 'enter');
+				assert.deepEqual(route.wildcardSegments, ['baz', 'buzz']);
+			} else {
+				assert.strictEqual(action, 'exit');
+				assert.deepEqual(route.wildcardSegments, ['baz']);
+			}
+			assert.strictEqual(route.id, 'bar');
+			count++;
+		});
+		router.setPath('/bar/baz/buzz');
+		handle.destroy();
+		assert.strictEqual(count, 2);
 	});
 
 	it('Should return all params for a route', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
A proposed implementation of wildcard routing

* A wildcard route is indicated by `*`. It will match a route normally up until the asterisk and then match anything after that.
* A slightly higher penalty is imposed on the route `score` than for a route param, so that a more specific route will always win.
* Introduces the `wildcard` route type and `wildcardSegments` to the `RouteContext` and `MatchDetails`. This will include all the segments of the path matched by the asterisk.
* Adds additional checking for `wildcard` routes so that a change in route segments triggers a route change, even if the same wildcard route is still matched.

Resolves #330 
