### PR TITLE
Do not return global injected theme as the theme property

### DIFF
--- a/tests/core/unit/middleware/theme.tsx
+++ b/tests/core/unit/middleware/theme.tsx
@@ -263,6 +263,66 @@ jsdomDescribe('theme middleware', () => {
 		assert.strictEqual(root.innerHTML, '<div class="variant-root"></div>');
 	});
 
+	it('returns injected theme variant class', () => {
+		const factory = create({ theme });
+		const themeWithVariant = {
+			theme: {
+				theme: {
+					'test-key': {
+						root: 'themed-root'
+					}
+				},
+				variants: {
+					default: {
+						root: 'variant-root'
+					}
+				}
+			}
+		};
+
+		const App = factory(function App({ middleware: { theme } }) {
+			theme.set(themeWithVariant.theme, 'default');
+			const variantRoot = theme.variant();
+			return <div classes={variantRoot} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, '<div class="variant-root"></div>');
+	});
+
+	it('Should use the newly set global theme', () => {
+		const factory = create({ theme });
+
+		const css = {
+			' _key': 'test-key',
+			root: 'root'
+		};
+		const themeWithVariant = {
+			theme: {
+				theme: {
+					'test-key': {
+						root: 'themed-root'
+					}
+				},
+				variants: {
+					default: {
+						root: 'variant-root'
+					}
+				}
+			}
+		};
+
+		const App = factory(function App({ middleware: { theme } }) {
+			theme.set(themeWithVariant.theme);
+			return <div classes={theme.classes(css).root} />;
+		});
+		const root = document.createElement('div');
+		const r = renderer(() => <App />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, '<div class="themed-root"></div>');
+	});
+
 	it('selects default variant theme with variants is set', () => {
 		const factory = create({ theme });
 		const themeWithVariants = {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changes to stop the `theme` middleware using `diffProperty` to augment a widgets `theme` property with a globally configured theme. Currently the `theme` middleware assumes that the `properties().theme` value is always correct (either the explicitly passed theme or the globally injected theme), which is problematic if the `theme.set(` api is called during a render (for example initially setting the theme). 

The `theme` property should only need to be used to pass onto a child widget (to ensure they use an explicitly passed theme if one is passed to the parent), otherwise only the middleware APIs should be used to work with themes. Internally the `theme` middleware has been changed to pick the theme to use by checking the widget's theme property first and falling back to the globally configured theme.

Resolves #758 
