### PR TITLE
[WIP] Improve typings for data transform option

### DIFF
--- a/docs/en/resources/introduction.md
+++ b/docs/en/resources/introduction.md
@@ -1,70 +1,62 @@
-# Introduction
+# Dojo Resources
 
-Dojo **resource** provides a consistent means to make widgets data aware. A `resource` is initialized with a `DataTemplate` that describes how to read data, and enables creation of a single data store which can be passed into multiple widgets. It allows data to be cached, transformed and filtered to suit the needs of the widget using it. Coupled with the data middleware, resources allow consistent, source-agnostic data access for widgets, without the widgets being aware of the underlying data fetching implementation or the raw data format being used, as these are abstracted away by both the template read mechanism and the resource.
+Dojo Resources is designed to provide a consistent pattern to make widgets "data aware". Resource can be configured to work with both external data sources and memory data sources. The resource is essentially a Dojo managed data store with caching, pagination and filtering built in. Coupled with the `data` middleware, resources allow consistent, source-agnostic data access for widgets, without the widgets needing to know about the fetching implementation or the raw data format.
 
-| Feature                                   | Description                                                                                                                                                                                  |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Built in support for memory resources** | Default support for using resources with in-memory data.                                                                                                                                     |
-| **Single data source**                    | Resources allow creation of a single source of data for a given template that can be shared between multiple widgets using the data middleware.                                              |
-| **Data transforms**                       | Allows specifying the data format that a widget requires, and transparently transforms source data into the expected output format for the widget to consume                                 |
-| **Support for async and sync data reads** | Resource templates can read data in any way they like - once data becomes available, the data middleware reactively invalidates any affected widgets.                                        |
-| **Consistent Resource Options**           | Resource options objects are passed to all api functions ensuring that all api functions are pure and provide only the data that was requested                                               |
-| **Sharable Resource Options**             | Resource options can be shared between widgets via the data middleware, allowing multiple widgets to react to any changes such as modifying a query, moving to a different page number, etc. |
+| Feature                                   | Description                                                                                                                                                  |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Built in support for memory resources** | Default support for using resources with in-memory data.                                                                                                     |
+| **Single data source**                    | Resources allow creation of a single source of data for a given template that can be shared between multiple widgets using the data middleware.              |
+| **Data transforms**                       | Allows specifying the data format that a widget requires, and transparently transforms source data into the expected output format for the widget to consume |
+| **Support for async and sync data reads** | Resource templates can read data in any way they like - once data becomes available, the data middleware reactively invalidates any affected widgets.        |
+| **Consistent Resource Options**           | Resource options objects are passed to all api functions ensuring that all api functions are pure and provide only the data that was requested.              |
+| **Sharable Resource Options**             | Resource options can be shared between widgets via the data middleware, allowing multiple widgets to react to resource changes.                              |
 
-# Basic usage
+# Basic Usage
 
-A Dojo resource can be created to fetch data in some way, and widgets are then able to access data from the resource through the data middleware.
+Dojo resources are created using the `createResource` factory from `@dojo/framework/core/resource`. The default resource comes with built-in support for working with in-memory data that can be used with data-aware widgets.
 
-## Creating a resource
-
-A basic resource can be created using the `createResource` factory from `@dojo/framework/core/resource` module, configured to work with in-memory data that can be passed within a widget.
-
-> resources.tsx
+> resource.tsx
 
 ```tsx
-const resource = createResource();
+import { createResource } from '@dojo/framework/core/resource';
+
+export default createResource();
 ```
 
-This `resource` can be used with any data aware widget, with any data that is passed.
+This resource can be used with "data aware" widget, meaning any widget that uses the `data` middleware from `@dojo/framework/core/middleware/data`.
 
-> MyWidget.tsx
+> App.tsx
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-
-import MyDataAwareWidget from './MyDataAwareWidget';
-import myResource from './resources';
+import myResource from './resource';
+import DataAwareWidget from './DataAwareWidget';
 
 const factory = create();
 
-const MyWidget = factory(function MyWidget() {
-	return (
-		<MyDataAwareWidget
-			resource={myResource([
-				/* array of data for the widget to use */
-			])}
-		/>
-	);
+const App = factory(function App() {
+	return <DataAwareWidget resource={myResource({ data: [] })} />;
 });
 ```
 
-## Custom Data Template
+# Customizing a resource's data source
 
-To use a `resource` to use a data source instead of requiring data to be passed into the resource on usage, a custom `DataTemplate` is required. By default the `DataTemplate` provided is an in-memory one that needs `data` to be passed on usage. The following is an example of a `DataTemplate` that wires a resource to a remote REST API.
+Dojo resources can be configured from a user defined data source, for example a RESTful API. This is done by passing an object with a `read` function that is responsible for fetching and returning the external datam known as a `DataTemplate`.
 
-> main.ts
+> userResource.tsx
 
-```ts
+```tsx
 import { createResource } from '@dojo/framework/core/resource';
 
-const resource = createResource({
+export default createResource({
 	read: async (options: ReadOptions) => {
+		// The template is injected with read options, offset, size and query
 		const { offset, size } = options;
-		let url = `https://my.endpoint.com?offset=${offset}&size=${size}`;
-
-		const response = await fetch(url);
+		// The options can be used to determine the data to fetch
+		const response = await fetch(`https://my.user.endpount.com?offset=${offset}&size=${size}`);
 		const data = await response.json();
 
+		// The template needs to return the array of data and the total number of items
 		return {
 			data: data.data,
 			total: data.total
@@ -73,69 +65,32 @@ const resource = createResource({
 });
 ```
 
-When a call is made to the resource api which requires data to be read, the `read` function will be called with the `ReadOptions`, a `put` function and a `get` function. The `ReadOptions` consist of the `offset`, the requested page `size` and a `query` for filtering. The two helper functions can be used to side-load data or to read existing data from the resource. More information on this can be found in the [supplemental documentation](/learn/resource/data-templates).
+# Accessing data within a widget
 
-## Transforming data
+A "data aware" widget needs use the `data` middleware that provides an API to work with passed `resource` property. The `data` middleware needs to be created using the `createDataMiddleware` factory from `@dojo/framework/core/middleware/data`, passing an interface that defines the expected `data` structure for the widget.
 
-Resources provides a `createTransformer` function which can be used to create a type safe transform object. In order to correctly type the transform source values, a generic must be passed to the `DataTemplate` to type the `read` return type. When used with the `createTransformer` function, this ensures that only return values from the read function can be used as source values.
+Accessing data in the widget is performed using the `getOrRead` function from the `data` middleware. `getOrRead` requires options to be passed that tell the `resource` what data is required, these options should be accessed using the `getOptions` function. The `getOrRead` method will return the data if it is available, otherwise it will call the `read` function of the resource's data template. If the `read` function on the data template is asynchronous the result will be `undefined` while the data is being fetched and the widget will re-render when the data is available.
 
-> main.ts
-
-```ts
-import { DataTemplate, createResource, createTransformer } from '@dojo/framework/core/resource';
-import { fetcher } from './personfetcher';
-
-const template: DataTemplate<{ firstName: string; lastName: string }> = {
-	read: fetcher
-};
-
-const transformer = createTransformer(template, {
-	value: ['firstName'],
-	label: ['firstName', 'lastName']
-});
-```
-
-The transformer can be passed to a widget which uses the data middleware to ensure that the data it receives from the resource is correct.
-
-## Passing a resource to a widget
-
-A widget that uses the data middleware can be passed a `resource` to use.
-
-> main.ts
-
-```tsx
-import { DataTemplate, createResource } from '@dojo/framework/core/resource';
-import { fetcher } from './personfetcher';
-import { List } from './List';
-
-const template: DataTemplate = {
-	read: fetcher
-};
-
-const resource = createResource(template);
-
-export default factory(function() {
-	return <List resource={resource} />;
-});
-```
-
-## Accessing data within a widget
-
-A data aware widget should use the `data` middleware to access data via its API. Each call made to the data apis require `Options` to be passed. These should be accessed and set via `getOptions` and `setOptions` functions to ensure that any widgets sharing the resource are using the same options.
-
-> List.ts
+> DataAwareWidget.tsx
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';
-import { data } from '@dojo/framework/core/middleware/data';
+import { createDataMiddleware } from '@dojo/framework/core/middleware/data';
+
+interface DataState {
+	value: string;
+}
+
+const data = createDataMiddleware<DataState>();
 
 const factory = create({ data });
 
-export const List = factory(function Select({ middleware: { data } }) {
+export const DataAwareWidget = factory(function DataAwareWidget({ middleware: { data } }) {
 	const { getOrRead, getOptions } = data();
-
 	const items = getOrRead(getOptions());
+	if (items) {
+		return <ul>{items.map((item) => <li>{item.value}</li>)}</ul>;
+	}
+	return <div>Loading...</div>;
 });
 ```
-
-As this example shows, `getOrRead` is being called with the result of `getOptions`. This is a reactive api and will return data if it is available or invalidate the widget when a read is complete and the data becomes available.

--- a/docs/en/resources/supplemental.md
+++ b/docs/en/resources/supplemental.md
@@ -94,8 +94,9 @@ The data middleware provides a widget access to the underlying resource and its 
 
 ```ts
 import { create } from '@dojo/framework/core/vdom';
-import data from '@dojo/framework/core/middleware/data';
+import createDataMiddleware from '@dojo/framework/core/middleware/data';
 
+const data = createDataMiddleware();
 const factory = create({ data });
 
 export const DataAwareWidget = factory(function DataAwareWidget({

--- a/src/core/middleware/data.ts
+++ b/src/core/middleware/data.ts
@@ -126,13 +126,23 @@ function transformQuery<T>(query: Query, transformConfig?: TransformConfig<T>): 
 
 function transformData<T>(item: any, transformConfig: TransformConfig<T>) {
 	let transformedItem: Partial<T> = {};
+	let sourceKeys: string[] = [];
 	Object.keys(transformConfig).forEach((key: string) => {
 		const sourceKey = transformConfig[key as keyof T];
 		transformedItem = {
 			...transformedItem,
 			[key]: item[sourceKey]
 		};
+		sourceKeys.push(sourceKey);
 	});
+	Object.keys(item)
+		.filter((key) => sourceKeys.indexOf(key) === -1)
+		.forEach((key) => {
+			transformedItem = {
+				...transformedItem,
+				[key]: item[key]
+			};
+		});
 	return transformedItem;
 }
 

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -100,7 +100,7 @@ export function createResource<S = any>(config: DataTemplate<S> = createMemoryTe
 	};
 
 	function invalidate(types: SubscriptionType[], options: ResourceOptions) {
-		const key = `${getQueryKey(options)}-${getPageKey(options)}`;
+		const key = `${getQueryKey(options.query)}-${getPageKey(options)}`;
 
 		types.forEach((type) => {
 			const keyedInvalidatorMap = invalidatorMaps[type];
@@ -117,12 +117,12 @@ export function createResource<S = any>(config: DataTemplate<S> = createMemoryTe
 		return `page-${pageNumber}-pageSize-${pageSize}`;
 	}
 
-	function getQueryKey(query = {}): string {
+	function getQueryKey(query: ResourceQuery[] = []): string {
 		return JSON.stringify(query);
 	}
 
 	function subscribe(type: SubscriptionType, options: ResourceOptions, invalidator: Invalidator) {
-		const key = `${getQueryKey(options)}-${getPageKey(options)}`;
+		const key = `${getQueryKey(options.query)}-${getPageKey(options)}`;
 		const keyedInvalidatorMap = invalidatorMaps[type];
 		const invalidatorSet = keyedInvalidatorMap.get(key) || new Set<Invalidator>();
 		invalidatorSet.add(invalidator);
@@ -210,7 +210,7 @@ export function createResource<S = any>(config: DataTemplate<S> = createMemoryTe
 		}
 	}
 
-	function setData(start: number, data: S[], size: number, query = {}) {
+	function setData(start: number, data: S[], size: number, query: ResourceQuery[] = []) {
 		const queryKey = getQueryKey(query);
 		const cachedQueryData = queryMap.get(queryKey);
 		const newQueryData = cachedQueryData && cachedQueryData.length ? cachedQueryData : [];
@@ -223,7 +223,7 @@ export function createResource<S = any>(config: DataTemplate<S> = createMemoryTe
 	}
 
 	function getOrRead(options: ResourceOptions): S[] | undefined {
-		const { pageNumber, query, pageSize } = options;
+		const { pageNumber = 1, query, pageSize } = options;
 		const queryKey = getQueryKey(options.query);
 
 		if (isLoading(options) || isFailed(options)) {

--- a/tests/core/unit/middleware/data.tsx
+++ b/tests/core/unit/middleware/data.tsx
@@ -5,6 +5,7 @@ import { renderer, tsx, create } from '../../../../src/core/vdom';
 import { createDataMiddleware } from '../../../../src/core/middleware/data';
 import { createResolvers } from '../../support/util';
 import { createResource, createMemoryTemplate, defaultFilter } from '../../../../src/core/resource';
+import icache from '../../../../src/core/middleware/icache';
 
 const resolvers = createResolvers();
 
@@ -16,7 +17,7 @@ jsdomDescribe('data middleware', () => {
 		resolvers.restore();
 	});
 
-	it('get() with options', () => {
+	it('get with options', () => {
 		const root = document.createElement('div');
 		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
 
@@ -67,10 +68,15 @@ jsdomDescribe('data middleware', () => {
 		const root = document.createElement('div');
 		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
 		const Thing = factory(({ middleware: { data } }) => {
-			const { get, getOptions, setOptions } = data();
+			const { get, getOptions, setOptions, getTotal } = data();
 			const { pageSize = 1, pageNumber = 1 } = getOptions();
 			setOptions({ pageSize, pageNumber });
-			return <div>{JSON.stringify(get(getOptions()))}</div>;
+			return (
+				<div>
+					<div>{JSON.stringify(get(getOptions()))}</div>
+					<div>{`${getTotal(getOptions())}`}</div>
+				</div>
+			);
 		});
 
 		const resource = createResource<{ wrong: string }>();
@@ -83,18 +89,50 @@ jsdomDescribe('data middleware', () => {
 
 		const r = renderer(() => <App />);
 		r.mount({ domNode: root });
-		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: '1' }])}</div>`);
+		assert.strictEqual(root.innerHTML, `<div><div>${JSON.stringify([{ hello: '1' }])}</div><div>2</div></div>`);
 	});
 
-	it('should not convert single fields into strings when using a transform', () => {
+	it('should by able to filter with transformed data', () => {
+		const root = document.createElement('div');
+		const factory = create({ data: createDataMiddleware<{ hello: string; foo?: string }>() });
+		const Thing = factory(({ middleware: { data } }) => {
+			const { getOrRead, getOptions, setOptions } = data();
+			const {
+				query: {}
+			} = getOptions();
+			setOptions({ ...getOptions(), query: { hello: '2', foo: '1' } });
+			return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
+		});
+
+		const resource = createResource<{ wrong: string; foo: string }>(
+			createMemoryTemplate({ filter: defaultFilter })
+		);
+
+		const App = create()(() => {
+			return (
+				<Thing
+					resource={resource({
+						transform: { hello: 'wrong' },
+						data: [{ wrong: '1', foo: '1' }, { wrong: '2', foo: '1' }, { wrong: '2', foo: '2' }]
+					})}
+				/>
+			);
+		});
+
+		const r = renderer(() => <App />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: '2', foo: '1' }])}</div>`);
+	});
+
+	it('should not convert fields into strings when using a transform', () => {
 		const root = document.createElement('div');
 		const factory = create({ data: createDataMiddleware<{ hello: number }>() });
 
 		const Thing = factory(({ middleware: { data } }) => {
-			const { get, getOptions, setOptions } = data();
+			const { getOrRead, getOptions, setOptions } = data();
 			const { pageSize = 1, pageNumber = 1 } = getOptions();
 			setOptions({ pageSize, pageNumber });
-			return <div>{JSON.stringify(get(getOptions()))}</div>;
+			return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
 		});
 
 		const resource = createResource<{ wrong: number }>();
@@ -143,6 +181,51 @@ jsdomDescribe('data middleware', () => {
 		await promise;
 		resolvers.resolveRAF();
 		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: 'world' }])}</div>`);
+	});
+
+	it('returns failed status of resource', async () => {
+		let rejector: () => void;
+		const promise = new Promise<{ data: any[]; total: number }>((_, reject) => {
+			rejector = reject;
+		});
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
+
+		const resource = createResource<{ hello: string }>({
+			read: () => {
+				return promise;
+			}
+		});
+
+		const Thing = factory(({ middleware: { data } }) => {
+			const { getOrRead, isLoading, isFailed } = data();
+			const items = getOrRead({ pageSize: 1, pageNumber: 1 });
+			const loading = isLoading({ pageSize: 1, pageNumber: 1 });
+			const failed = isFailed({ pageSize: 1, pageNumber: 1 });
+			if (loading) {
+				return <div>Loading</div>;
+			}
+			if (failed) {
+				return <div>Failed</div>;
+			}
+			return <div>{JSON.stringify(items)}</div>;
+		});
+
+		const App = create()(() => {
+			return <Thing resource={resource()} />;
+		});
+
+		const r = renderer(() => <App />);
+		const root = document.createElement('div');
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, `<div>Loading</div>`);
+		rejector!();
+		try {
+			await promise;
+			assert.fail('The promise should be rejected');
+		} catch {
+			resolvers.resolveRAF();
+			assert.strictEqual(root.innerHTML, `<div>Failed</div>`);
+		}
 	});
 
 	it('should be able to share basic resource across between widgets', () => {
@@ -194,6 +277,58 @@ jsdomDescribe('data middleware', () => {
 		assert.strictEqual(
 			root.innerHTML,
 			`<div><button></button><div>${JSON.stringify([{ hello: 'world again' }])}</div></div>`
+		);
+	});
+
+	it('should be force unique instance of resource when using reset', () => {
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
+		const resource = createResource<{ hello: string }>();
+
+		const WidgetOne = factory(({ middleware: { data } }) => {
+			const { setOptions, getOptions } = data();
+			return (
+				<button
+					onclick={() => {
+						setOptions({ ...getOptions(), pageNumber: 2 });
+					}}
+				/>
+			);
+		});
+
+		const WidgetTwo = factory(({ middleware: { data } }) => {
+			const { getOrRead, setOptions, getOptions } = data({ reset: true });
+			const { pageNumber = 1, pageSize = 1 } = getOptions();
+			setOptions({ pageNumber, pageSize });
+			const items = getOrRead(getOptions());
+			return <div>{JSON.stringify(items)}</div>;
+		});
+
+		const Parent = factory(({ middleware: { data } }) => {
+			const { shared } = data();
+			return (
+				<div>
+					<WidgetOne resource={shared()} />
+					<WidgetTwo resource={shared()} />
+				</div>
+			);
+		});
+
+		const App = create()(() => {
+			return <Parent resource={resource({ data: [{ hello: 'world' }, { hello: 'world again' }] })} />;
+		});
+
+		const r = renderer(() => <App />);
+		const root = document.createElement('div');
+		r.mount({ domNode: root });
+		assert.strictEqual(
+			root.innerHTML,
+			`<div><button></button><div>${JSON.stringify([{ hello: 'world' }])}</div></div>`
+		);
+		(root.children[0].children[0] as any).click();
+		resolvers.resolveRAF();
+		assert.strictEqual(
+			root.innerHTML,
+			`<div><button></button><div>${JSON.stringify([{ hello: 'world' }])}</div></div>`
 		);
 	});
 
@@ -250,397 +385,90 @@ jsdomDescribe('data middleware', () => {
 		);
 	});
 
-	// it('should transform appropriate query options when calling resource apis', () => {
-	// 	const factory = create({ data: createDataMiddleware<{ value: string }>() });
-	// 	const App = factory(function App({ middleware: { data } }) {
-	// 		const { get } = data();
-	// 		return (
-	// 			<div>
-	// 				{JSON.stringify(
-	// 					get({
-	// 						query: {
-	// 							value: 'test',
-	// 							foo: 'bar'
-	// 						}
-	// 					})
-	// 				)}
-	// 			</div>
-	// 		);
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App resource={resourceStub} transform={{ value: ['item'] }} />);
-	// 	r.mount({ domNode: root });
-	// 	assert.isTrue(
-	// 		resourceStub.get.calledWith({ query: [{ keys: ['item'], value: 'test' }, { keys: ['foo'], value: 'bar' }] })
-	// 	);
-	// });
+	it('should update the data in the resource', () => {
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
+		const resource = createResource<{ hello: string }>(createMemoryTemplate({ filter: defaultFilter }));
 
-	// it('should still convert query options to resource query format when not using a transform', () => {
-	// 	const factory = create({ data: dataMiddleware });
-	// 	const App = factory(function App({ middleware: { data } }) {
-	// 		const { get } = data();
-	// 		return (
-	// 			<div>
-	// 				{JSON.stringify(
-	// 					get({
-	// 						query: {
-	// 							value: 'test',
-	// 							foo: 'bar'
-	// 						}
-	// 					})
-	// 				)}
-	// 			</div>
-	// 		);
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App resource={resourceStub} />);
-	// 	r.mount({ domNode: root });
-	// 	assert.isTrue(
-	// 		resourceStub.get.calledWith({
-	// 			query: [{ keys: ['value'], value: 'test' }, { keys: ['foo'], value: 'bar' }]
-	// 		})
-	// 	);
-	// });
+		const WidgetOne = factory(({ middleware: { data } }) => {
+			const { getOrRead, setOptions, getOptions } = data();
+			const { pageNumber = 1, pageSize = 2, query = {} } = getOptions();
+			setOptions({ pageNumber, pageSize, query });
+			const items = getOrRead(getOptions());
+			return <div>{JSON.stringify(items)}</div>;
+		});
 
-	// it('can create shared resources that share options', () => {
-	// 	resourceStub.getOrRead.returns([{ value: 'foo' }, { value: 'bar' }]);
-	// 	const WidgetA = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-	// 		const { getOptions, setOptions } = dataMiddleware();
-	// 		setOptions({
-	// 			pageNumber: 99,
-	// 			pageSize: 99,
-	// 			query: { value: 'test' }
-	// 		});
-	// 		return <div>{JSON.stringify(getOptions())}</div>;
-	// 	});
-	// 	const WidgetB = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-	// 		const { getOptions } = dataMiddleware();
-	// 		return <div>{JSON.stringify(getOptions())}</div>;
-	// 	});
-	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-	// 		const { shared } = dataMiddleware();
-	// 		const sharedResource = shared();
-	// 		return (
-	// 			<virtual>
-	// 				<WidgetA resource={sharedResource} />
-	// 				<WidgetB resource={sharedResource} />
-	// 			</virtual>
-	// 		);
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App resource={resourceStub} />);
-	// 	r.mount({ domNode: root });
-	// 	assert.strictEqual(
-	// 		root.innerHTML,
-	// 		`<div>${JSON.stringify({
-	// 			pageNumber: 99,
-	// 			pageSize: 99,
-	// 			query: { value: 'test' }
-	// 		})}</div><div>${JSON.stringify({
-	// 			pageNumber: 99,
-	// 			pageSize: 99,
-	// 			query: { value: 'test' }
-	// 		})}</div>`
-	// 	);
-	// });
+		const App = create({ icache })(({ middleware: { icache } }) => {
+			const data = icache.getOrSet('data', [{ hello: 'world' }, { hello: 'moon' }]);
+			return (
+				<div>
+					<button
+						onclick={() => {
+							icache.set('data', [{ hello: 'mars' }, { hello: 'venus' }]);
+						}}
+					/>
+					<WidgetOne resource={resource({ data })} />
+				</div>
+			);
+		});
 
-	// it('can reset a shared resource to obtain its own options', () => {
-	// 	resourceStub.getOrRead.returns([{ value: 'foo' }, { value: 'bar' }]);
-	// 	const WidgetA = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-	// 		const { getOptions, setOptions } = dataMiddleware({ reset: true });
-	// 		setOptions({
-	// 			pageNumber: 99,
-	// 			pageSize: 99,
-	// 			query: { value: 'testA' }
-	// 		});
-	// 		return <div>{JSON.stringify(getOptions())}</div>;
-	// 	});
-	// 	const WidgetB = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-	// 		const { getOptions, setOptions } = dataMiddleware({ reset: true });
-	// 		setOptions({
-	// 			pageNumber: 10,
-	// 			pageSize: 10,
-	// 			query: { value: 'testB' }
-	// 		});
-	// 		return <div>{JSON.stringify(getOptions())}</div>;
-	// 	});
-	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-	// 		const { shared } = dataMiddleware();
-	// 		const sharedResource = shared();
-	// 		return (
-	// 			<virtual>
-	// 				<WidgetA resource={sharedResource} />
-	// 				<WidgetB resource={sharedResource} />
-	// 			</virtual>
-	// 		);
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App resource={resourceStub} />);
-	// 	r.mount({ domNode: root });
-	// 	assert.strictEqual(
-	// 		root.innerHTML,
-	// 		`<div>${JSON.stringify({
-	// 			pageNumber: 99,
-	// 			pageSize: 99,
-	// 			query: { value: 'testA' }
-	// 		})}</div><div>${JSON.stringify({
-	// 			pageNumber: 10,
-	// 			pageSize: 10,
-	// 			query: { value: 'testB' }
-	// 		})}</div>`
-	// 	);
-	// });
+		const r = renderer(() => <App />);
+		const root = document.createElement('div');
+		r.mount({ domNode: root });
+		assert.strictEqual(
+			root.innerHTML,
+			`<div><button></button><div>${JSON.stringify([{ hello: 'world' }, { hello: 'moon' }])}</div></div>`
+		);
+		(root.children[0].children[0] as any).click();
+		resolvers.resolveRAF();
+		assert.strictEqual(
+			root.innerHTML,
+			`<div><button></button><div>${JSON.stringify([{ hello: 'mars' }, { hello: 'venus' }])}</div></div>`
+		);
+	});
 
-	// it('can have a resource passed via a different property', () => {
-	// 	const otherResource: any = {
-	// 		getOrRead: sb.stub(),
-	// 		getTotal: sb.stub(),
-	// 		subscribe: sb.stub(),
-	// 		unsubscribe: sb.stub(),
-	// 		isLoading: sb.stub(),
-	// 		isFailed: sb.stub(),
-	// 		set: sb.stub(),
-	// 		get: sb.stub()
-	// 	};
-	// 	otherResource.getOrRead.returns(['apple', 'pear']);
-	// 	const Widget = create({ dataMiddleware }).properties<{ otherResource: Resource }>()(function Widget({
-	// 		properties,
-	// 		middleware: { dataMiddleware }
-	// 	}) {
-	// 		const { getOrRead, getOptions } = dataMiddleware({ resource: properties().otherResource });
-	// 		return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
-	// 	});
-	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-	// 		const { resource } = dataMiddleware();
+	it('should destroy resources when widget is removed', () => {
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
+		const resource = createResource<{ hello: string }>(createMemoryTemplate({ filter: defaultFilter }));
+		let renderCount = 0;
+		let callSetOptions: any;
+		const WidgetOne = factory(({ middleware: { data } }) => {
+			const { getOrRead, setOptions, getOptions } = data();
+			renderCount++;
+			callSetOptions = setOptions;
+			const { pageNumber = 1, pageSize = 2, query = {} } = getOptions();
+			setOptions({ pageNumber, pageSize, query });
+			const items = getOrRead(getOptions());
+			return <div>{JSON.stringify(items)}</div>;
+		});
 
-	// 		return <Widget resource={resource} otherResource={otherResource} />;
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App resource={resourceStub} />);
-	// 	r.mount({ domNode: root });
-	// 	assert.strictEqual(root.innerHTML, `<div>${JSON.stringify(['apple', 'pear'])}</div>`);
-	// });
+		const App = create({ icache })(({ middleware: { icache } }) => {
+			const show = icache.getOrSet<boolean>('show', true);
+			return (
+				<div>
+					<button
+						onclick={() => {
+							icache.set<boolean>('show', (value) => !value);
+						}}
+					/>
+					{show && <WidgetOne resource={resource({ data: [{ hello: 'world' }, { hello: 'moon' }] })} />}
+				</div>
+			);
+		});
 
-	// it('can use key property to differentiate between options on same resource', () => {
-	// 	resourceStub.getOrRead.returns([{ value: 'foo' }, { value: 'bar' }]);
-	// 	const Widget = create({ dataMiddleware }).properties<{ otherResource: ResourceOrResourceWrapper }>()(
-	// 		function Widget({ properties, middleware: { dataMiddleware } }) {
-	// 			const { setOptions } = dataMiddleware();
-	// 			const { setOptions: setOptions2, getOptions: getOptions2 } = dataMiddleware({
-	// 				key: 'two',
-	// 				resource: properties().otherResource
-	// 			});
-	// 			setOptions2({
-	// 				pageSize: 2,
-	// 				pageNumber: 2,
-	// 				query: { value: 'two-query' }
-	// 			});
-	// 			setOptions({
-	// 				pageSize: 1,
-	// 				pageNumber: 1,
-	// 				query: { value: 'one-query' }
-	// 			});
-	// 			return <div>{JSON.stringify(getOptions2())}</div>;
-	// 		}
-	// 	);
-	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-	// 		const { resource } = dataMiddleware();
-
-	// 		return <Widget resource={resource} otherResource={resource} />;
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App resource={resourceStub} />);
-	// 	r.mount({ domNode: root });
-	// 	assert.strictEqual(
-	// 		root.innerHTML,
-	// 		`<div>${JSON.stringify({
-	// 			pageSize: 2,
-	// 			pageNumber: 2,
-	// 			query: { value: 'two-query' }
-	// 		})}</div>`
-	// 	);
-	// });
-
-	// it('subscribes to resource events when using the api', () => {
-	// 	const { callback } = dataMiddleware();
-	// 	const data = callback({
-	// 		id: 'test',
-	// 		middleware: {
-	// 			invalidator: invalidatorStub,
-	// 			destroy: destroyStub,
-	// 			diffProperty: diffPropertyStub
-	// 		},
-	// 		properties: () => ({
-	// 			resource: resourceStub
-	// 		}),
-	// 		children: () => []
-	// 	});
-
-	// 	const options = {
-	// 		pageNumber: 1,
-	// 		pageSize: 10
-	// 	};
-
-	// 	let { getTotal, isFailed, isLoading, getOrRead } = data();
-	// 	getTotal(options);
-	// 	assert.isTrue(resourceStub.subscribe.calledWith('total', options, invalidatorStub));
-	// 	sb.resetHistory();
-	// 	isFailed(options);
-	// 	assert.isTrue(resourceStub.subscribe.calledWith('failed', options, invalidatorStub));
-	// 	sb.resetHistory();
-	// 	getOrRead(options);
-	// 	assert.isTrue(resourceStub.subscribe.calledWith('data', options, invalidatorStub));
-	// 	sb.resetHistory();
-	// 	isLoading(options);
-	// 	assert.isTrue(resourceStub.subscribe.calledWith('loading', options, invalidatorStub));
-	// });
-
-	// it('unsubscribes from the resource when widget is removed from render', () => {
-	// 	let show = true;
-	// 	let invalidate: any;
-	// 	const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-	// 		const { getOrRead } = dataMiddleware();
-	// 		getOrRead({ pageNumber: 1, pageSize: 2, query: { value: 'test' } });
-	// 		return <div>testing</div>;
-	// 	});
-	// 	const App = create({ dataMiddleware, invalidator })(function App({
-	// 		middleware: { dataMiddleware, invalidator }
-	// 	}) {
-	// 		const { resource } = dataMiddleware();
-	// 		invalidate = invalidator;
-	// 		return show && <Widget resource={resource} />;
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App resource={resourceStub} />);
-	// 	r.mount({ domNode: root });
-	// 	resolvers.resolveRAF();
-	// 	show = false;
-	// 	invalidate();
-	// 	resolvers.resolveRAF();
-	// 	assert.isTrue(resourceStub.unsubscribe.called);
-	// });
-
-	// it('returns loading status of resource', () => {
-	// 	resourceStub.isLoading.returns(true);
-	// 	const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-	// 		const { isLoading, getOptions } = dataMiddleware();
-	// 		const loading = isLoading(getOptions());
-	// 		return <div>{`${loading}`}</div>;
-	// 	});
-	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-	// 		const { resource } = dataMiddleware();
-	// 		return <Widget resource={resource} />;
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App resource={resourceStub} />);
-	// 	r.mount({ domNode: root });
-
-	// 	assert.strictEqual(root.innerHTML, `<div>true</div>`);
-	// });
-
-	// it('returns failed status of resource', () => {
-	// 	resourceStub.isFailed.returns(true);
-	// 	const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-	// 		const { isFailed, getOptions } = dataMiddleware();
-	// 		const failed = isFailed(getOptions());
-	// 		return <div>{`${failed}`}</div>;
-	// 	});
-	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-	// 		const { resource } = dataMiddleware();
-	// 		return <Widget resource={resource} />;
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App resource={resourceStub} />);
-	// 	r.mount({ domNode: root });
-
-	// 	assert.strictEqual(root.innerHTML, `<div>true</div>`);
-	// });
-
-	// it('should call create resource only once when provided a factory and data', () => {
-	// 	const factory = create({ data: dataMiddleware, invalidator });
-	// 	let invalidate: any;
-	// 	const App = factory(function App({ middleware: { data, invalidator } }) {
-	// 		invalidate = invalidator;
-	// 		const { get } = data();
-	// 		return <div>{JSON.stringify(get({}))}</div>;
-	// 	});
-	// 	const root = document.createElement('div');
-	// 	const factoryStub = resourceStub;
-	// 	const r = renderer(() => (
-	// 		<App resource={{ resource: factoryStub, data: [{ value: 'foo' }, { value: 'bar' }] }} />
-	// 	));
-	// 	r.mount({ domNode: root });
-	// 	resolvers.resolveRAF();
-	// 	invalidate();
-	// 	resolvers.resolveRAF();
-	// 	assert.isTrue(factoryStub.set.calledOnce);
-	// });
-
-	// it('should call create resource again if the data passed has changed', () => {
-	// 	const testData = [{ value: 'foo' }, { value: 'bar' }];
-	// 	const testData2 = [{ value: 'red' }, { value: 'blue' }, { value: 'green' }];
-	// 	let invalidate: any;
-	// 	let useAltData = false;
-
-	// 	const Widget = create({ data: dataMiddleware, invalidator })(function Widget({
-	// 		middleware: { data, invalidator }
-	// 	}) {
-	// 		const { get } = data();
-	// 		return <div>{JSON.stringify(get({}))}</div>;
-	// 	});
-
-	// 	const App = create({ invalidator })(function App({ middleware: { invalidator } }) {
-	// 		invalidate = invalidator;
-	// 		const resource = useAltData
-	// 			? { resource: factoryStub, data: testData2 }
-	// 			: { resource: factoryStub, data: testData };
-	// 		return <Widget resource={resource} />;
-	// 	});
-
-	// 	const root = document.createElement('div');
-	// 	const factoryStub = resourceStub;
-	// 	const r = renderer(() => <App />);
-	// 	r.mount({ domNode: root });
-	// 	resolvers.resolveRAF();
-	// 	useAltData = true;
-
-	// 	invalidate();
-
-	// 	resolvers.resolveRAF();
-	// 	assert.isTrue(factoryStub.set.calledTwice);
-	// });
-
-	// it('should call create resource again if the data passed has changed using resource to set data', () => {
-	// 	const testData = [{ value: 'foo' }, { value: 'bar' }];
-	// 	const testData2 = [{ value: 'red' }, { value: 'blue' }, { value: 'green' }];
-	// 	let invalidate: any;
-	// 	let useAltData = false;
-	// 	const factoryStub = (data: any) => {
-	// 		return {
-	// 			resource: resourceStub,
-	// 			data
-	// 		};
-	// 	};
-
-	// 	const Widget = create({ data: dataMiddleware, invalidator })(function Widget({
-	// 		middleware: { data, invalidator }
-	// 	}) {
-	// 		const { get } = data();
-	// 		return <div>{JSON.stringify(get({}))}</div>;
-	// 	});
-
-	// 	const App = create({ invalidator })(function App({ middleware: { invalidator } }) {
-	// 		invalidate = invalidator;
-	// 		return <Widget resource={useAltData ? factoryStub(testData2) : factoryStub(testData)} />;
-	// 	});
-
-	// 	const root = document.createElement('div');
-	// 	const r = renderer(() => <App />);
-	// 	r.mount({ domNode: root });
-	// 	resolvers.resolveRAF();
-	// 	useAltData = true;
-	// 	invalidate();
-	// 	resolvers.resolveRAF();
-	// 	assert.isTrue(resourceStub.set.calledTwice);
-	// });
+		const r = renderer(() => <App />);
+		const root = document.createElement('div');
+		r.mount({ domNode: root });
+		assert.strictEqual(
+			root.innerHTML,
+			'<div><button></button><div>[{"hello":"world"},{"hello":"moon"}]</div></div>'
+		);
+		(root.children[0].children[0] as any).click();
+		resolvers.resolveRAF();
+		assert.strictEqual(renderCount, 1);
+		assert.strictEqual(root.innerHTML, '<div><button></button></div>');
+		callSetOptions({ pageNumber: 2, pageSize: 100, query: {} });
+		resolvers.resolveRAF();
+		assert.strictEqual(renderCount, 1);
+		assert.strictEqual(root.innerHTML, '<div><button></button></div>');
+	});
 });

--- a/tests/core/unit/middleware/data.tsx
+++ b/tests/core/unit/middleware/data.tsx
@@ -1,29 +1,12 @@
 const { it, afterEach, beforeEach } = intern.getInterface('bdd');
 const { describe: jsdomDescribe } = intern.getPlugin('jsdom');
 const { assert } = intern.getPlugin('chai');
-import { sandbox } from 'sinon';
-import { renderer, tsx, create, invalidator } from '../../../../src/core/vdom';
-import dataMiddleware, { createDataMiddleware, ResourceOrResourceWrapper } from '../../../../src/core/middleware/data';
+import { renderer, tsx, create } from '../../../../src/core/vdom';
+import { createDataMiddleware } from '../../../../src/core/middleware/data';
 import { createResolvers } from '../../support/util';
-import { Resource } from '../../../../src/core/resource';
+import { createResource, createMemoryTemplate, defaultFilter } from '../../../../src/core/resource';
 
 const resolvers = createResolvers();
-
-const sb = sandbox.create();
-const invalidatorStub = sb.stub();
-const destroyStub = sb.stub();
-const diffPropertyStub = sb.stub();
-
-let resourceStub: any = sb.stub();
-
-resourceStub.getOrRead = sb.stub();
-resourceStub.getTotal = sb.stub();
-resourceStub.subscribe = sb.stub();
-resourceStub.unsubscribe = sb.stub();
-resourceStub.isLoading = sb.stub();
-resourceStub.isFailed = sb.stub();
-resourceStub.get = sb.stub();
-resourceStub.set = sb.stub();
 
 jsdomDescribe('data middleware', () => {
 	beforeEach(() => {
@@ -31,523 +14,633 @@ jsdomDescribe('data middleware', () => {
 	});
 	afterEach(() => {
 		resolvers.restore();
-		sb.resetHistory();
 	});
 
-	it('should return default API with options', () => {
-		const { callback } = dataMiddleware();
-		const data = callback({
-			id: 'test',
-			middleware: {
-				invalidator: invalidatorStub,
-				destroy: destroyStub,
-				diffProperty: diffPropertyStub
-			},
-			properties: () => ({
-				resource: resourceStub
-			}),
-			children: () => []
-		});
-
-		resourceStub.getOrRead.returns('test');
-		const { getOrRead, getOptions } = data();
-		const result = getOrRead(getOptions());
-		assert.equal(result, 'test');
-	});
-
-	it('can call get with options', () => {
-		const { callback } = dataMiddleware();
-		const data = callback({
-			id: 'test',
-			middleware: {
-				invalidator: invalidatorStub,
-				destroy: destroyStub,
-				diffProperty: diffPropertyStub
-			},
-			properties: () => ({
-				resource: resourceStub
-			}),
-			children: () => []
-		});
-
-		resourceStub.get.returns('test');
-		const { get, getOptions } = data();
-		const result = get(getOptions());
-		assert.equal(result, 'test');
-	});
-
-	it('should invalidate when new options are set', () => {
-		const { callback } = dataMiddleware();
-		const data = callback({
-			id: 'test',
-			middleware: {
-				invalidator: invalidatorStub,
-				destroy: destroyStub,
-				diffProperty: diffPropertyStub
-			},
-			properties: () => ({
-				resource: resourceStub
-			}),
-			children: () => []
-		});
-
-		let { setOptions, getOptions } = data();
-		setOptions({
-			pageNumber: 2,
-			pageSize: 15
-		});
-		assert.isTrue(invalidatorStub.calledOnce);
-		const options = getOptions();
-		assert.equal(options.pageNumber, 2);
-		assert.equal(options.pageSize, 15);
-	});
-
-	it('should transform getOrRead response when using createDataMiddleware', () => {
-		resourceStub.getOrRead.returns([{ item: 'foo' }, { item: 'bar' }]);
-		const factory = create({ data: createDataMiddleware<{ value: string }>() });
-		const App = factory(function App({ middleware: { data } }) {
-			const { getOrRead, getOptions } = data();
-			return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
-		});
+	it('get() with options', () => {
 		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} transform={{ value: ['item'] }} />);
-		r.mount({ domNode: root });
-		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ value: 'foo' }, { value: 'bar' }])}</div>`);
-	});
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
 
-	it('should concat multiple sources into a single response field where appropriate', () => {
-		resourceStub.getOrRead.returns([{ a: 'foo', b: 'b' }, { a: 'bar', b: 'b' }]);
-		const factory = create({ data: createDataMiddleware<{ value: string }>() });
-		const App = factory(function App({ middleware: { data } }) {
-			const { getOrRead, getOptions } = data();
-			return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
-		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} transform={{ value: ['a', 'b'] }} />);
-		r.mount({ domNode: root });
-		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ value: 'foo b' }, { value: 'bar b' }])}</div>`);
-	});
-
-	it('should not convert single sources into strings', () => {
-		resourceStub.getOrRead.returns([{ a: true, b: 2 }, { a: false, b: 3 }, { b: 4 }]);
-		const factory = create({ data: createDataMiddleware<{ value: string; foo: string }>() });
-		const App = factory(function App({ middleware: { data } }) {
-			const { getOrRead, getOptions } = data();
-			return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
-		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} transform={{ value: ['a'], foo: ['b'] }} />);
-		r.mount({ domNode: root });
-		assert.strictEqual(
-			root.innerHTML,
-			`<div>${JSON.stringify([{ value: true, foo: 2 }, { value: false, foo: 3 }, { foo: 4 }])}</div>`
-		);
-	});
-
-	it('should transform get response when using createDataMiddleware', () => {
-		resourceStub.get.returns([{ item: 'foo' }, { item: 'bar' }]);
-		const factory = create({ data: createDataMiddleware<{ value: string }>() });
-		const App = factory(function App({ middleware: { data } }) {
+		const Thing = factory(({ middleware: { data } }) => {
 			const { get, getOptions } = data();
 			return <div>{JSON.stringify(get(getOptions()))}</div>;
 		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} transform={{ value: ['item'] }} />);
+
+		const resource = createResource<{ hello: string }>();
+
+		const App = create()(() => {
+			return <Thing resource={resource({ data: [{ hello: '1' }] })} />;
+		});
+
+		const r = renderer(() => <App />);
 		r.mount({ domNode: root });
-		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ value: 'foo' }, { value: 'bar' }])}</div>`);
+		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: '1' }])}</div>`);
 	});
 
-	it('should transform appropriate query options when calling resource apis', () => {
-		const factory = create({ data: createDataMiddleware<{ value: string }>() });
-		const App = factory(function App({ middleware: { data } }) {
-			const { get } = data();
+	it('should update when setOptions() called', () => {
+		const root = document.createElement('div');
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
+
+		let set: any;
+		const Thing = factory(({ middleware: { data } }) => {
+			const { get, getOptions, setOptions } = data();
+			set = setOptions;
+			const { pageSize = 1, pageNumber = 1 } = getOptions();
+			setOptions({ pageSize, pageNumber });
+			return <div>{JSON.stringify(get(getOptions()))}</div>;
+		});
+
+		const resource = createResource<{ hello: string }>();
+
+		const App = create()(() => {
+			return <Thing resource={resource({ data: [{ hello: '1' }, { hello: '2' }] })} />;
+		});
+
+		const r = renderer(() => <App />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: '1' }])}</div>`);
+		set({ pageNumber: 2 });
+		resolvers.resolveRAF();
+		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: '2' }])}</div>`);
+	});
+
+	it('should transform data', () => {
+		const root = document.createElement('div');
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
+		const Thing = factory(({ middleware: { data } }) => {
+			const { get, getOptions, setOptions } = data();
+			const { pageSize = 1, pageNumber = 1 } = getOptions();
+			setOptions({ pageSize, pageNumber });
+			return <div>{JSON.stringify(get(getOptions()))}</div>;
+		});
+
+		const resource = createResource<{ wrong: string }>();
+
+		const App = create()(() => {
 			return (
-				<div>
-					{JSON.stringify(
-						get({
-							query: {
-								value: 'test',
-								foo: 'bar'
-							}
-						})
-					)}
-				</div>
+				<Thing resource={resource({ transform: { hello: 'wrong' }, data: [{ wrong: '1' }, { wrong: '2' }] })} />
 			);
 		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} transform={{ value: ['item'] }} />);
+
+		const r = renderer(() => <App />);
 		r.mount({ domNode: root });
-		assert.isTrue(
-			resourceStub.get.calledWith({ query: [{ keys: ['item'], value: 'test' }, { keys: ['foo'], value: 'bar' }] })
-		);
+		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: '1' }])}</div>`);
 	});
 
-	it('should still convert query options to resource query format when not using a transform', () => {
-		const factory = create({ data: dataMiddleware });
-		const App = factory(function App({ middleware: { data } }) {
-			const { get } = data();
-			return (
-				<div>
-					{JSON.stringify(
-						get({
-							query: {
-								value: 'test',
-								foo: 'bar'
-							}
-						})
-					)}
-				</div>
-			);
-		});
+	it('should not convert single fields into strings when using a transform', () => {
 		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} />);
+		const factory = create({ data: createDataMiddleware<{ hello: number }>() });
+
+		const Thing = factory(({ middleware: { data } }) => {
+			const { get, getOptions, setOptions } = data();
+			const { pageSize = 1, pageNumber = 1 } = getOptions();
+			setOptions({ pageSize, pageNumber });
+			return <div>{JSON.stringify(get(getOptions()))}</div>;
+		});
+
+		const resource = createResource<{ wrong: number }>();
+
+		const App = create()(() => {
+			return <Thing resource={resource({ transform: { hello: 'wrong' }, data: [{ wrong: 1 }, { wrong: 2 }] })} />;
+		});
+
+		const r = renderer(() => <App />);
 		r.mount({ domNode: root });
-		assert.isTrue(
-			resourceStub.get.calledWith({
-				query: [{ keys: ['value'], value: 'test' }, { keys: ['foo'], value: 'bar' }]
-			})
-		);
+		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: 1 }])}</div>`);
 	});
 
-	it('can create shared resources that share options', () => {
-		resourceStub.getOrRead.returns([{ value: 'foo' }, { value: 'bar' }]);
-		const WidgetA = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-			const { getOptions, setOptions } = dataMiddleware();
-			setOptions({
-				pageNumber: 99,
-				pageSize: 99,
-				query: { value: 'test' }
-			});
-			return <div>{JSON.stringify(getOptions())}</div>;
+	it('returns loading status of resource', async () => {
+		let resolver: (options: { data: any[]; total: number }) => void;
+		const promise = new Promise<{ data: any[]; total: number }>((resolve) => {
+			resolver = resolve;
 		});
-		const WidgetB = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-			const { getOptions } = dataMiddleware();
-			return <div>{JSON.stringify(getOptions())}</div>;
-		});
-		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-			const { shared } = dataMiddleware();
-			const sharedResource = shared();
-			return (
-				<virtual>
-					<WidgetA resource={sharedResource} />
-					<WidgetB resource={sharedResource} />
-				</virtual>
-			);
-		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} />);
-		r.mount({ domNode: root });
-		assert.strictEqual(
-			root.innerHTML,
-			`<div>${JSON.stringify({
-				pageNumber: 99,
-				pageSize: 99,
-				query: { value: 'test' }
-			})}</div><div>${JSON.stringify({
-				pageNumber: 99,
-				pageSize: 99,
-				query: { value: 'test' }
-			})}</div>`
-		);
-	});
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
 
-	it('can reset a shared resource to obtain its own options', () => {
-		resourceStub.getOrRead.returns([{ value: 'foo' }, { value: 'bar' }]);
-		const WidgetA = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-			const { getOptions, setOptions } = dataMiddleware({ reset: true });
-			setOptions({
-				pageNumber: 99,
-				pageSize: 99,
-				query: { value: 'testA' }
-			});
-			return <div>{JSON.stringify(getOptions())}</div>;
-		});
-		const WidgetB = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-			const { getOptions, setOptions } = dataMiddleware({ reset: true });
-			setOptions({
-				pageNumber: 10,
-				pageSize: 10,
-				query: { value: 'testB' }
-			});
-			return <div>{JSON.stringify(getOptions())}</div>;
-		});
-		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-			const { shared } = dataMiddleware();
-			const sharedResource = shared();
-			return (
-				<virtual>
-					<WidgetA resource={sharedResource} />
-					<WidgetB resource={sharedResource} />
-				</virtual>
-			);
-		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} />);
-		r.mount({ domNode: root });
-		assert.strictEqual(
-			root.innerHTML,
-			`<div>${JSON.stringify({
-				pageNumber: 99,
-				pageSize: 99,
-				query: { value: 'testA' }
-			})}</div><div>${JSON.stringify({
-				pageNumber: 10,
-				pageSize: 10,
-				query: { value: 'testB' }
-			})}</div>`
-		);
-	});
-
-	it('can have a resource passed via a different property', () => {
-		const otherResource: any = {
-			getOrRead: sb.stub(),
-			getTotal: sb.stub(),
-			subscribe: sb.stub(),
-			unsubscribe: sb.stub(),
-			isLoading: sb.stub(),
-			isFailed: sb.stub(),
-			set: sb.stub(),
-			get: sb.stub()
-		};
-		otherResource.getOrRead.returns(['apple', 'pear']);
-		const Widget = create({ dataMiddleware }).properties<{ otherResource: Resource }>()(function Widget({
-			properties,
-			middleware: { dataMiddleware }
-		}) {
-			const { getOrRead, getOptions } = dataMiddleware({ resource: properties().otherResource });
-			return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
-		});
-		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-			const { resource } = dataMiddleware();
-
-			return <Widget resource={resource} otherResource={otherResource} />;
-		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} />);
-		r.mount({ domNode: root });
-		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify(['apple', 'pear'])}</div>`);
-	});
-
-	it('can use key property to differentiate between options on same resource', () => {
-		resourceStub.getOrRead.returns([{ value: 'foo' }, { value: 'bar' }]);
-		const Widget = create({ dataMiddleware }).properties<{ otherResource: ResourceOrResourceWrapper }>()(
-			function Widget({ properties, middleware: { dataMiddleware } }) {
-				const { setOptions } = dataMiddleware();
-				const { setOptions: setOptions2, getOptions: getOptions2 } = dataMiddleware({
-					key: 'two',
-					resource: properties().otherResource
-				});
-				setOptions2({
-					pageSize: 2,
-					pageNumber: 2,
-					query: { value: 'two-query' }
-				});
-				setOptions({
-					pageSize: 1,
-					pageNumber: 1,
-					query: { value: 'one-query' }
-				});
-				return <div>{JSON.stringify(getOptions2())}</div>;
+		const resource = createResource<{ hello: string }>({
+			read: () => {
+				return promise;
 			}
-		);
-		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-			const { resource } = dataMiddleware();
-
-			return <Widget resource={resource} otherResource={resource} />;
 		});
+
+		const Thing = factory(({ middleware: { data } }) => {
+			const { getOrRead, isLoading } = data();
+			const items = getOrRead({ pageSize: 1, pageNumber: 1 });
+			const loading = isLoading({ pageSize: 1, pageNumber: 1 });
+			if (loading) {
+				return <div>Loading</div>;
+			}
+			return <div>{JSON.stringify(items)}</div>;
+		});
+
+		const App = create()(() => {
+			return <Thing resource={resource()} />;
+		});
+
+		const r = renderer(() => <App />);
 		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} />);
+		r.mount({ domNode: root });
+		assert.strictEqual(root.innerHTML, `<div>Loading</div>`);
+		resolver!({ data: [{ hello: 'world' }], total: 1 });
+		await promise;
+		resolvers.resolveRAF();
+		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: 'world' }])}</div>`);
+	});
+
+	it('should be able to share basic resource across between widgets', () => {
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
+		const resource = createResource<{ hello: string }>();
+
+		const WidgetOne = factory(({ middleware: { data } }) => {
+			const { setOptions, getOptions } = data();
+			return (
+				<button
+					onclick={() => {
+						setOptions({ ...getOptions(), pageNumber: 2 });
+					}}
+				/>
+			);
+		});
+
+		const WidgetTwo = factory(({ middleware: { data } }) => {
+			const { getOrRead, setOptions, getOptions } = data();
+			const { pageNumber = 1, pageSize = 1 } = getOptions();
+			setOptions({ pageNumber, pageSize });
+			const items = getOrRead(getOptions());
+			return <div>{JSON.stringify(items)}</div>;
+		});
+
+		const Parent = factory(({ middleware: { data } }) => {
+			const { shared } = data();
+			return (
+				<div>
+					<WidgetOne resource={shared()} />
+					<WidgetTwo resource={shared()} />
+				</div>
+			);
+		});
+
+		const App = create()(() => {
+			return <Parent resource={resource({ data: [{ hello: 'world' }, { hello: 'world again' }] })} />;
+		});
+
+		const r = renderer(() => <App />);
+		const root = document.createElement('div');
 		r.mount({ domNode: root });
 		assert.strictEqual(
 			root.innerHTML,
-			`<div>${JSON.stringify({
-				pageSize: 2,
-				pageNumber: 2,
-				query: { value: 'two-query' }
-			})}</div>`
+			`<div><button></button><div>${JSON.stringify([{ hello: 'world' }])}</div></div>`
+		);
+		(root.children[0].children[0] as any).click();
+		resolvers.resolveRAF();
+		assert.strictEqual(
+			root.innerHTML,
+			`<div><button></button><div>${JSON.stringify([{ hello: 'world again' }])}</div></div>`
 		);
 	});
 
-	it('subscribes to resource events when using the api', () => {
-		const { callback } = dataMiddleware();
-		const data = callback({
-			id: 'test',
-			middleware: {
-				invalidator: invalidatorStub,
-				destroy: destroyStub,
-				diffProperty: diffPropertyStub
-			},
-			properties: () => ({
-				resource: resourceStub
-			}),
-			children: () => []
+	it('should be able to share search query across widgets', () => {
+		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
+		const resource = createResource<{ hello: string }>(createMemoryTemplate({ filter: defaultFilter }));
+
+		const WidgetOne = factory(({ middleware: { data } }) => {
+			const { setOptions, getOptions } = data();
+			return (
+				<button
+					onclick={() => {
+						setOptions({ ...getOptions(), query: { hello: 'again' } });
+					}}
+				/>
+			);
 		});
 
-		const options = {
-			pageNumber: 1,
-			pageSize: 10
-		};
-
-		let { getTotal, isFailed, isLoading, getOrRead } = data();
-		getTotal(options);
-		assert.isTrue(resourceStub.subscribe.calledWith('total', options, invalidatorStub));
-		sb.resetHistory();
-		isFailed(options);
-		assert.isTrue(resourceStub.subscribe.calledWith('failed', options, invalidatorStub));
-		sb.resetHistory();
-		getOrRead(options);
-		assert.isTrue(resourceStub.subscribe.calledWith('data', options, invalidatorStub));
-		sb.resetHistory();
-		isLoading(options);
-		assert.isTrue(resourceStub.subscribe.calledWith('loading', options, invalidatorStub));
-	});
-
-	it('unsubscribes from the resource when widget is removed from render', () => {
-		let show = true;
-		let invalidate: any;
-		const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-			const { getOrRead } = dataMiddleware();
-			getOrRead({ pageNumber: 1, pageSize: 2, query: { value: 'test' } });
-			return <div>testing</div>;
-		});
-		const App = create({ dataMiddleware, invalidator })(function App({
-			middleware: { dataMiddleware, invalidator }
-		}) {
-			const { resource } = dataMiddleware();
-			invalidate = invalidator;
-			return show && <Widget resource={resource} />;
-		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} />);
-		r.mount({ domNode: root });
-		resolvers.resolveRAF();
-		show = false;
-		invalidate();
-		resolvers.resolveRAF();
-		assert.isTrue(resourceStub.unsubscribe.called);
-	});
-
-	it('returns loading status of resource', () => {
-		resourceStub.isLoading.returns(true);
-		const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-			const { isLoading, getOptions } = dataMiddleware();
-			const loading = isLoading(getOptions());
-			return <div>{`${loading}`}</div>;
-		});
-		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-			const { resource } = dataMiddleware();
-			return <Widget resource={resource} />;
-		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} />);
-		r.mount({ domNode: root });
-
-		assert.strictEqual(root.innerHTML, `<div>true</div>`);
-	});
-
-	it('returns failed status of resource', () => {
-		resourceStub.isFailed.returns(true);
-		const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
-			const { isFailed, getOptions } = dataMiddleware();
-			const failed = isFailed(getOptions());
-			return <div>{`${failed}`}</div>;
-		});
-		const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
-			const { resource } = dataMiddleware();
-			return <Widget resource={resource} />;
-		});
-		const root = document.createElement('div');
-		const r = renderer(() => <App resource={resourceStub} />);
-		r.mount({ domNode: root });
-
-		assert.strictEqual(root.innerHTML, `<div>true</div>`);
-	});
-
-	it('should call create resource only once when provided a factory and data', () => {
-		const factory = create({ data: dataMiddleware, invalidator });
-		let invalidate: any;
-		const App = factory(function App({ middleware: { data, invalidator } }) {
-			invalidate = invalidator;
-			const { get } = data();
-			return <div>{JSON.stringify(get({}))}</div>;
-		});
-		const root = document.createElement('div');
-		const factoryStub = resourceStub;
-		const r = renderer(() => (
-			<App resource={{ resource: factoryStub, data: [{ value: 'foo' }, { value: 'bar' }] }} />
-		));
-		r.mount({ domNode: root });
-		resolvers.resolveRAF();
-		invalidate();
-		resolvers.resolveRAF();
-		assert.isTrue(factoryStub.set.calledOnce);
-	});
-
-	it('should call create resource again if the data passed has changed', () => {
-		const testData = [{ value: 'foo' }, { value: 'bar' }];
-		const testData2 = [{ value: 'red' }, { value: 'blue' }, { value: 'green' }];
-		let invalidate: any;
-		let useAltData = false;
-
-		const Widget = create({ data: dataMiddleware, invalidator })(function Widget({
-			middleware: { data, invalidator }
-		}) {
-			const { get } = data();
-			return <div>{JSON.stringify(get({}))}</div>;
+		const WidgetTwo = factory(({ middleware: { data } }) => {
+			const { getOrRead, setOptions, getOptions } = data();
+			const { pageNumber = 1, pageSize = 2, query = {} } = getOptions();
+			setOptions({ pageNumber, pageSize, query });
+			const items = getOrRead(getOptions());
+			return <div>{JSON.stringify(items)}</div>;
 		});
 
-		const App = create({ invalidator })(function App({ middleware: { invalidator } }) {
-			invalidate = invalidator;
-			const resource = useAltData
-				? { resource: factoryStub, data: testData2 }
-				: { resource: factoryStub, data: testData };
-			return <Widget resource={resource} />;
+		const Parent = factory(({ middleware: { data } }) => {
+			const { shared } = data();
+
+			return (
+				<div>
+					<WidgetOne resource={shared()} />
+					<WidgetTwo resource={shared()} />
+				</div>
+			);
 		});
 
-		const root = document.createElement('div');
-		const factoryStub = resourceStub;
+		const App = create()(() => {
+			return <Parent resource={resource({ data: [{ hello: 'world' }, { hello: 'world again' }] })} />;
+		});
+
 		const r = renderer(() => <App />);
-		r.mount({ domNode: root });
-		resolvers.resolveRAF();
-		useAltData = true;
-
-		invalidate();
-
-		resolvers.resolveRAF();
-		assert.isTrue(factoryStub.set.calledTwice);
-	});
-
-	it('should call create resource again if the data passed has changed using resource to set data', () => {
-		const testData = [{ value: 'foo' }, { value: 'bar' }];
-		const testData2 = [{ value: 'red' }, { value: 'blue' }, { value: 'green' }];
-		let invalidate: any;
-		let useAltData = false;
-		const factoryStub = (data: any) => {
-			return {
-				resource: resourceStub,
-				data
-			};
-		};
-
-		const Widget = create({ data: dataMiddleware, invalidator })(function Widget({
-			middleware: { data, invalidator }
-		}) {
-			const { get } = data();
-			return <div>{JSON.stringify(get({}))}</div>;
-		});
-
-		const App = create({ invalidator })(function App({ middleware: { invalidator } }) {
-			invalidate = invalidator;
-			return <Widget resource={useAltData ? factoryStub(testData2) : factoryStub(testData)} />;
-		});
-
 		const root = document.createElement('div');
-		const r = renderer(() => <App />);
 		r.mount({ domNode: root });
+		assert.strictEqual(
+			root.innerHTML,
+			`<div><button></button><div>${JSON.stringify([{ hello: 'world' }, { hello: 'world again' }])}</div></div>`
+		);
+		(root.children[0].children[0] as any).click();
 		resolvers.resolveRAF();
-		useAltData = true;
-		invalidate();
-		resolvers.resolveRAF();
-		assert.isTrue(resourceStub.set.calledTwice);
+		assert.strictEqual(
+			root.innerHTML,
+			`<div><button></button><div>${JSON.stringify([{ hello: 'world again' }])}</div></div>`
+		);
 	});
+
+	// it('should transform appropriate query options when calling resource apis', () => {
+	// 	const factory = create({ data: createDataMiddleware<{ value: string }>() });
+	// 	const App = factory(function App({ middleware: { data } }) {
+	// 		const { get } = data();
+	// 		return (
+	// 			<div>
+	// 				{JSON.stringify(
+	// 					get({
+	// 						query: {
+	// 							value: 'test',
+	// 							foo: 'bar'
+	// 						}
+	// 					})
+	// 				)}
+	// 			</div>
+	// 		);
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App resource={resourceStub} transform={{ value: ['item'] }} />);
+	// 	r.mount({ domNode: root });
+	// 	assert.isTrue(
+	// 		resourceStub.get.calledWith({ query: [{ keys: ['item'], value: 'test' }, { keys: ['foo'], value: 'bar' }] })
+	// 	);
+	// });
+
+	// it('should still convert query options to resource query format when not using a transform', () => {
+	// 	const factory = create({ data: dataMiddleware });
+	// 	const App = factory(function App({ middleware: { data } }) {
+	// 		const { get } = data();
+	// 		return (
+	// 			<div>
+	// 				{JSON.stringify(
+	// 					get({
+	// 						query: {
+	// 							value: 'test',
+	// 							foo: 'bar'
+	// 						}
+	// 					})
+	// 				)}
+	// 			</div>
+	// 		);
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App resource={resourceStub} />);
+	// 	r.mount({ domNode: root });
+	// 	assert.isTrue(
+	// 		resourceStub.get.calledWith({
+	// 			query: [{ keys: ['value'], value: 'test' }, { keys: ['foo'], value: 'bar' }]
+	// 		})
+	// 	);
+	// });
+
+	// it('can create shared resources that share options', () => {
+	// 	resourceStub.getOrRead.returns([{ value: 'foo' }, { value: 'bar' }]);
+	// 	const WidgetA = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+	// 		const { getOptions, setOptions } = dataMiddleware();
+	// 		setOptions({
+	// 			pageNumber: 99,
+	// 			pageSize: 99,
+	// 			query: { value: 'test' }
+	// 		});
+	// 		return <div>{JSON.stringify(getOptions())}</div>;
+	// 	});
+	// 	const WidgetB = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+	// 		const { getOptions } = dataMiddleware();
+	// 		return <div>{JSON.stringify(getOptions())}</div>;
+	// 	});
+	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+	// 		const { shared } = dataMiddleware();
+	// 		const sharedResource = shared();
+	// 		return (
+	// 			<virtual>
+	// 				<WidgetA resource={sharedResource} />
+	// 				<WidgetB resource={sharedResource} />
+	// 			</virtual>
+	// 		);
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App resource={resourceStub} />);
+	// 	r.mount({ domNode: root });
+	// 	assert.strictEqual(
+	// 		root.innerHTML,
+	// 		`<div>${JSON.stringify({
+	// 			pageNumber: 99,
+	// 			pageSize: 99,
+	// 			query: { value: 'test' }
+	// 		})}</div><div>${JSON.stringify({
+	// 			pageNumber: 99,
+	// 			pageSize: 99,
+	// 			query: { value: 'test' }
+	// 		})}</div>`
+	// 	);
+	// });
+
+	// it('can reset a shared resource to obtain its own options', () => {
+	// 	resourceStub.getOrRead.returns([{ value: 'foo' }, { value: 'bar' }]);
+	// 	const WidgetA = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+	// 		const { getOptions, setOptions } = dataMiddleware({ reset: true });
+	// 		setOptions({
+	// 			pageNumber: 99,
+	// 			pageSize: 99,
+	// 			query: { value: 'testA' }
+	// 		});
+	// 		return <div>{JSON.stringify(getOptions())}</div>;
+	// 	});
+	// 	const WidgetB = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+	// 		const { getOptions, setOptions } = dataMiddleware({ reset: true });
+	// 		setOptions({
+	// 			pageNumber: 10,
+	// 			pageSize: 10,
+	// 			query: { value: 'testB' }
+	// 		});
+	// 		return <div>{JSON.stringify(getOptions())}</div>;
+	// 	});
+	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+	// 		const { shared } = dataMiddleware();
+	// 		const sharedResource = shared();
+	// 		return (
+	// 			<virtual>
+	// 				<WidgetA resource={sharedResource} />
+	// 				<WidgetB resource={sharedResource} />
+	// 			</virtual>
+	// 		);
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App resource={resourceStub} />);
+	// 	r.mount({ domNode: root });
+	// 	assert.strictEqual(
+	// 		root.innerHTML,
+	// 		`<div>${JSON.stringify({
+	// 			pageNumber: 99,
+	// 			pageSize: 99,
+	// 			query: { value: 'testA' }
+	// 		})}</div><div>${JSON.stringify({
+	// 			pageNumber: 10,
+	// 			pageSize: 10,
+	// 			query: { value: 'testB' }
+	// 		})}</div>`
+	// 	);
+	// });
+
+	// it('can have a resource passed via a different property', () => {
+	// 	const otherResource: any = {
+	// 		getOrRead: sb.stub(),
+	// 		getTotal: sb.stub(),
+	// 		subscribe: sb.stub(),
+	// 		unsubscribe: sb.stub(),
+	// 		isLoading: sb.stub(),
+	// 		isFailed: sb.stub(),
+	// 		set: sb.stub(),
+	// 		get: sb.stub()
+	// 	};
+	// 	otherResource.getOrRead.returns(['apple', 'pear']);
+	// 	const Widget = create({ dataMiddleware }).properties<{ otherResource: Resource }>()(function Widget({
+	// 		properties,
+	// 		middleware: { dataMiddleware }
+	// 	}) {
+	// 		const { getOrRead, getOptions } = dataMiddleware({ resource: properties().otherResource });
+	// 		return <div>{JSON.stringify(getOrRead(getOptions()))}</div>;
+	// 	});
+	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+	// 		const { resource } = dataMiddleware();
+
+	// 		return <Widget resource={resource} otherResource={otherResource} />;
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App resource={resourceStub} />);
+	// 	r.mount({ domNode: root });
+	// 	assert.strictEqual(root.innerHTML, `<div>${JSON.stringify(['apple', 'pear'])}</div>`);
+	// });
+
+	// it('can use key property to differentiate between options on same resource', () => {
+	// 	resourceStub.getOrRead.returns([{ value: 'foo' }, { value: 'bar' }]);
+	// 	const Widget = create({ dataMiddleware }).properties<{ otherResource: ResourceOrResourceWrapper }>()(
+	// 		function Widget({ properties, middleware: { dataMiddleware } }) {
+	// 			const { setOptions } = dataMiddleware();
+	// 			const { setOptions: setOptions2, getOptions: getOptions2 } = dataMiddleware({
+	// 				key: 'two',
+	// 				resource: properties().otherResource
+	// 			});
+	// 			setOptions2({
+	// 				pageSize: 2,
+	// 				pageNumber: 2,
+	// 				query: { value: 'two-query' }
+	// 			});
+	// 			setOptions({
+	// 				pageSize: 1,
+	// 				pageNumber: 1,
+	// 				query: { value: 'one-query' }
+	// 			});
+	// 			return <div>{JSON.stringify(getOptions2())}</div>;
+	// 		}
+	// 	);
+	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+	// 		const { resource } = dataMiddleware();
+
+	// 		return <Widget resource={resource} otherResource={resource} />;
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App resource={resourceStub} />);
+	// 	r.mount({ domNode: root });
+	// 	assert.strictEqual(
+	// 		root.innerHTML,
+	// 		`<div>${JSON.stringify({
+	// 			pageSize: 2,
+	// 			pageNumber: 2,
+	// 			query: { value: 'two-query' }
+	// 		})}</div>`
+	// 	);
+	// });
+
+	// it('subscribes to resource events when using the api', () => {
+	// 	const { callback } = dataMiddleware();
+	// 	const data = callback({
+	// 		id: 'test',
+	// 		middleware: {
+	// 			invalidator: invalidatorStub,
+	// 			destroy: destroyStub,
+	// 			diffProperty: diffPropertyStub
+	// 		},
+	// 		properties: () => ({
+	// 			resource: resourceStub
+	// 		}),
+	// 		children: () => []
+	// 	});
+
+	// 	const options = {
+	// 		pageNumber: 1,
+	// 		pageSize: 10
+	// 	};
+
+	// 	let { getTotal, isFailed, isLoading, getOrRead } = data();
+	// 	getTotal(options);
+	// 	assert.isTrue(resourceStub.subscribe.calledWith('total', options, invalidatorStub));
+	// 	sb.resetHistory();
+	// 	isFailed(options);
+	// 	assert.isTrue(resourceStub.subscribe.calledWith('failed', options, invalidatorStub));
+	// 	sb.resetHistory();
+	// 	getOrRead(options);
+	// 	assert.isTrue(resourceStub.subscribe.calledWith('data', options, invalidatorStub));
+	// 	sb.resetHistory();
+	// 	isLoading(options);
+	// 	assert.isTrue(resourceStub.subscribe.calledWith('loading', options, invalidatorStub));
+	// });
+
+	// it('unsubscribes from the resource when widget is removed from render', () => {
+	// 	let show = true;
+	// 	let invalidate: any;
+	// 	const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+	// 		const { getOrRead } = dataMiddleware();
+	// 		getOrRead({ pageNumber: 1, pageSize: 2, query: { value: 'test' } });
+	// 		return <div>testing</div>;
+	// 	});
+	// 	const App = create({ dataMiddleware, invalidator })(function App({
+	// 		middleware: { dataMiddleware, invalidator }
+	// 	}) {
+	// 		const { resource } = dataMiddleware();
+	// 		invalidate = invalidator;
+	// 		return show && <Widget resource={resource} />;
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App resource={resourceStub} />);
+	// 	r.mount({ domNode: root });
+	// 	resolvers.resolveRAF();
+	// 	show = false;
+	// 	invalidate();
+	// 	resolvers.resolveRAF();
+	// 	assert.isTrue(resourceStub.unsubscribe.called);
+	// });
+
+	// it('returns loading status of resource', () => {
+	// 	resourceStub.isLoading.returns(true);
+	// 	const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+	// 		const { isLoading, getOptions } = dataMiddleware();
+	// 		const loading = isLoading(getOptions());
+	// 		return <div>{`${loading}`}</div>;
+	// 	});
+	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+	// 		const { resource } = dataMiddleware();
+	// 		return <Widget resource={resource} />;
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App resource={resourceStub} />);
+	// 	r.mount({ domNode: root });
+
+	// 	assert.strictEqual(root.innerHTML, `<div>true</div>`);
+	// });
+
+	// it('returns failed status of resource', () => {
+	// 	resourceStub.isFailed.returns(true);
+	// 	const Widget = create({ dataMiddleware })(function Widget({ middleware: { dataMiddleware } }) {
+	// 		const { isFailed, getOptions } = dataMiddleware();
+	// 		const failed = isFailed(getOptions());
+	// 		return <div>{`${failed}`}</div>;
+	// 	});
+	// 	const App = create({ dataMiddleware })(function App({ middleware: { dataMiddleware } }) {
+	// 		const { resource } = dataMiddleware();
+	// 		return <Widget resource={resource} />;
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App resource={resourceStub} />);
+	// 	r.mount({ domNode: root });
+
+	// 	assert.strictEqual(root.innerHTML, `<div>true</div>`);
+	// });
+
+	// it('should call create resource only once when provided a factory and data', () => {
+	// 	const factory = create({ data: dataMiddleware, invalidator });
+	// 	let invalidate: any;
+	// 	const App = factory(function App({ middleware: { data, invalidator } }) {
+	// 		invalidate = invalidator;
+	// 		const { get } = data();
+	// 		return <div>{JSON.stringify(get({}))}</div>;
+	// 	});
+	// 	const root = document.createElement('div');
+	// 	const factoryStub = resourceStub;
+	// 	const r = renderer(() => (
+	// 		<App resource={{ resource: factoryStub, data: [{ value: 'foo' }, { value: 'bar' }] }} />
+	// 	));
+	// 	r.mount({ domNode: root });
+	// 	resolvers.resolveRAF();
+	// 	invalidate();
+	// 	resolvers.resolveRAF();
+	// 	assert.isTrue(factoryStub.set.calledOnce);
+	// });
+
+	// it('should call create resource again if the data passed has changed', () => {
+	// 	const testData = [{ value: 'foo' }, { value: 'bar' }];
+	// 	const testData2 = [{ value: 'red' }, { value: 'blue' }, { value: 'green' }];
+	// 	let invalidate: any;
+	// 	let useAltData = false;
+
+	// 	const Widget = create({ data: dataMiddleware, invalidator })(function Widget({
+	// 		middleware: { data, invalidator }
+	// 	}) {
+	// 		const { get } = data();
+	// 		return <div>{JSON.stringify(get({}))}</div>;
+	// 	});
+
+	// 	const App = create({ invalidator })(function App({ middleware: { invalidator } }) {
+	// 		invalidate = invalidator;
+	// 		const resource = useAltData
+	// 			? { resource: factoryStub, data: testData2 }
+	// 			: { resource: factoryStub, data: testData };
+	// 		return <Widget resource={resource} />;
+	// 	});
+
+	// 	const root = document.createElement('div');
+	// 	const factoryStub = resourceStub;
+	// 	const r = renderer(() => <App />);
+	// 	r.mount({ domNode: root });
+	// 	resolvers.resolveRAF();
+	// 	useAltData = true;
+
+	// 	invalidate();
+
+	// 	resolvers.resolveRAF();
+	// 	assert.isTrue(factoryStub.set.calledTwice);
+	// });
+
+	// it('should call create resource again if the data passed has changed using resource to set data', () => {
+	// 	const testData = [{ value: 'foo' }, { value: 'bar' }];
+	// 	const testData2 = [{ value: 'red' }, { value: 'blue' }, { value: 'green' }];
+	// 	let invalidate: any;
+	// 	let useAltData = false;
+	// 	const factoryStub = (data: any) => {
+	// 		return {
+	// 			resource: resourceStub,
+	// 			data
+	// 		};
+	// 	};
+
+	// 	const Widget = create({ data: dataMiddleware, invalidator })(function Widget({
+	// 		middleware: { data, invalidator }
+	// 	}) {
+	// 		const { get } = data();
+	// 		return <div>{JSON.stringify(get({}))}</div>;
+	// 	});
+
+	// 	const App = create({ invalidator })(function App({ middleware: { invalidator } }) {
+	// 		invalidate = invalidator;
+	// 		return <Widget resource={useAltData ? factoryStub(testData2) : factoryStub(testData)} />;
+	// 	});
+
+	// 	const root = document.createElement('div');
+	// 	const r = renderer(() => <App />);
+	// 	r.mount({ domNode: root });
+	// 	resolvers.resolveRAF();
+	// 	useAltData = true;
+	// 	invalidate();
+	// 	resolvers.resolveRAF();
+	// 	assert.isTrue(resourceStub.set.calledTwice);
+	// });
 });

--- a/tests/core/unit/middleware/data.tsx
+++ b/tests/core/unit/middleware/data.tsx
@@ -21,7 +21,7 @@ jsdomDescribe('data middleware', () => {
 		const root = document.createElement('div');
 		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
 
-		const Thing = factory(({ middleware: { data } }) => {
+		const Widget = factory(({ middleware: { data } }) => {
 			const { get, getOptions } = data();
 			return <div>{JSON.stringify(get(getOptions()))}</div>;
 		});
@@ -29,7 +29,7 @@ jsdomDescribe('data middleware', () => {
 		const resource = createResource<{ hello: string }>();
 
 		const App = create()(() => {
-			return <Thing resource={resource({ data: [{ hello: '1' }] })} />;
+			return <Widget resource={resource({ data: [{ hello: '1' }] })} />;
 		});
 
 		const r = renderer(() => <App />);
@@ -37,12 +37,12 @@ jsdomDescribe('data middleware', () => {
 		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([{ hello: '1' }])}</div>`);
 	});
 
-	it('should update when setOptions() called', () => {
+	it('should update when setOptions called', () => {
 		const root = document.createElement('div');
 		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
 
 		let set: any;
-		const Thing = factory(({ middleware: { data } }) => {
+		const Widget = factory(({ middleware: { data } }) => {
 			const { get, getOptions, setOptions } = data();
 			set = setOptions;
 			const { pageSize = 1, pageNumber = 1 } = getOptions();
@@ -53,7 +53,7 @@ jsdomDescribe('data middleware', () => {
 		const resource = createResource<{ hello: string }>();
 
 		const App = create()(() => {
-			return <Thing resource={resource({ data: [{ hello: '1' }, { hello: '2' }] })} />;
+			return <Widget resource={resource({ data: [{ hello: '1' }, { hello: '2' }] })} />;
 		});
 
 		const r = renderer(() => <App />);
@@ -67,7 +67,7 @@ jsdomDescribe('data middleware', () => {
 	it('should transform data', () => {
 		const root = document.createElement('div');
 		const factory = create({ data: createDataMiddleware<{ hello: string }>() });
-		const Thing = factory(({ middleware: { data } }) => {
+		const Widget = factory(({ middleware: { data } }) => {
 			const { get, getOptions, setOptions, getTotal } = data();
 			const { pageSize = 1, pageNumber = 1 } = getOptions();
 			setOptions({ pageSize, pageNumber });
@@ -83,7 +83,9 @@ jsdomDescribe('data middleware', () => {
 
 		const App = create()(() => {
 			return (
-				<Thing resource={resource({ transform: { hello: 'wrong' }, data: [{ wrong: '1' }, { wrong: '2' }] })} />
+				<Widget
+					resource={resource({ transform: { hello: 'wrong' }, data: [{ wrong: '1' }, { wrong: '2' }] })}
+				/>
 			);
 		});
 
@@ -95,7 +97,7 @@ jsdomDescribe('data middleware', () => {
 	it('should by able to filter with transformed data', () => {
 		const root = document.createElement('div');
 		const factory = create({ data: createDataMiddleware<{ hello: string; foo?: string }>() });
-		const Thing = factory(({ middleware: { data } }) => {
+		const Widget = factory(({ middleware: { data } }) => {
 			const { getOrRead, getOptions, setOptions } = data();
 			const {
 				query: {}
@@ -110,7 +112,7 @@ jsdomDescribe('data middleware', () => {
 
 		const App = create()(() => {
 			return (
-				<Thing
+				<Widget
 					resource={resource({
 						transform: { hello: 'wrong' },
 						data: [{ wrong: '1', foo: '1' }, { wrong: '2', foo: '1' }, { wrong: '2', foo: '2' }]
@@ -128,7 +130,7 @@ jsdomDescribe('data middleware', () => {
 		const root = document.createElement('div');
 		const factory = create({ data: createDataMiddleware<{ hello: number }>() });
 
-		const Thing = factory(({ middleware: { data } }) => {
+		const Widget = factory(({ middleware: { data } }) => {
 			const { getOrRead, getOptions, setOptions } = data();
 			const { pageSize = 1, pageNumber = 1 } = getOptions();
 			setOptions({ pageSize, pageNumber });
@@ -138,7 +140,9 @@ jsdomDescribe('data middleware', () => {
 		const resource = createResource<{ wrong: number }>();
 
 		const App = create()(() => {
-			return <Thing resource={resource({ transform: { hello: 'wrong' }, data: [{ wrong: 1 }, { wrong: 2 }] })} />;
+			return (
+				<Widget resource={resource({ transform: { hello: 'wrong' }, data: [{ wrong: 1 }, { wrong: 2 }] })} />
+			);
 		});
 
 		const r = renderer(() => <App />);
@@ -159,7 +163,7 @@ jsdomDescribe('data middleware', () => {
 			}
 		});
 
-		const Thing = factory(({ middleware: { data } }) => {
+		const Widget = factory(({ middleware: { data } }) => {
 			const { getOrRead, isLoading } = data();
 			const items = getOrRead({ pageSize: 1, pageNumber: 1 });
 			const loading = isLoading({ pageSize: 1, pageNumber: 1 });
@@ -170,7 +174,7 @@ jsdomDescribe('data middleware', () => {
 		});
 
 		const App = create()(() => {
-			return <Thing resource={resource()} />;
+			return <Widget resource={resource()} />;
 		});
 
 		const r = renderer(() => <App />);
@@ -196,7 +200,7 @@ jsdomDescribe('data middleware', () => {
 			}
 		});
 
-		const Thing = factory(({ middleware: { data } }) => {
+		const Widget = factory(({ middleware: { data } }) => {
 			const { getOrRead, isLoading, isFailed } = data();
 			const items = getOrRead({ pageSize: 1, pageNumber: 1 });
 			const loading = isLoading({ pageSize: 1, pageNumber: 1 });
@@ -211,7 +215,7 @@ jsdomDescribe('data middleware', () => {
 		});
 
 		const App = create()(() => {
-			return <Thing resource={resource()} />;
+			return <Widget resource={resource()} />;
 		});
 
 		const r = renderer(() => <App />);

--- a/tests/core/unit/resource.ts
+++ b/tests/core/unit/resource.ts
@@ -30,7 +30,7 @@ describe('resource', () => {
 	});
 
 	it('returns resource an associated data', () => {
-		const resource = createResource()([1, 2, 3]);
+		const resource = createResource()({ data: [1, 2, 3] });
 		assert.hasAllKeys(resource.resource, [
 			'getOrRead',
 			'get',
@@ -54,7 +54,7 @@ describe('resource', () => {
 	it('calls the read template function with calculated offset when getOrRead is called', () => {
 		template.read.returns({ data: [], total: 0 });
 		const resource = createResource(template);
-		const query = [{ value: 'test', keys: ['foo', 'bar'] }];
+		const query = [{ value: 'test', keys: 'foo' }];
 		resource.getOrRead({ pageNumber: 2, pageSize: 10, query });
 		assert.isTrue(template.read.calledWith({ offset: 10, size: 10, query }));
 	});
@@ -69,7 +69,7 @@ describe('resource', () => {
 		assert.deepEqual(resource.get({}), data);
 	});
 
-	it('sets the date and total when the set function is used to sideload data', () => {
+	it('sets the date and total when the set function is used to side-load data', () => {
 		const testData = [{ value: 1 }, { value: 2 }];
 		template.read.returns({ data: testData, total: 2 });
 		const resource = createResource(template);
@@ -96,7 +96,7 @@ describe('resource', () => {
 		template.read.returns(new Promise(() => {}));
 		const invalidatorStub = sb.stub();
 		const resource = createResource(template);
-		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: 'foo' }] };
 		resource.subscribe('loading', options, invalidatorStub);
 		resource.getOrRead(options);
 		assert.isTrue(resource.isLoading(options));
@@ -109,7 +109,7 @@ describe('resource', () => {
 		const loadingInvalidator = sb.stub();
 		const failedInvalidator = sb.stub();
 		const resource = createResource(template);
-		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: 'foo' }] };
 		resource.subscribe('loading', options, loadingInvalidator);
 		resource.subscribe('failed', options, failedInvalidator);
 		resource.getOrRead(options);
@@ -127,7 +127,7 @@ describe('resource', () => {
 		});
 		template.read.returns(promise);
 		const resource = createResource(template);
-		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: 'foo' }] };
 		resource.subscribe('data', options, dataInvalidator);
 		resource.getOrRead(options);
 		resolver({ data: ['foo', 'bar'], total: 2 });
@@ -144,7 +144,7 @@ describe('resource', () => {
 		template.read.returns(new Promise(() => {}));
 		const invalidatorStub = sb.stub();
 		const resource = createResource(template);
-		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: ['foo', 'bar'] }] };
+		const options = { pageNumber: 1, pageSize: 2, query: [{ value: 'test', keys: 'foo' }] };
 		resource.subscribe('loading', options, invalidatorStub);
 		resource.getOrRead(options);
 		assert.isTrue(invalidatorStub.called);
@@ -185,10 +185,10 @@ describe('resource', () => {
 		resource.set([{ value: 'one' }, { value: 'two' }]);
 		assert.deepEqual(resource.get({}), [{ value: 'one' }, { value: 'two' }]);
 		assert.equal(resource.getTotal({}), 2);
-		let results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: ['value'] }] });
+		let results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: 'value' }] });
 		assert.deepEqual(results, [{ value: 'one' }]);
-		results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: ['other'] }] });
-		assert.deepEqual(results, [{ value: 'one' }, { value: 'two' }]);
+		results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'two', keys: 'value' }] });
+		assert.deepEqual(results, [{ value: 'two' }]);
 	});
 
 	it('Can provide a custom filter with memory resource', () => {
@@ -205,7 +205,7 @@ describe('resource', () => {
 		resource.set([{ value: 'one' }, { value: 'two' }]);
 		assert.deepEqual(resource.get({}), [{ value: 'one' }, { value: 'two' }]);
 		assert.equal(resource.getTotal({}), 2);
-		const results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: ['value'] }] });
+		const results = resource.getOrRead({ pageNumber: 1, pageSize: 10, query: [{ value: 'one', keys: 'value' }] });
 		assert.deepEqual(results, [{ value: 'two' }]);
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Overhauls the `data` and `resource` typings to improve the ergonomics for passing a `transform` that describes how to convert the resource data to the data middleware data. The `transform` is now passed to the `resource` factory, along with the optional `data`, if the resource item structure matches the data item structure then the transform is not required. When the two data types do not match then a transform is required when using the resource.

When passing a `resource` to a widget, it is required to call the factory, a bare resource can no longer be passed without being called.

```tsx
// This will now error
<MyWidget resource={resource} />

// This is fine as long as the resource/data item structures match
<MyWidget resource={resource()} />

// Using a transform to convert the resource data to the data item structure
<MyWidget resource={resource({ transform: { value: 'resourceProp' )} />
```

* `transform` is optional based on whether the resource can fulfil the data structure.
* `transforms` only supports single keys, not possible to provide composite keys as part of the transform
* `resources` the default page number is now set to `1`
* `defaultFilter` no longer checks for `value` and `label` and uses the passed query directly
* A default `data` middleware is no longer exported, only the data middleware factory
* Re-write the introduction resource documentation

**TODO**: Update the supplemental documentation 
