### PR TITLE
Harness and test renderer support diffProperty functions that return values

### DIFF
--- a/src/testing/harness/harness.ts
+++ b/src/testing/harness/harness.ts
@@ -142,9 +142,14 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 		mockMiddleware.push([
 			diffProperty,
 			factory(() => (propName: string, propertiesOrDiff: Function, diff?: Function) => {
+				const diffFunction = diff || propertiesOrDiff;
 				if (customDiffNames.indexOf(propName) === -1) {
 					customDiffNames.push(propName);
-					customDiffs.push([propName, diff || propertiesOrDiff]);
+					customDiffs.push([propName, diffFunction]);
+					const result = diffFunction({}, properties);
+					if (result) {
+						properties = { ...properties, [propName]: result };
+					}
 				}
 			})
 		]);

--- a/src/testing/harness/harness.ts
+++ b/src/testing/harness/harness.ts
@@ -72,7 +72,7 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 	let middleware: any = {};
 	let properties: any = {};
 	let children: any = [];
-	let customDiffs: any[] = [];
+	let customDiffs: [string, Function][] = [];
 	let customDiffNames: string[] = [];
 	let customComparator: CustomComparator[] = [];
 	let mockMiddleware: [
@@ -141,10 +141,10 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 		mockMiddleware.push([destroy, factory(() => () => {})]);
 		mockMiddleware.push([
 			diffProperty,
-			factory(() => (propName: string, func: any) => {
+			factory(() => (propName: string, propertiesOrDiff: Function, diff?: Function) => {
 				if (customDiffNames.indexOf(propName) === -1) {
 					customDiffNames.push(propName);
-					customDiffs.push(func);
+					customDiffs.push([propName, diff || propertiesOrDiff]);
 				}
 			})
 		]);
@@ -187,7 +187,13 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 		let render: RenderResult;
 		const wNode = renderFunc();
 		if (isWidgetFunction(widget)) {
-			customDiffs.forEach((diff) => diff(properties, wNode.properties));
+			for (let i = 0; i < customDiffs.length; i++) {
+				const [name, diff] = customDiffs[i];
+				const result = diff(properties, wNode.properties);
+				if (result) {
+					wNode.properties = { ...wNode.properties, [name]: result };
+				}
+			}
 			propertiesDiff(
 				properties,
 				wNode.properties,

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -494,9 +494,14 @@ export function renderer(renderFunc: () => WNode, options: RendererOptions = {})
 		mockMiddleware.push([
 			diffProperty,
 			factory(() => (propName: string, propertiesOrDiff: Function, diff?: Function) => {
+				const diffFunction = diff || propertiesOrDiff;
 				if (customDiffNames.indexOf(propName) === -1) {
 					customDiffNames.push(propName);
-					customDiffs.push([propName, diff || propertiesOrDiff]);
+					customDiffs.push([propName, diffFunction]);
+					const result = diffFunction({}, properties);
+					if (result) {
+						properties = { ...properties, [propName]: result };
+					}
 				}
 			})
 		]);

--- a/tests/testing/unit/harness/harness.tsx
+++ b/tests/testing/unit/harness/harness.tsx
@@ -683,9 +683,11 @@ describe('harness', () => {
 
 		it('should support returning a property value diffProperty middleware', () => {
 			const factory = create({ diffProperty, invalidator }).properties<{ foo: string }>();
-			const App = factory(({ middleware: { diffProperty }, properties }) => {
+			let id = 0;
+			const App = factory(({ middleware: { diffProperty, invalidator }, properties }) => {
 				diffProperty('foo', properties, () => {
-					return 'new';
+					invalidator();
+					return `new ${id++}`;
 				});
 				return (
 					<div>
@@ -696,7 +698,12 @@ describe('harness', () => {
 			const h = harness(() => <App foo="foo" />);
 			h.expect(() => (
 				<div>
-					<button key="click-me">new</button>
+					<button key="click-me">new 0</button>
+				</div>
+			));
+			h.expect(() => (
+				<div>
+					<button key="click-me">new 1</button>
 				</div>
 			));
 		});

--- a/tests/testing/unit/harness/harness.tsx
+++ b/tests/testing/unit/harness/harness.tsx
@@ -637,17 +637,17 @@ describe('harness', () => {
 			const h = harness(() => <App />);
 			h.expect(() => (
 				<div>
-					<button key="click-me">Click Me 0</button>
-				</div>
-			));
-			h.expect(() => (
-				<div>
 					<button key="click-me">Click Me 1</button>
 				</div>
 			));
 			h.expect(() => (
 				<div>
 					<button key="click-me">Click Me 2</button>
+				</div>
+			));
+			h.expect(() => (
+				<div>
+					<button key="click-me">Click Me 3</button>
 				</div>
 			));
 		});
@@ -677,6 +677,26 @@ describe('harness', () => {
 			h.expect(() => (
 				<div>
 					<button key="click-me">app 1</button>
+				</div>
+			));
+		});
+
+		it('should support returning a property value diffProperty middleware', () => {
+			const factory = create({ diffProperty, invalidator }).properties<{ foo: string }>();
+			const App = factory(({ middleware: { diffProperty }, properties }) => {
+				diffProperty('foo', properties, () => {
+					return 'new';
+				});
+				return (
+					<div>
+						<button key="click-me">{properties().foo}</button>
+					</div>
+				);
+			});
+			const h = harness(() => <App foo="foo" />);
+			h.expect(() => (
+				<div>
+					<button key="click-me">new</button>
 				</div>
 			));
 		});

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -649,9 +649,11 @@ describe('test renderer', () => {
 
 		it('should support returning a property value diffProperty middleware', () => {
 			const factory = create({ diffProperty, invalidator }).properties<{ foo: string }>();
-			const App = factory(({ middleware: { diffProperty }, properties }) => {
+			let id = 0;
+			const App = factory(({ middleware: { diffProperty, invalidator }, properties }) => {
 				diffProperty('foo', properties, () => {
-					return 'new';
+					invalidator();
+					return `new ${id++}`;
 				});
 				return (
 					<div>
@@ -663,7 +665,14 @@ describe('test renderer', () => {
 			r.expect(
 				assertion(() => (
 					<div>
-						<button key="click-me">new</button>
+						<button key="click-me">new 0</button>
+					</div>
+				))
+			);
+			r.expect(
+				assertion(() => (
+					<div>
+						<button key="click-me">new 1</button>
 					</div>
 				))
 			);

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -593,7 +593,7 @@ describe('test renderer', () => {
 			r.expect(
 				assertion(() => (
 					<div>
-						<button key="click-me">Click Me 0</button>
+						<button key="click-me">Click Me 1</button>
 					</div>
 				))
 			);
@@ -601,14 +601,14 @@ describe('test renderer', () => {
 			r.expect(
 				assertion(() => (
 					<div>
-						<button key="click-me">Click Me 1</button>
+						<button key="click-me">Click Me 2</button>
 					</div>
 				))
 			);
 			r.expect(
 				assertion(() => (
 					<div>
-						<button key="click-me">Click Me 2</button>
+						<button key="click-me">Click Me 3</button>
 					</div>
 				))
 			);
@@ -642,6 +642,28 @@ describe('test renderer', () => {
 				assertion(() => (
 					<div>
 						<button key="click-me">app 1</button>
+					</div>
+				))
+			);
+		});
+
+		it('should support returning a property value diffProperty middleware', () => {
+			const factory = create({ diffProperty, invalidator }).properties<{ foo: string }>();
+			const App = factory(({ middleware: { diffProperty }, properties }) => {
+				diffProperty('foo', properties, () => {
+					return 'new';
+				});
+				return (
+					<div>
+						<button key="click-me">{properties().foo}</button>
+					</div>
+				);
+			});
+			const r = renderer(() => <App foo="foo" />);
+			r.expect(
+				assertion(() => (
+					<div>
+						<button key="click-me">new</button>
 					</div>
 				))
 			);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support to both the harness and test renderer for `diffProperty` functions that return values.