### PR TITLE
fix: use UUID middleware IDs in harness and renderer

### DIFF
--- a/src/testing/harness/harness.ts
+++ b/src/testing/harness/harness.ts
@@ -12,6 +12,7 @@ import {
 import { WidgetBase } from '../../core/WidgetBase';
 import { isWidgetFunction } from '../../core/Registry';
 import { invalidator, diffProperty, destroy, create, propertiesDiff } from '../../core/vdom';
+import { uuid } from '../../core/util';
 
 export interface CustomComparator {
 	selector: string;
@@ -52,8 +53,6 @@ export interface HarnessAPI {
 	trigger: Trigger;
 	getRender: GetRender;
 }
-
-let middlewareId = 0;
 
 interface HarnessOptions {
 	customComparator?: CustomComparator[];
@@ -96,7 +95,7 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 		const resolveMiddleware = (middlewares: any, mocks: any[]) => {
 			const keys = Object.keys(middlewares);
 			const results: any = {};
-			const uniqueId = `${middlewareId++}`;
+			const uniqueId = uuid();
 			const mockMiddlewareMap = new Map(mocks);
 
 			for (let i = 0; i < keys.length; i++) {

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -81,8 +81,6 @@ export interface Property {
 	): void;
 }
 
-let middlewareId = 0;
-
 interface RendererOptions {
 	middleware?: [MiddlewareResultFactory<any, any, any, any>, MiddlewareResultFactory<any, any, any, any>][];
 }
@@ -448,7 +446,7 @@ export function renderer(renderFunc: () => WNode, options: RendererOptions = {})
 		const resolveMiddleware = (middlewares: any, mocks: any[]) => {
 			const keys = Object.keys(middlewares);
 			const results: any = {};
-			const uniqueId = `${middlewareId++}`;
+			const uniqueId = uuid();
 			const mockMiddlewareMap = new Map(mocks);
 
 			for (let i = 0; i < keys.length; i++) {


### PR DESCRIPTION
**Type:** bugfix

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR


**Description:**

This pull request updates the test harness and the test renderer to use the `uuid` module instead of locally-incremented numerical IDs for middlewares so that they can be used in parallel without potential ID collision.

Resolves #776
