### PR TITLE
Handle undefined properties in renderer diffs

### DIFF
--- a/src/testing/decorate.ts
+++ b/src/testing/decorate.ts
@@ -126,7 +126,7 @@ export function decorate(actual: RenderResult, expected: RenderResult, instructi
 				const propertyKeys = Object.keys(expectedNode.properties);
 				for (let i = 0; i < propertyKeys.length; i++) {
 					const key = propertyKeys[i];
-					if (expectedNode.properties[key].type === 'compare') {
+					if (expectedNode.properties[key] != null && expectedNode.properties[key].type === 'compare') {
 						const result = expectedNode.properties[key](actualNode.properties[key]);
 						if (result) {
 							expectedNode.properties[key] = actualNode.properties[key];

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -574,6 +574,23 @@ describe('test renderer', () => {
 			});
 		});
 
+		it('should handle undefined properties', () => {
+			const factory = create().properties<{ foo?: string }>();
+			const Foo = factory(() => 'foo');
+			const WidgetUnderTest = factory(({ properties }) => (
+				<div>
+					<Foo foo={properties().foo} />
+				</div>
+			));
+			const template = assertion(() => (
+				<div>
+					<Foo foo={undefined} />
+				</div>
+			));
+			const r = renderer(() => <WidgetUnderTest />);
+			r.expect(template);
+		});
+
 		it('should run diffProperty middleware', () => {
 			const factory = create({ diffProperty, invalidator });
 			let id = 0;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Allows the `renderer` to handle diffing widgets where a property was passed `null` or `undefined`
