### PR TITLE
Allow finding and modifying wrapped widgets in functional children

### DIFF
--- a/tests/testing/unit/assertRender.tsx
+++ b/tests/testing/unit/assertRender.tsx
@@ -46,8 +46,8 @@ class WidgetWithMap extends WidgetBase {
 }
 
 function getExpectedError() {
-	const mockWidgetName = (MockWidget as any).name || 'Widget-3';
-	const widgetWithChildrenName = (MockWidget as any).name ? 'WidgetWithNamedChildren' : 'Widget-4';
+	const mockWidgetName = (MockWidget as any).name || 'Widget-4';
+	const widgetWithChildrenName = (MockWidget as any).name ? 'WidgetWithNamedChildren' : 'Widget-5';
 	return `
 <div
 (A)	classes={["one","two","three"]}

--- a/tests/testing/unit/assertion.tsx
+++ b/tests/testing/unit/assertion.tsx
@@ -124,7 +124,7 @@ describe('new/assertion', () => {
 			<div>
 				<AWidget>
 					{{
-						foo: () => <WrappedDiv>child</WrappedDiv>
+						foo: () => [<WrappedDiv>child</WrappedDiv>]
 					}}
 				</AWidget>
 			</div>
@@ -215,12 +215,15 @@ describe('new/assertion', () => {
 	});
 
 	it('can set a child of a functional child widget', () => {
-		const AWidget = create().children<{ foo(): RenderResult }>()(({ children }) => (
-			<div>{children()[0].foo()}</div>
+		const AWidget = create().children<{ bar: RenderResult; foo(): RenderResult }>()(({ children }) => (
+			<div>
+				{children()[0].foo()}
+				{children()[0].bar}
+			</div>
 		));
 		const ParentWidget = create()(() => (
 			<div>
-				<AWidget>{{ foo: () => <div>bar</div> }}</AWidget>
+				<AWidget>{{ foo: () => <div>bar</div>, bar: <div>foo</div> }}</AWidget>
 			</div>
 		));
 		const WrappedWidget = wrap(AWidget);
@@ -231,7 +234,8 @@ describe('new/assertion', () => {
 			<div>
 				<WrappedWidget>
 					{{
-						foo: () => <WrappedDiv>foo</WrappedDiv>
+						foo: () => <WrappedDiv>foo</WrappedDiv>,
+						bar: <div>foo</div>
 					}}
 				</WrappedWidget>
 			</div>


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Now functional children are executed and replaced with the resulting node when finding nodes for assertion updates.
Resolves #775 