### PR TITLE
Allow numbers in vdom

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -534,7 +534,7 @@ export interface WNode<W extends WidgetBaseTypes = any> {
 /**
  * union type for all possible return types from render
  */
-export type DNode<W extends WidgetBaseTypes = any> = VNode | WNode<W> | undefined | null | string | boolean;
+export type DNode<W extends WidgetBaseTypes = any> = VNode | WNode<W> | undefined | null | string | boolean | number;
 
 /**
  * Property Change record for specific property diff functions

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -293,12 +293,18 @@ export function isWNode<W extends WidgetBaseTypes = any>(child: any): child is W
 
 export function isVNode(child: DNode): child is VNode {
 	return Boolean(
-		child && child !== true && typeof child !== 'string' && (child.type === VNODE || child.type === DOMVNODE)
+		child &&
+			child !== true &&
+			typeof child !== 'number' &&
+			typeof child !== 'string' &&
+			(child.type === VNODE || child.type === DOMVNODE)
 	);
 }
 
 export function isDomVNode(child: DNode): child is DomVNode {
-	return Boolean(child && child !== true && typeof child !== 'string' && child.type === DOMVNODE);
+	return Boolean(
+		child && child !== true && typeof child !== 'number' && typeof child !== 'string' && child.type === DOMVNODE
+	);
 }
 
 export function isElementNode(value: any): value is Element {
@@ -1301,7 +1307,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 			if (!renderedItem || renderedItem === true) {
 				continue;
 			}
-			if (typeof renderedItem === 'string') {
+			if (typeof renderedItem === 'string' || typeof renderedItem === 'number') {
 				renderedItem = toTextVNode(renderedItem);
 			}
 			const owningNode = _nodeToWrapperMap.get(renderedItem);

--- a/src/testing/assertRender.ts
+++ b/src/testing/assertRender.ts
@@ -53,7 +53,7 @@ function format(nodes: DNode | DNode[], depth = 0): string {
 			str = `${str}\n${getTabs(depth)}`;
 		}
 
-		if (typeof node === 'string') {
+		if (typeof node === 'string' || typeof node === 'number') {
 			return `${str}${node}`;
 		}
 

--- a/src/testing/harness/support/assertRender.ts
+++ b/src/testing/harness/support/assertRender.ts
@@ -43,7 +43,7 @@ export function formatDNodes(nodes: DNode | DNode[], depth: number = 0): string 
 		}
 		result = `${result}${tabs}`;
 
-		if (typeof node === 'string') {
+		if (typeof node === 'string' || typeof node === 'number') {
 			return `${result}"${node}"`;
 		}
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This would accept numbers as DNodes and render them.  This seems straightforward so I'm not sure if there's any other reason we wouldn't want to allow this. I don't think we'd want to render booleans this way given the utility of the common `boolean && node` pattern.
Resolves #761 
