### PR TITLE
Allow store middleware to take an initial state

### DIFF
--- a/src/core/middleware/store.ts
+++ b/src/core/middleware/store.ts
@@ -5,10 +5,10 @@ import { Process } from '../../stores/process';
 
 const factory = create({ destroy, invalidator, injector });
 
-export const createStoreMiddleware = <S = any>(initial?: (store: Store<S>) => void) => {
-	let store = new Store<S>();
+export const createStoreMiddleware = <S = any>(initial?: Store<S> | ((store: Store<S>) => void)) => {
+	let store = initial && typeof initial !== 'function' ? initial : new Store<S>();
 	let initialized = false;
-	initial && initial(store);
+	typeof initial === 'function' && initial(store);
 	const storeMiddleware = factory(({ middleware: { destroy, invalidator, injector } }) => {
 		const handles: any[] = [];
 		destroy(() => {

--- a/src/core/middleware/store.ts
+++ b/src/core/middleware/store.ts
@@ -1,12 +1,12 @@
 import { destroy, invalidator, create } from '../vdom';
 import injector from '../middleware/injector';
-import Store, { StatePaths, Path } from '../../stores/Store';
+import Store, { StatePaths, Path, MutableState } from '../../stores/Store';
 import { Process } from '../../stores/process';
 
 const factory = create({ destroy, invalidator, injector });
 
-export const createStoreMiddleware = <S = any>(initial?: Store<S> | ((store: Store<S>) => void)) => {
-	let store = initial && typeof initial !== 'function' ? initial : new Store<S>();
+export const createStoreMiddleware = <S = any>(initial?: MutableState<S> | ((store: Store<S>) => void)) => {
+	let store = initial && typeof initial !== 'function' ? new Store<S>({ state: initial }) : new Store<S>();
 	let initialized = false;
 	typeof initial === 'function' && initial(store);
 	const storeMiddleware = factory(({ middleware: { destroy, invalidator, injector } }) => {

--- a/tests/core/unit/middleware/store.ts
+++ b/tests/core/unit/middleware/store.ts
@@ -160,4 +160,11 @@ describe('store middleware', () => {
 		storeMiddleware = createStoreMiddleware(init);
 		assert.isTrue(init.calledOnce);
 	});
+
+	it('Should accept an initial store', () => {
+		const store = new Store<{ foo: string }>();
+		store.apply([replace(store.path('foo'), 'foo')]);
+		storeMiddleware = createStoreMiddleware(store);
+		assert.equal(store.get(store.path('foo')), 'foo');
+	});
 });

--- a/tests/core/unit/middleware/store.ts
+++ b/tests/core/unit/middleware/store.ts
@@ -4,7 +4,7 @@ import { sandbox } from 'sinon';
 
 import { createProcess } from '../../../../src/stores/process';
 import { replace } from '../../../../src/stores/state/operations';
-import Store from '../../../../src/stores/Store';
+import Store, { DefaultState } from '../../../../src/stores/Store';
 import createStoreMiddleware from '../../../../src/core/middleware/store';
 
 const sb = sandbox.create();
@@ -161,10 +161,10 @@ describe('store middleware', () => {
 		assert.isTrue(init.calledOnce);
 	});
 
-	it('Should accept an initial store', () => {
-		const store = new Store<{ foo: string }>();
-		store.apply([replace(store.path('foo'), 'foo')]);
-		storeMiddleware = createStoreMiddleware(store);
-		assert.equal(store.get(store.path('foo')), 'foo');
+	it('Should accept an initial state', () => {
+		const state = new DefaultState<{ foo: string }>();
+		state.apply([replace(state.path('foo'), 'foo')]);
+		storeMiddleware = createStoreMiddleware(state);
+		assert.equal(state.get(state.path('foo')), 'foo');
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This came up in the discussion around #744 although it doesn't directly resolve the issue there.
