### PR TITLE
Pass all params through to the function using `renderer.property()`

### DIFF
--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -584,7 +584,7 @@ export function renderer(renderFunc: () => WNode, options: RendererOptions = {})
 			childInstructions.set(wrapped.id, { wrapped, params, type: 'child' });
 			invalidated = true;
 		},
-		property(wrapped: any, key: any, params: any = []) {
+		property(wrapped: any, key: any, ...params: any[]) {
 			if (!expectedRenderResult) {
 				throw new Error('To use `.property` please perform an initial expect');
 			}

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -140,6 +140,40 @@ describe('test renderer', () => {
 			);
 		});
 
+		it('should pass all parameters to the triggered property', () => {
+			const factory = create({ icache });
+			const Button = create().properties<{ onClick: (first: string, second: string) => void }>()(
+				function Button() {
+					return '';
+				}
+			);
+			const Widget = factory(function Widget({ middleware: { icache } }) {
+				const value = icache.getOrSet('value', '');
+				return (
+					<div>
+						<Button
+							onClick={(first, second) => {
+								icache.set('value', `${first}-${second}`);
+							}}
+						/>
+						<span>{value}</span>
+					</div>
+				);
+			});
+			const WrappedButton = wrap(Button);
+			const WrappedSpan = wrap('span');
+			const baseTemplate = assertion(() => (
+				<div>
+					<WrappedButton onClick={() => {}} />
+					<WrappedSpan />
+				</div>
+			));
+			const r = renderer(() => w(Widget, {}));
+			r.expect(baseTemplate);
+			r.property(WrappedButton, 'onClick', 'one', 'two');
+			r.expect(baseTemplate.replaceChildren(WrappedSpan, () => ['one-two']));
+		});
+
 		it('trigger property of wrapped widget', () => {
 			const WrappedChild = wrap(ChildWidget);
 			const baseTemplate = assertion(() =>


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The params for functions called by `property()` in the test renderer should all be passed to down to the function.

Resolves #786 
