### PR TITLE
Fix the diffing for resource options

### DIFF
--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -47,7 +47,7 @@ export function shallow(previousProperty: any, newProperty: any, depth = 0): Pro
 	} else {
 		changed = newKeys.some((key) => {
 			if (depth > 0) {
-				return shallow(newProperty[key], previousProperty[key], depth - 1).changed;
+				return auto(newProperty[key], previousProperty[key], depth - 1).changed;
 			}
 			return newProperty[key] !== previousProperty[key];
 		});

--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -873,7 +873,7 @@ function createOptionsWrapper(): Options<any> {
 	function setOptions(newOptions?: Partial<ResourceOptions<any>>): ResourceOptions<any> {
 		if (newOptions) {
 			const calculatedOptions = { ...options, ...newOptions };
-			const changed = auto(options, calculatedOptions, 1);
+			const { changed } = auto(options, calculatedOptions, 2);
 			if (changed) {
 				options = calculatedOptions;
 				invalidate();

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -83,7 +83,7 @@ describe('Resources Middleware', () => {
 		const r = renderer(() => <App />);
 		r.mount({ domNode: root });
 		assert.strictEqual(root.innerHTML, `<div><div>${JSON.stringify([[{ hello: '1' }]])}</div><div>1</div></div>`);
-		set({ page: 1 });
+		set({ page: 1, query: {} });
 		resolvers.resolveRAF();
 		assert.strictEqual(root.innerHTML, `<div><div>${JSON.stringify([[{ hello: '1' }]])}</div><div>1</div></div>`);
 		set({ page: 2 });

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -50,16 +50,22 @@ describe('Resources Middleware', () => {
 
 	it('should update when options called', () => {
 		const root = document.createElement('div');
-		const factory = create({ resource: createResourceMiddleware<{ hello: string }>() });
+		const factory = create({ icache, resource: createResourceMiddleware<{ hello: string }>() });
 
 		let set: any;
-		const Widget = factory(({ id, properties, middleware: { resource } }) => {
+		const Widget = factory(({ id, properties, middleware: { resource, icache } }) => {
 			const { getOrRead, createOptions } = resource;
 			const {
 				resource: { template, options = createOptions(id) }
 			} = properties();
+			const counter = icache.set<number>('counter', (counter = 0) => ++counter);
 			set = options;
-			return <div>{JSON.stringify(getOrRead(template, options({ size: 1 })))}</div>;
+			return (
+				<div>
+					<div>{JSON.stringify(getOrRead(template, options({ size: 1 })))}</div>
+					<div>{`${counter}`}</div>
+				</div>
+			);
 		});
 
 		const template = createResourceTemplateWithInit<{ hello: string }, { data: { hello: string }[] }>(
@@ -76,10 +82,13 @@ describe('Resources Middleware', () => {
 
 		const r = renderer(() => <App />);
 		r.mount({ domNode: root });
-		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([[{ hello: '1' }]])}</div>`);
+		assert.strictEqual(root.innerHTML, `<div><div>${JSON.stringify([[{ hello: '1' }]])}</div><div>1</div></div>`);
+		set({ page: 1 });
+		resolvers.resolveRAF();
+		assert.strictEqual(root.innerHTML, `<div><div>${JSON.stringify([[{ hello: '1' }]])}</div><div>1</div></div>`);
 		set({ page: 2 });
 		resolvers.resolveRAF();
-		assert.strictEqual(root.innerHTML, `<div>${JSON.stringify([[{ hello: '2' }]])}</div>`);
+		assert.strictEqual(root.innerHTML, `<div><div>${JSON.stringify([[{ hello: '2' }]])}</div><div>2</div></div>`);
 	});
 
 	it('should be able to perform a read with a meta request', () => {


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fix the diff used for resource's options and use the correct property for `changed`. This includes changing `shallow`  to use `auto` internally to correctly diff if a non array/object is hit before the maximum depth has been reached (required for the options diff fix)

Resolves #785 
Resolves #788 
