### PR TITLE
create resource should not be exported

### DIFF
--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -486,7 +486,7 @@ function diffInitOptions(current: any, next: any) {
 	return [...keys].some((initKey) => auto(current[initKey], next[initKey], 1).changed);
 }
 
-export function createResource<S = never, T extends ResourceInitOptions = ResourceInitOptions>(
+function createResource<S = never, T extends ResourceInitOptions = ResourceInitOptions>(
 	template: ResourceTemplate<S> | ResourceTemplateWithInit<S>,
 	initOptions?: T
 ): Resource<S> {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Do not export `createResource`