### PR TITLE
Expand types for insert after/before

### DIFF
--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -138,20 +138,14 @@ export interface AssertionResult {
 	): AssertionResult;
 	insertBefore<T extends WidgetBaseInterface>(
 		target: Wrapped<Constructor<T>>,
-		children: TemplateChildren<T['children']>
+		children: TemplateChildren
 	): AssertionResult;
-	insertBefore<T extends WidgetFactory>(
-		target: Wrapped<T>,
-		children: TemplateChildren<T['children']>
-	): AssertionResult;
+	insertBefore<T extends WidgetFactory>(target: Wrapped<T>, children: TemplateChildren): AssertionResult;
 	insertAfter<T extends WidgetBaseInterface>(
 		target: Wrapped<Constructor<T>>,
-		children: TemplateChildren<T['children']>
+		children: TemplateChildren
 	): AssertionResult;
-	insertAfter<T extends WidgetFactory>(
-		target: Wrapped<T>,
-		children: TemplateChildren<T['children']>
-	): AssertionResult;
+	insertAfter<T extends WidgetFactory>(target: Wrapped<T>, children: TemplateChildren): AssertionResult;
 	insertSiblings<T extends WidgetBaseInterface>(
 		target: T,
 		children: TemplateChildren,

--- a/tests/testing/unit/assertRender.tsx
+++ b/tests/testing/unit/assertRender.tsx
@@ -46,8 +46,8 @@ class WidgetWithMap extends WidgetBase {
 }
 
 function getExpectedError() {
-	const mockWidgetName = (MockWidget as any).name || 'Widget-3';
-	const widgetWithChildrenName = (MockWidget as any).name ? 'WidgetWithNamedChildren' : 'Widget-4';
+	const mockWidgetName = (MockWidget as any).name || 'Widget-4';
+	const widgetWithChildrenName = (MockWidget as any).name ? 'WidgetWithNamedChildren' : 'Widget-5';
 	return `
 <div
 (A)	classes={["one","two","three"]}

--- a/tests/testing/unit/assertion.tsx
+++ b/tests/testing/unit/assertion.tsx
@@ -70,10 +70,11 @@ class ListWidget extends WidgetBase {
 
 const baseListAssertion = assertion(() => v('div', { classes: ['root'] }, [v(WrappedList.tag, [])]));
 
+const First = create().children<string>()(({ children }) => <div>{children()}</div>);
 class MultiRootWidget extends WidgetBase<{ after?: boolean; last?: boolean }> {
 	render() {
 		const { after, last = true } = this.properties;
-		const result = [v('div', ['first'])];
+		const result: DNode[] = [w(First, {}, ['first'])];
 		if (after) {
 			result.push(v('div', ['after']));
 		}
@@ -84,10 +85,13 @@ class MultiRootWidget extends WidgetBase<{ after?: boolean; last?: boolean }> {
 	}
 }
 
-const WrappedFirst = wrap('div');
+const WrappedFirst = wrap(First);
 const WrappedSecond = wrap('div');
 
-const baseMultiRootAssertion = assertion(() => [v(WrappedFirst.tag, ['first']), v(WrappedSecond.tag, ['last'])]);
+const baseMultiRootAssertion = assertion(() => [
+	<WrappedFirst>first</WrappedFirst>,
+	<WrappedSecond>last</WrappedSecond>
+]);
 
 const tsxAssertion = assertion(() => (
 	<div classes={['root']}>
@@ -256,7 +260,7 @@ describe('new/assertion', () => {
 	});
 
 	it('can insert after a node in the root', () => {
-		const insertionAssertion = baseMultiRootAssertion.insertAfter(WrappedFirst, () => [v('div', {}, ['after'])]);
+		const insertionAssertion = baseMultiRootAssertion.insertAfter(WrappedFirst, () => [<div>after</div>]);
 		const r = renderer(() => w(MultiRootWidget, { after: true }));
 		r.expect(insertionAssertion);
 	});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This expands the types for `insertBefore/insertAfter`. This would I believe be a backwards compatible fix but I think may be the appropriate fix in general.
 We currently allow inserting before/after at the root and when the parent is not wrapped, and requiring a parent would break both of those use cases. Making the parent argument optional could allow the user to opt into typing but seems klugey since the parent isn't actually needed.

Additionally the only concern with widening the type is that we'd allow the parent's child type to be violated, but even if we enforced it here the `replace` function accepts any DNode. It seems inconsistent if our API enforces the types of siblings but not the node itself. 
Resolves #801 
