### PR TITLE
Add further context to i18n documentationand mention cldr-data dep

### DIFF
--- a/docs/en/i18n/introduction.md
+++ b/docs/en/i18n/introduction.md
@@ -79,6 +79,8 @@ export default {
 ## Adding a widget language localization bundle
 
 -   Supporting two locales - English as the default, together with a French translation that is activated for any users that have `fr` set as their primary language.
+-         Unless a locale is specifically set for you application, the appropriate `supportedLocale` will be used according to the browsers locale settings where available.
+-   To run the app build with i18n you will need to install `cldr-data` as a dependency into your application or the build will fail.
 
 > .dojorc
 
@@ -113,6 +115,8 @@ export default {
 	content: 'Ceci est un widget internationalisé'
 };
 ```
+
+Note that the fs language bundle simply returns the message bundle, not an object containing a message bundle like the default locale file.
 
 ## Specifying a root locale within an application
 

--- a/docs/en/i18n/supplemental.md
+++ b/docs/en/i18n/supplemental.md
@@ -57,6 +57,17 @@ export default {
 };
 ```
 
+> .dojorc
+
+```ts
+{
+	"build-app": {
+		"locale": "en",
+		"supportedLocales": [ "fr", "ar", "ja" ]
+	}
+}
+```
+
 ## Importing and using bundles
 
 The default language module for a bundle is `import`ed like any other TypeScript module into each widget that requires use of the set of messages contained within the bundle.
@@ -400,6 +411,10 @@ export class MyWidget extends WidgetBase {
 			}),
 			w(WidgetB, {
 				i18nBundle: overrideMapForWidgetB
+			}),
+			// This example partially overrides the overrideKey value in the widgetB1 bundle
+			w(WidgetC, {
+				i18nBundle: { ...widgetB1, { overrideKey: 'abc' }}
 			})
 		];
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- clarifies shape of extra locale exports
- mentions dependency on cldr-date
- mentions that browser locale will be used if locale not explicitly set 


Resolves #811
