### PR TITLE
Add menu to button type type

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -797,7 +797,7 @@ export interface ButtonAttributes extends VNodeProperties<HTMLButtonElement> {
 	formNoValidate?: boolean;
 	formTarget?: string;
 	name?: string;
-	type?: 'submit' | 'reset' | 'button';
+	type?: 'submit' | 'reset' | 'button' | 'menu';
 }
 
 export interface CanvasAttributes extends VNodeProperties<HTMLCanvasElement> {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Allows "menu" for button type attribute
