### PR TITLE
Add function to create "typed" version of middleware

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -1280,7 +1280,7 @@ export interface DefaultMiddlewareResult extends MiddlewareResult<any, any, any,
 
 export interface MiddlewareResultFactory<Props, Children, Middleware, ReturnValue> {
 	(): MiddlewareResult<Props, Children, Middleware, ReturnValue>;
-	returns: <Api extends ReturnValue, CustomProps = Props>() => MiddlewareResultFactory<
+	withType: <Api extends ReturnValue, CustomProps = Props>() => MiddlewareResultFactory<
 		CustomProps,
 		Children,
 		Middleware,

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -1280,6 +1280,12 @@ export interface DefaultMiddlewareResult extends MiddlewareResult<any, any, any,
 
 export interface MiddlewareResultFactory<Props, Children, Middleware, ReturnValue> {
 	(): MiddlewareResult<Props, Children, Middleware, ReturnValue>;
+	returns: <Api extends ReturnValue, CustomProps = Props>() => MiddlewareResultFactory<
+		CustomProps,
+		Children,
+		Middleware,
+		Api
+	>;
 }
 
 export interface DefaultChildrenWNodeFactory<W extends WNodeFactoryTypes> {

--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -52,80 +52,79 @@ export interface ICacheResult<S = void> {
 	clear(invalidate?: boolean): void;
 }
 
-export function createICacheMiddleware<S = void>() {
-	const icache = factory(
-		({ middleware: { invalidator, destroy } }): ICacheResult<S> => {
-			const cacheMap = new Map<string, CacheWrapper>();
-			destroy(() => {
-				cacheMap.clear();
-			});
+const icacheFactory = factory(
+	({ middleware: { invalidator, destroy } }): ICacheResult<any> => {
+		const cacheMap = new Map<string, CacheWrapper>();
+		destroy(() => {
+			cacheMap.clear();
+		});
 
-			const api: any = {
-				get: (key: any): any => {
-					const cachedValue = cacheMap.get(key);
-					if (!cachedValue || cachedValue.status === 'pending') {
-						return undefined;
-					}
-					return cachedValue.value;
-				}
-			};
-
-			api.set = (key: any, value: any, invalidate: boolean = true): any => {
-				const current = api.get(key);
-				if (typeof value === 'function') {
-					value = value(current);
-					if (value && typeof value.then === 'function') {
-						cacheMap.set(key, {
-							status: 'pending',
-							value
-						});
-						value.then((result: any) => {
-							const cachedValue = cacheMap.get(key);
-							if (cachedValue && cachedValue.value === value) {
-								cacheMap.set(key, {
-									status: 'resolved',
-									value: result
-								});
-								invalidate && invalidator();
-							}
-						});
-						return undefined;
-					}
-				}
-				cacheMap.set(key, {
-					status: 'resolved',
-					value
-				});
-				invalidate && invalidator();
-				return value;
-			};
-			api.has = (key: any) => {
-				return cacheMap.has(key);
-			};
-			api.delete = (key: any, invalidate: boolean = true) => {
-				cacheMap.delete(key);
-				invalidate && invalidator();
-			};
-			api.clear = (invalidate: boolean = true): void => {
-				cacheMap.clear();
-				invalidate && invalidator();
-			};
-			api.getOrSet = (key: any, value: any, invalidate: boolean = true): any | undefined => {
-				let cachedValue = cacheMap.get(key);
-				if (!cachedValue) {
-					api.set(key, value, invalidate);
-				}
-				cachedValue = cacheMap.get(key);
+		const api: any = {
+			get: (key: any): any => {
+				const cachedValue = cacheMap.get(key);
 				if (!cachedValue || cachedValue.status === 'pending') {
 					return undefined;
 				}
 				return cachedValue.value;
-			};
-			return api;
-		}
-	);
-	return icache;
-}
+			}
+		};
+
+		api.set = (key: any, value: any, invalidate: boolean = true): any => {
+			const current = api.get(key);
+			if (typeof value === 'function') {
+				value = value(current);
+				if (value && typeof value.then === 'function') {
+					cacheMap.set(key, {
+						status: 'pending',
+						value
+					});
+					value.then((result: any) => {
+						const cachedValue = cacheMap.get(key);
+						if (cachedValue && cachedValue.value === value) {
+							cacheMap.set(key, {
+								status: 'resolved',
+								value: result
+							});
+							invalidate && invalidator();
+						}
+					});
+					return undefined;
+				}
+			}
+			cacheMap.set(key, {
+				status: 'resolved',
+				value
+			});
+			invalidate && invalidator();
+			return value;
+		};
+		api.has = (key: any) => {
+			return cacheMap.has(key);
+		};
+		api.delete = (key: any, invalidate: boolean = true) => {
+			cacheMap.delete(key);
+			invalidate && invalidator();
+		};
+		api.clear = (invalidate: boolean = true): void => {
+			cacheMap.clear();
+			invalidate && invalidator();
+		};
+		api.getOrSet = (key: any, value: any, invalidate: boolean = true): any | undefined => {
+			let cachedValue = cacheMap.get(key);
+			if (!cachedValue) {
+				api.set(key, value, invalidate);
+			}
+			cachedValue = cacheMap.get(key);
+			if (!cachedValue || cachedValue.status === 'pending') {
+				return undefined;
+			}
+			return cachedValue.value;
+		};
+		return api;
+	}
+);
+
+export const createICacheMiddleware = <S = void>() => icacheFactory.returns<ICacheResult<S>>();
 
 export const icache = createICacheMiddleware();
 

--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -124,7 +124,7 @@ const icacheFactory = factory(
 	}
 );
 
-export const createICacheMiddleware = <S = void>() => icacheFactory.returns<ICacheResult<S>>();
+export const createICacheMiddleware = <S = void>() => icacheFactory.withType<ICacheResult<S>>();
 
 export const icache = createICacheMiddleware();
 

--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -941,170 +941,174 @@ function getResource(
 	return resource;
 }
 
-export function createResourceMiddleware<MIDDLEWARE = void>() {
-	const factory = create({ diffProperty, invalidator, destroy }).properties<
-		MIDDLEWARE extends void ? {} : ResourceMiddlewareProperties<MIDDLEWARE>
-	>();
-	return factory(
-		({ id: middlewareId, middleware: { diffProperty, invalidator, destroy } }): ResourceMiddleware<MIDDLEWARE> => {
-			const optionsMap = new Map<string, Options<MIDDLEWARE>>();
-			destroy(() => {
-				const resources = idToResourceMap.get(middlewareId);
-				if (resources) {
-					resources.forEach((resource) => {
-						if (resource.type === 'subscribed') {
-							resource.resource.unsubscribe(invalidator);
-						} else {
-							resource.resource.destroy(middlewareId);
-						}
-					});
-				}
-				idToResourceMap.delete(middlewareId);
-			});
-			diffProperty(
-				'resource',
-				(): ResourceMiddlewareProperties<MIDDLEWARE> => {
-					return {} as any;
-				},
-				({ resource: current }, { resource: next }) => {
-					if (current && next) {
-						const id = next.template.id || 'global';
-						const {
-							template: { initOptions: currentInitOptions }
-						} = current;
-						const {
-							template: { initOptions: nextInitOptions }
-						} = next;
-						if (nextInitOptions) {
-							const changed = diffInitOptions(currentInitOptions || {}, nextInitOptions);
-							if (changed) {
-								const resourceMap = templateToResourceMap.get(next.template.template);
-								if (resourceMap) {
-									const resource = resourceMap.get(id);
-									if (resource) {
-										resource.init(nextInitOptions);
-										invalidator();
-									}
+const factory = create({ diffProperty, invalidator, destroy });
+
+const resourceMiddlewareFactory = factory(
+	({ id: middlewareId, middleware: { diffProperty, invalidator, destroy } }): ResourceMiddleware => {
+		const optionsMap = new Map<string, Options<any>>();
+		destroy(() => {
+			const resources = idToResourceMap.get(middlewareId);
+			if (resources) {
+				resources.forEach((resource) => {
+					if (resource.type === 'subscribed') {
+						resource.resource.unsubscribe(invalidator);
+					} else {
+						resource.resource.destroy(middlewareId);
+					}
+				});
+			}
+			idToResourceMap.delete(middlewareId);
+		});
+		diffProperty(
+			'resource',
+			(): ResourceMiddlewareProperties<any> => {
+				return {} as any;
+			},
+			({ resource: current }, { resource: next }) => {
+				if (current && next) {
+					const id = next.template.id || 'global';
+					const {
+						template: { initOptions: currentInitOptions }
+					} = current;
+					const {
+						template: { initOptions: nextInitOptions }
+					} = next;
+					if (nextInitOptions) {
+						const changed = diffInitOptions(currentInitOptions || {}, nextInitOptions);
+						if (changed) {
+							const resourceMap = templateToResourceMap.get(next.template.template);
+							if (resourceMap) {
+								const resource = resourceMap.get(id);
+								if (resource) {
+									resource.init(nextInitOptions);
+									invalidator();
 								}
 							}
 						}
-						const nextOptions = next.options;
-						const currOptions = current.options;
-						if (currOptions && currOptions !== nextOptions) {
-							const invalidatorSet = optionInvalidatorMap.get(currOptions.options);
-							if (invalidatorSet) {
-								invalidatorSet.delete(invalidator);
-								invalidator();
-							}
-						}
 					}
-					if (next) {
-						const nextOptions = next.options;
-						const currOptions = current && current.options;
-						if (nextOptions) {
-							const options: any = (options?: Partial<ResourceOptions<any>>) => {
-								const invalidatorSet = optionInvalidatorMap.get(nextOptions.options) || new Set();
-								invalidatorSet.add(invalidator);
-								optionInvalidatorMap.set(nextOptions.options, invalidatorSet);
-								return nextOptions.options(options);
-							};
-							options.options = nextOptions.options;
-							if (!currOptions || currOptions.options !== nextOptions.options) {
-								invalidator();
-							}
-							return {
-								options,
-								template: next.template
-							} as any;
+					const nextOptions = next.options;
+					const currOptions = current.options;
+					if (currOptions && currOptions !== nextOptions) {
+						const invalidatorSet = optionInvalidatorMap.get(currOptions.options);
+						if (invalidatorSet) {
+							invalidatorSet.delete(invalidator);
+							invalidator();
 						}
 					}
 				}
-			);
-
-			const middleware = function(resource: any) {
-				if (isTemplate(resource.template)) {
-					let { template, transform, initOptions, ...rest } = resource;
-					return {
-						template: {
-							template,
-							transform,
-							id: initOptions ? `${middlewareId}/${initOptions.id}` : 'global',
-							initOptions
-						},
-						...rest
-					};
-				}
-				return resource;
-			};
-			middleware.createOptions = (key: string): Options<any> => {
-				const options = optionsMap.get(key);
-				if (options) {
-					return options;
-				}
-				const optionsWrapper = createOptionsWrapper();
-				function setOptions(options?: Partial<ResourceOptions<any>>) {
-					const invalidatorSet = optionInvalidatorMap.get(optionsWrapper.options) || new Set();
-					invalidatorSet.add(invalidator);
-					optionInvalidatorMap.set(optionsWrapper.options, invalidatorSet);
-					return optionsWrapper(options);
-				}
-				setOptions.options = optionsWrapper.options;
-				optionsMap.set(key, setOptions);
-				return setOptions;
-			};
-			middleware.getOrRead = (template: any, options: any, init?: any) => {
-				const resource = getResource(template, middlewareId, init);
-				const transform = !isTemplate(template) && template.transform;
-				const resourceOptions = transformOptions(options, transform);
-				resource.subscribeRead(invalidator, options);
-				const data = resource.getOrRead(resourceOptions);
-				if (data && transform) {
-					return data.map((items: any) => {
-						if (items) {
-							return items.map((item: any) => transformData(item, transform));
+				if (next) {
+					const nextOptions = next.options;
+					const currOptions = current && current.options;
+					if (nextOptions) {
+						const options: any = (options?: Partial<ResourceOptions<any>>) => {
+							const invalidatorSet = optionInvalidatorMap.get(nextOptions.options) || new Set();
+							invalidatorSet.add(invalidator);
+							optionInvalidatorMap.set(nextOptions.options, invalidatorSet);
+							return nextOptions.options(options);
+						};
+						options.options = nextOptions.options;
+						if (!currOptions || currOptions.options !== nextOptions.options) {
+							invalidator();
 						}
-						return items;
-					});
+						return {
+							options,
+							template: next.template
+						} as any;
+					}
 				}
-				return data;
-			};
-			middleware.find = (template: any, options: any, init?: any) => {
-				const resource = getResource(template, middlewareId, init);
-				const transform = !isTemplate(template) && template.transform;
-				const findOptions = transformOptions(options, transform);
-				resource.subscribeFind(invalidator, findOptions);
-				const result = resource.find(findOptions);
-				if (result && result.item && transform) {
-					result.item = transformData(result.item, transform);
-				}
-				return result;
-			};
+			}
+		);
 
-			middleware.meta = (template: any, options: any, request = false, init?: any) => {
-				const resource = getResource(template, middlewareId, init);
-				const transform = !isTemplate(template) && template.transform;
-				const resourceOptions = transformOptions(options, transform);
-				resource.subscribeMeta(invalidator, resourceOptions);
-				if (request) {
-					resource.subscribeRead(invalidator, resourceOptions);
-				}
-				return resource.meta(resourceOptions, request);
-			};
-			middleware.isLoading = (template: any, options: any, init?: any) => {
-				const resource = getResource(template, middlewareId, init);
-				const transform = !isTemplate(template) && template.transform;
-				const resourceOptions = transformOptions(options, transform);
-				resource.subscribeLoading(invalidator, resourceOptions);
-				return resource.isLoading(resourceOptions);
-			};
-			middleware.isFailed = (template: any, options: any, init?: any) => {
-				const resource = getResource(template, middlewareId, init);
-				const transform = !isTemplate(template) && template.transform;
-				const resourceOptions = transformOptions(options, transform);
-				resource.subscribeFailed(invalidator, resourceOptions);
-				return resource.isFailed(resourceOptions);
-			};
-			return middleware;
-		}
-	);
+		const middleware = function(resource: any) {
+			if (isTemplate(resource.template)) {
+				let { template, transform, initOptions, ...rest } = resource;
+				return {
+					template: {
+						template,
+						transform,
+						id: initOptions ? `${middlewareId}/${initOptions.id}` : 'global',
+						initOptions
+					},
+					...rest
+				};
+			}
+			return resource;
+		};
+		middleware.createOptions = (key: string): Options<any> => {
+			const options = optionsMap.get(key);
+			if (options) {
+				return options;
+			}
+			const optionsWrapper = createOptionsWrapper();
+			function setOptions(options?: Partial<ResourceOptions<any>>) {
+				const invalidatorSet = optionInvalidatorMap.get(optionsWrapper.options) || new Set();
+				invalidatorSet.add(invalidator);
+				optionInvalidatorMap.set(optionsWrapper.options, invalidatorSet);
+				return optionsWrapper(options);
+			}
+			setOptions.options = optionsWrapper.options;
+			optionsMap.set(key, setOptions);
+			return setOptions;
+		};
+		middleware.getOrRead = (template: any, options: any, init?: any) => {
+			const resource = getResource(template, middlewareId, init);
+			const transform = !isTemplate(template) && template.transform;
+			const resourceOptions = transformOptions(options, transform);
+			resource.subscribeRead(invalidator, options);
+			const data = resource.getOrRead(resourceOptions);
+			if (data && transform) {
+				return data.map((items: any) => {
+					if (items) {
+						return items.map((item: any) => transformData(item, transform));
+					}
+					return items;
+				});
+			}
+			return data;
+		};
+		middleware.find = (template: any, options: any, init?: any) => {
+			const resource = getResource(template, middlewareId, init);
+			const transform = !isTemplate(template) && template.transform;
+			const findOptions = transformOptions(options, transform);
+			resource.subscribeFind(invalidator, findOptions);
+			const result = resource.find(findOptions);
+			if (result && result.item && transform) {
+				result.item = transformData(result.item, transform);
+			}
+			return result;
+		};
+
+		middleware.meta = (template: any, options: any, request = false, init?: any) => {
+			const resource = getResource(template, middlewareId, init);
+			const transform = !isTemplate(template) && template.transform;
+			const resourceOptions = transformOptions(options, transform);
+			resource.subscribeMeta(invalidator, resourceOptions);
+			if (request) {
+				resource.subscribeRead(invalidator, resourceOptions);
+			}
+			return resource.meta(resourceOptions, request);
+		};
+		middleware.isLoading = (template: any, options: any, init?: any) => {
+			const resource = getResource(template, middlewareId, init);
+			const transform = !isTemplate(template) && template.transform;
+			const resourceOptions = transformOptions(options, transform);
+			resource.subscribeLoading(invalidator, resourceOptions);
+			return resource.isLoading(resourceOptions);
+		};
+		middleware.isFailed = (template: any, options: any, init?: any) => {
+			const resource = getResource(template, middlewareId, init);
+			const transform = !isTemplate(template) && template.transform;
+			const resourceOptions = transformOptions(options, transform);
+			resource.subscribeFailed(invalidator, resourceOptions);
+			return resource.isFailed(resourceOptions);
+		};
+		return middleware;
+	}
+);
+
+export function createResourceMiddleware<MIDDLEWARE = void>() {
+	return resourceMiddlewareFactory.returns<
+		ResourceMiddleware<MIDDLEWARE>,
+		MIDDLEWARE extends void ? {} : ResourceMiddlewareProperties<MIDDLEWARE>
+	>();
 }

--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -1107,7 +1107,7 @@ const resourceMiddlewareFactory = factory(
 );
 
 export function createResourceMiddleware<MIDDLEWARE = void>() {
-	return resourceMiddlewareFactory.returns<
+	return resourceMiddlewareFactory.withType<
 		ResourceMiddleware<MIDDLEWARE>,
 		MIDDLEWARE extends void ? {} : ResourceMiddlewareProperties<MIDDLEWARE>
 	>();

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -803,6 +803,9 @@ function createFactory(callback: any, middlewares: any, key?: any): any {
 		return keys;
 	}, key ? [key] : []);
 
+	factory.returns = () => {
+		return factory;
+	};
 	callback.keys = keys;
 	factory.keys = keys;
 	factory.isFactory = true;

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -803,7 +803,7 @@ function createFactory(callback: any, middlewares: any, key?: any): any {
 		return keys;
 	}, key ? [key] : []);
 
-	factory.returns = () => {
+	factory.withType = () => {
 		return factory;
 	};
 	callback.keys = keys;

--- a/src/testing/harness/harness.ts
+++ b/src/testing/harness/harness.ts
@@ -56,7 +56,10 @@ export interface HarnessAPI {
 
 interface HarnessOptions {
 	customComparator?: CustomComparator[];
-	middleware?: [MiddlewareResultFactory<any, any, any, any>, MiddlewareResultFactory<any, any, any, any>][];
+	middleware?: [
+		MiddlewareResultFactory<any, any, any, any>,
+		Exclude<keyof MiddlewareResultFactory<any, any, any, any>, 'withType'>
+	][];
 }
 
 const factory = create();

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -86,7 +86,7 @@ interface RendererOptions {
 		MiddlewareResultFactory<any, any, any, any>,
 		Pick<
 			MiddlewareResultFactory<any, any, any, any>,
-			Exclude<keyof MiddlewareResultFactory<any, any, any, any>, 'returns'>
+			Exclude<keyof MiddlewareResultFactory<any, any, any, any>, 'withType'>
 		>
 	][];
 }

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -82,7 +82,13 @@ export interface Property {
 }
 
 interface RendererOptions {
-	middleware?: [MiddlewareResultFactory<any, any, any, any>, MiddlewareResultFactory<any, any, any, any>][];
+	middleware?: [
+		MiddlewareResultFactory<any, any, any, any>,
+		Pick<
+			MiddlewareResultFactory<any, any, any, any>,
+			Exclude<keyof MiddlewareResultFactory<any, any, any, any>, 'returns'>
+		>
+	][];
 }
 
 export type PropertiesComparatorFunction<T = any> = (actualProperties: T) => T;

--- a/tests/testing/unit/mocks/middleware/icache.tsx
+++ b/tests/testing/unit/mocks/middleware/icache.tsx
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 import { tsx, create } from '../../../../../src/core/vdom';
 import renderer, { assertion } from '../../../../../src/testing/renderer';
 import createICacheMock from '../../../../../src/testing/mocks/middleware/icache';
-import icache from '../../../../../src/core/middleware/icache';
+import icache, { createICacheMiddleware } from '../../../../../src/core/middleware/icache';
 import global from '../../../../../src/shim/global';
 
 describe('icache mock', () => {
@@ -23,6 +23,27 @@ describe('icache mock', () => {
 		global.fetch = sinon.stub().returns(Promise.resolve({ json: () => Promise.resolve('api data') }));
 
 		const r = renderer(() => <App />, { middleware: [[icache, iCacheMock]] });
+		r.expect(assertion(() => <div>Loading</div>));
+		await iCacheMock('users');
+		r.expect(assertion(() => <div>api data</div>));
+	});
+
+	it('should provide access to async typed-icache loads', async () => {
+		const iCacheMock = createICacheMock();
+		const icache = createICacheMiddleware<{ users: any }>();
+		const factory = create({ icache });
+		const App = factory(({ middleware: { icache } }) => {
+			const value = icache.getOrSet('users', async () => {
+				const response = await fetch('https://reqres.in/api/users');
+				return await response.json();
+			});
+
+			return value ? <div>{value}</div> : <div>Loading</div>;
+		});
+
+		global.fetch = sinon.stub().returns(Promise.resolve({ json: () => Promise.resolve('api data') }));
+
+		const r = renderer(() => <App />, { middleware: [[createICacheMiddleware(), iCacheMock]] });
 		r.expect(assertion(() => <div>Loading</div>));
 		await iCacheMock('users');
 		r.expect(assertion(() => <div>api data</div>));


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

When factories are used to create middleware to print typings we don't need to actually create the middleware-factory every time, only stamp the type on the returned middleware-factory type.

Resolves #817 
