### PR TITLE
Fix mock middleware types

### DIFF
--- a/src/testing/harness/harness.ts
+++ b/src/testing/harness/harness.ts
@@ -7,7 +7,8 @@ import {
 	VNode,
 	Callback,
 	RenderResult,
-	MiddlewareResultFactory
+	MiddlewareResultFactory,
+	MiddlewareResult
 } from '../../core/interfaces';
 import { WidgetBase } from '../../core/WidgetBase';
 import { isWidgetFunction } from '../../core/Registry';
@@ -56,10 +57,7 @@ export interface HarnessAPI {
 
 interface HarnessOptions {
 	customComparator?: CustomComparator[];
-	middleware?: [
-		MiddlewareResultFactory<any, any, any, any>,
-		Exclude<keyof MiddlewareResultFactory<any, any, any, any>, 'withType'>
-	][];
+	middleware?: [MiddlewareResultFactory<any, any, any, any>, () => MiddlewareResult<any, any, any, any>][];
 }
 
 const factory = create();
@@ -79,7 +77,7 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 	let customComparator: CustomComparator[] = [];
 	let mockMiddleware: [
 		MiddlewareResultFactory<any, any, any, any>,
-		MiddlewareResultFactory<any, any, any, any>
+		() => MiddlewareResult<any, any, any, any>
 	][] = [];
 	if (Array.isArray(options)) {
 		customComparator = options;

--- a/src/testing/harness/harness.ts
+++ b/src/testing/harness/harness.ts
@@ -8,7 +8,7 @@ import {
 	Callback,
 	RenderResult,
 	MiddlewareResultFactory,
-	MiddlewareResult
+	DefaultMiddlewareResult
 } from '../../core/interfaces';
 import { WidgetBase } from '../../core/WidgetBase';
 import { isWidgetFunction } from '../../core/Registry';
@@ -57,7 +57,7 @@ export interface HarnessAPI {
 
 interface HarnessOptions {
 	customComparator?: CustomComparator[];
-	middleware?: [MiddlewareResultFactory<any, any, any, any>, () => MiddlewareResult<any, any, any, any>][];
+	middleware?: [MiddlewareResultFactory<any, any, any, any>, () => DefaultMiddlewareResult][];
 }
 
 const factory = create();
@@ -75,10 +75,7 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 	let customDiffs: [string, Function][] = [];
 	let customDiffNames: string[] = [];
 	let customComparator: CustomComparator[] = [];
-	let mockMiddleware: [
-		MiddlewareResultFactory<any, any, any, any>,
-		() => MiddlewareResult<any, any, any, any>
-	][] = [];
+	let mockMiddleware: [MiddlewareResultFactory<any, any, any, any>, () => DefaultMiddlewareResult][] = [];
 	if (Array.isArray(options)) {
 		customComparator = options;
 	} else {

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -11,7 +11,8 @@ import {
 	OptionalWNodeFactory,
 	WidgetBaseInterface,
 	DefaultChildrenWNodeFactory,
-	VNode
+	VNode,
+	MiddlewareResult
 } from '../core/interfaces';
 import { WidgetBase } from '../core/WidgetBase';
 import { isWidgetFunction } from '../core/Registry';
@@ -82,13 +83,7 @@ export interface Property {
 }
 
 interface RendererOptions {
-	middleware?: [
-		MiddlewareResultFactory<any, any, any, any>,
-		Pick<
-			MiddlewareResultFactory<any, any, any, any>,
-			Exclude<keyof MiddlewareResultFactory<any, any, any, any>, 'withType'>
-		>
-	][];
+	middleware?: [MiddlewareResultFactory<any, any, any, any>, () => MiddlewareResult<any, any, any, any>][];
 }
 
 export type PropertiesComparatorFunction<T = any> = (actualProperties: T) => T;

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -12,7 +12,7 @@ import {
 	WidgetBaseInterface,
 	DefaultChildrenWNodeFactory,
 	VNode,
-	MiddlewareResult
+	DefaultMiddlewareResult
 } from '../core/interfaces';
 import { WidgetBase } from '../core/WidgetBase';
 import { isWidgetFunction } from '../core/Registry';
@@ -83,7 +83,7 @@ export interface Property {
 }
 
 interface RendererOptions {
-	middleware?: [MiddlewareResultFactory<any, any, any, any>, () => MiddlewareResult<any, any, any, any>][];
+	middleware?: [MiddlewareResultFactory<any, any, any, any>, () => DefaultMiddlewareResult][];
 }
 
 export type PropertiesComparatorFunction<T = any> = (actualProperties: T) => T;

--- a/tests/testing/unit/harness/harness.tsx
+++ b/tests/testing/unit/harness/harness.tsx
@@ -1,5 +1,3 @@
-import createICacheMock from '../../../../src/testing/mocks/middleware/icache';
-
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
@@ -605,42 +603,6 @@ describe('harness', () => {
 				);
 			});
 			const h = harness(() => <App />);
-			h.expect(() => (
-				<div>
-					<button key="click-me" onclick={() => {}}>
-						Click Me 0
-					</button>
-				</div>
-			));
-			h.trigger('@click-me', 'onclick');
-			h.expect(() => (
-				<div>
-					<button key="click-me" onclick={() => {}}>
-						Click Me 1
-					</button>
-				</div>
-			));
-		});
-
-		it('should mock icache middleware', () => {
-			const factory = create({ icache });
-
-			const App = factory(({ middleware: { icache } }) => {
-				const counter = icache.get<number>('counter') || 0;
-				return (
-					<div>
-						<button
-							key="click-me"
-							onclick={() => {
-								const counter = icache.get<number>('counter') || 0;
-								icache.set('counter', counter + 1);
-							}}
-						>{`Click Me ${counter}`}</button>
-					</div>
-				);
-			});
-			const mockIcache = createICacheMock();
-			const h = harness(() => <App />, { middleware: [[icache, mockIcache]] });
 			h.expect(() => (
 				<div>
 					<button key="click-me" onclick={() => {}}>

--- a/tests/testing/unit/harness/harness.tsx
+++ b/tests/testing/unit/harness/harness.tsx
@@ -1,3 +1,5 @@
+import createICacheMock from '../../../../src/testing/mocks/middleware/icache';
+
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
@@ -603,6 +605,42 @@ describe('harness', () => {
 				);
 			});
 			const h = harness(() => <App />);
+			h.expect(() => (
+				<div>
+					<button key="click-me" onclick={() => {}}>
+						Click Me 0
+					</button>
+				</div>
+			));
+			h.trigger('@click-me', 'onclick');
+			h.expect(() => (
+				<div>
+					<button key="click-me" onclick={() => {}}>
+						Click Me 1
+					</button>
+				</div>
+			));
+		});
+
+		it('should mock icache middleware', () => {
+			const factory = create({ icache });
+
+			const App = factory(({ middleware: { icache } }) => {
+				const counter = icache.get<number>('counter') || 0;
+				return (
+					<div>
+						<button
+							key="click-me"
+							onclick={() => {
+								const counter = icache.get<number>('counter') || 0;
+								icache.set('counter', counter + 1);
+							}}
+						>{`Click Me ${counter}`}</button>
+					</div>
+				);
+			});
+			const mockIcache = createICacheMock();
+			const h = harness(() => <App />, { middleware: [[icache, mockIcache]] });
 			h.expect(() => (
 				<div>
 					<button key="click-me" onclick={() => {}}>

--- a/tests/testing/unit/mocks/middleware/icache.tsx
+++ b/tests/testing/unit/mocks/middleware/icache.tsx
@@ -3,6 +3,7 @@ const { describe } = intern.getPlugin('jsdom');
 import * as sinon from 'sinon';
 import { tsx, create } from '../../../../../src/core/vdom';
 import renderer, { assertion } from '../../../../../src/testing/renderer';
+import harness from '../../../../../src/testing/harness/harness';
 import createICacheMock from '../../../../../src/testing/mocks/middleware/icache';
 import icache, { createICacheMiddleware } from '../../../../../src/core/middleware/icache';
 import global from '../../../../../src/shim/global';
@@ -26,6 +27,26 @@ describe('icache mock', () => {
 		r.expect(assertion(() => <div>Loading</div>));
 		await iCacheMock('users');
 		r.expect(assertion(() => <div>api data</div>));
+	});
+
+	it('should provide access to async icache loads with harness', async () => {
+		const iCacheMock = createICacheMock();
+		const factory = create({ icache });
+		const App = factory(({ middleware: { icache } }) => {
+			const value = icache.getOrSet('users', async () => {
+				const response = await fetch('https://reqres.in/api/users');
+				return await response.json();
+			});
+
+			return value ? <div>{value}</div> : <div>Loading</div>;
+		});
+
+		global.fetch = sinon.stub().returns(Promise.resolve({ json: () => Promise.resolve('api data') }));
+
+		const h = harness(() => <App />, { middleware: [[icache, iCacheMock]] });
+		h.expect(assertion(() => <div>Loading</div>));
+		await iCacheMock('users');
+		h.expect(assertion(() => <div>api data</div>));
 	});
 
 	it('should provide access to async typed-icache loads', async () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
`Exclude<keyof X, 'Y'>` returns a unioned string type not the object type. Normally using `Omit` or `Pick` would fix that but In the case of the MiddlewareResultFactory the type is `never` becuase the call signature isn't a key.

This changes the mocked middleware type to the call signature itself.
