### PR TITLE
V7 Backports

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -34,18 +34,16 @@ import { auto } from './diff';
 import RegistryHandler from './RegistryHandler';
 import { NodeHandler } from './NodeHandler';
 
-declare global {
-	namespace JSX {
-		type Element = WNode;
-		interface ElementAttributesProperty {
-			__properties__: {};
-		}
-		interface IntrinsicElements {
-			[key: string]: VNodeProperties;
-		}
-		interface ElementChildrenAttribute {
-			__children__: {};
-		}
+export namespace tsx.JSX {
+	export type Element = WNode;
+	export interface ElementAttributesProperty {
+		__properties__: {};
+	}
+	export interface IntrinsicElements {
+		[key: string]: VNodeProperties;
+	}
+	export interface ElementChildrenAttribute {
+		__children__: {};
 	}
 }
 

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1393,6 +1393,10 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		while (!insertBefore) {
 			const nextSibling = _wrapperSiblingMap.get(searchNode);
 			if (nextSibling) {
+				if (isBodyWrapper(nextSibling) || isHeadWrapper(nextSibling)) {
+					searchNode = nextSibling;
+					continue;
+				}
 				let domNode = nextSibling.domNode;
 				if (isWNodeWrapper(nextSibling) || isVirtualWrapper(nextSibling)) {
 					if (!nextSibling.childDomWrapperId) {

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -138,20 +138,14 @@ export interface AssertionResult {
 	): AssertionResult;
 	insertBefore<T extends WidgetBaseInterface>(
 		target: Wrapped<Constructor<T>>,
-		children: TemplateChildren<T['children']>
+		children: TemplateChildren
 	): AssertionResult;
-	insertBefore<T extends WidgetFactory>(
-		target: Wrapped<T>,
-		children: TemplateChildren<T['children']>
-	): AssertionResult;
+	insertBefore<T extends WidgetFactory>(target: Wrapped<T>, children: TemplateChildren): AssertionResult;
 	insertAfter<T extends WidgetBaseInterface>(
 		target: Wrapped<Constructor<T>>,
-		children: TemplateChildren<T['children']>
+		children: TemplateChildren
 	): AssertionResult;
-	insertAfter<T extends WidgetFactory>(
-		target: Wrapped<T>,
-		children: TemplateChildren<T['children']>
-	): AssertionResult;
+	insertAfter<T extends WidgetFactory>(target: Wrapped<T>, children: TemplateChildren): AssertionResult;
 	insertSiblings<T extends WidgetBaseInterface>(
 		target: T,
 		children: TemplateChildren,

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -4848,6 +4848,74 @@ jsdomDescribe('vdom', () => {
 			results = document.querySelectorAll('.body-span');
 			assert.lengthOf(results, 0);
 		});
+
+		it('should support attaching body nodes in nested widgets', () => {
+			const factory = create({ icache }).properties<any>();
+
+			const Foo = factory(function Foo() {
+				return (
+					<div id="wrapper-2">
+						<body>
+							<div id="body-2" />
+						</body>
+					</div>
+				);
+			});
+
+			const Bar = factory(function Bar({ properties }) {
+				return (
+					<div id="wrapper-1">
+						<Foo close={() => properties().close()} />
+						<body>
+							<div id="body-1" />
+						</body>
+					</div>
+				);
+			});
+
+			const App = factory(function App({ middleware: { icache } }) {
+				const show = icache.getOrSet('show', false);
+				return (
+					<div>
+						<button
+							onclick={() => {
+								icache.set('show', (current) => !current);
+							}}
+						>
+							Open/Close
+						</button>
+						{show && (
+							<Bar
+								close={() => {
+									icache.set('show', false);
+								}}
+							/>
+						)}
+						<h2>Start editing to see some magic happen</h2>
+					</div>
+				);
+			});
+
+			const r = renderer(() => w(App, {}));
+			r.mount({ domNode: root });
+			(root.children[0].children[0] as any).click();
+			resolvers.resolve();
+			assert.strictEqual(
+				root.innerHTML,
+				'<div><button>Open/Close</button><div id="wrapper-1"><div id="wrapper-2"></div></div><h2>Start editing to see some magic happen</h2></div>'
+			);
+			assert.lengthOf(document.querySelectorAll('#body-1'), 1);
+			assert.lengthOf(document.querySelectorAll('#body-2'), 1);
+			(root.children[0].children[0] as any).click();
+			resolvers.resolve();
+			resolvers.resolve();
+			assert.strictEqual(
+				root.innerHTML,
+				'<div><button>Open/Close</button><h2>Start editing to see some magic happen</h2></div>'
+			);
+			assert.lengthOf(document.querySelectorAll('#body-1'), 0);
+			assert.lengthOf(document.querySelectorAll('#body-2'), 0);
+		});
 	});
 
 	describe('head node', () => {
@@ -5099,6 +5167,74 @@ jsdomDescribe('vdom', () => {
 			resolvers.resolveRAF();
 			results = document.querySelectorAll('.head-span');
 			assert.lengthOf(results, 0);
+		});
+
+		it('should support attaching head nodes in nested widgets', () => {
+			const factory = create({ icache }).properties<any>();
+
+			const Foo = factory(function Foo() {
+				return (
+					<div id="wrapper-2">
+						<head>
+							<div id="head-2" />
+						</head>
+					</div>
+				);
+			});
+
+			const Bar = factory(function Bar({ properties }) {
+				return (
+					<div id="wrapper-1">
+						<Foo close={() => properties().close()} />
+						<head>
+							<div id="head-1" />
+						</head>
+					</div>
+				);
+			});
+
+			const App = factory(function App({ middleware: { icache } }) {
+				const show = icache.getOrSet('show', false);
+				return (
+					<div>
+						<button
+							onclick={() => {
+								icache.set('show', (current) => !current);
+							}}
+						>
+							Open/Close
+						</button>
+						{show && (
+							<Bar
+								close={() => {
+									icache.set('show', false);
+								}}
+							/>
+						)}
+						<h2>Start editing to see some magic happen</h2>
+					</div>
+				);
+			});
+
+			const r = renderer(() => w(App, {}));
+			r.mount({ domNode: root });
+			(root.children[0].children[0] as any).click();
+			resolvers.resolve();
+			assert.strictEqual(
+				root.innerHTML,
+				'<div><button>Open/Close</button><div id="wrapper-1"><div id="wrapper-2"></div></div><h2>Start editing to see some magic happen</h2></div>'
+			);
+			assert.lengthOf(document.querySelectorAll('#head-1'), 1);
+			assert.lengthOf(document.querySelectorAll('#head-2'), 1);
+			(root.children[0].children[0] as any).click();
+			resolvers.resolve();
+			resolvers.resolve();
+			assert.strictEqual(
+				root.innerHTML,
+				'<div><button>Open/Close</button><h2>Start editing to see some magic happen</h2></div>'
+			);
+			assert.lengthOf(document.querySelectorAll('#head-1'), 0);
+			assert.lengthOf(document.querySelectorAll('#head-2'), 0);
 		});
 	});
 

--- a/tests/testing/unit/assertRender.tsx
+++ b/tests/testing/unit/assertRender.tsx
@@ -46,8 +46,8 @@ class WidgetWithMap extends WidgetBase {
 }
 
 function getExpectedError() {
-	const mockWidgetName = (MockWidget as any).name || 'Widget-3';
-	const widgetWithChildrenName = (MockWidget as any).name ? 'WidgetWithNamedChildren' : 'Widget-4';
+	const mockWidgetName = (MockWidget as any).name || 'Widget-4';
+	const widgetWithChildrenName = (MockWidget as any).name ? 'WidgetWithNamedChildren' : 'Widget-5';
 	return `
 <div
 (A)	classes={["one","two","three"]}

--- a/tests/testing/unit/assertion.tsx
+++ b/tests/testing/unit/assertion.tsx
@@ -70,10 +70,11 @@ class ListWidget extends WidgetBase {
 
 const baseListAssertion = assertion(() => v('div', { classes: ['root'] }, [v(WrappedList.tag, [])]));
 
+const First = create().children<string>()(({ children }) => <div>{children()}</div>);
 class MultiRootWidget extends WidgetBase<{ after?: boolean; last?: boolean }> {
 	render() {
 		const { after, last = true } = this.properties;
-		const result = [v('div', ['first'])];
+		const result: DNode[] = [w(First, {}, ['first'])];
 		if (after) {
 			result.push(v('div', ['after']));
 		}
@@ -84,10 +85,13 @@ class MultiRootWidget extends WidgetBase<{ after?: boolean; last?: boolean }> {
 	}
 }
 
-const WrappedFirst = wrap('div');
+const WrappedFirst = wrap(First);
 const WrappedSecond = wrap('div');
 
-const baseMultiRootAssertion = assertion(() => [v(WrappedFirst.tag, ['first']), v(WrappedSecond.tag, ['last'])]);
+const baseMultiRootAssertion = assertion(() => [
+	<WrappedFirst>first</WrappedFirst>,
+	<WrappedSecond>last</WrappedSecond>
+]);
 
 const tsxAssertion = assertion(() => (
 	<div classes={['root']}>
@@ -256,7 +260,7 @@ describe('new/assertion', () => {
 	});
 
 	it('can insert after a node in the root', () => {
-		const insertionAssertion = baseMultiRootAssertion.insertAfter(WrappedFirst, () => [v('div', {}, ['after'])]);
+		const insertionAssertion = baseMultiRootAssertion.insertAfter(WrappedFirst, () => [<div>after</div>]);
 		const r = renderer(() => w(MultiRootWidget, { after: true }));
 		r.expect(insertionAssertion);
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Backports of #802, #812 and #818 
