### PR TITLE
Prettier on i18n introduction doc

### DIFF
--- a/docs/en/i18n/introduction.md
+++ b/docs/en/i18n/introduction.md
@@ -79,7 +79,7 @@ export default {
 ## Adding a widget language localization bundle
 
 -   Supporting two locales - English as the default, together with a French translation that is activated for any users that have `fr` set as their primary language.
--         Unless a locale is specifically set for you application, the appropriate `supportedLocale` will be used according to the browsers locale settings where available.
+-   Unless a locale is specifically set for you application, the appropriate `supportedLocale` will be used according to the browsers locale settings where available.
 -   To run the app build with i18n you will need to install `cldr-data` as a dependency into your application or the build will fail.
 
 > .dojorc


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Doc formatting