### PR TITLE
Enhancement: `onUpdate` and `onDetach` APIs for `dom` pragma

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -171,6 +171,8 @@ export interface DomOptions {
 	on?: On;
 	diffType?: DiffType;
 	onAttach?: () => void;
+	onUpdate?: () => void;
+	onDetach?: () => void;
 }
 
 export interface VDomOptions {
@@ -1217,6 +1219,8 @@ export interface VNode {
 export interface DomVNode extends VNode {
 	domNode: Text | Element;
 	onAttach?: () => void;
+	onUpdate?: () => void;
+	onDetach?: () => void;
 }
 
 export interface ESMDefaultWidgetBase<T extends WidgetBaseTypes> {

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -5999,6 +5999,71 @@ jsdomDescribe('vdom', () => {
 			meta.setRenderResult(vnode);
 			assert.strictEqual(onAttachCallCount, 2);
 		});
+		it('Should run onUpdate after the dom node has been updated in the dom', () => {
+			let onUpdateCallCount = 0;
+			const myDomNode = document.createElement('div');
+			const div = document.createElement('div');
+			let vnode = d({
+				node: myDomNode,
+				onUpdate: () => {
+					onUpdateCallCount++;
+				}
+			});
+			const [Widget, meta] = getWidget(vnode);
+			const r = renderer(() => w(Widget, {}));
+			r.mount({ domNode: div, sync: true });
+			assert.strictEqual(onUpdateCallCount, 0);
+			meta.setRenderResult(vnode);
+			assert.strictEqual(onUpdateCallCount, 1);
+			meta.setRenderResult(vnode);
+			assert.strictEqual(onUpdateCallCount, 2);
+			meta.setRenderResult(vnode);
+			assert.strictEqual(onUpdateCallCount, 3);
+		});
+		it('Should run onDetach after the dom node has been removed from the dom', () => {
+			let onDetachCallCount = 0;
+			const myDomNode = document.createElement('div');
+			const div = document.createElement('div');
+			let vnode = d({
+				node: myDomNode,
+				onDetach: () => {
+					onDetachCallCount++;
+				}
+			});
+			const [Widget, meta] = getWidget(vnode);
+			const r = renderer(() => w(Widget, {}));
+			r.mount({ domNode: div, sync: true });
+			assert.strictEqual(onDetachCallCount, 0);
+			meta.setRenderResult(vnode);
+			assert.strictEqual(onDetachCallCount, 0);
+			meta.setRenderResult(null);
+			assert.strictEqual(onDetachCallCount, 1);
+			meta.setRenderResult(vnode);
+			assert.strictEqual(onDetachCallCount, 1);
+		});
+		it('Should run onDetach after the dom node has been removed from the dom in nested dom node', () => {
+			let onDetachCallCount = 0;
+			const myDomNode = document.createElement('div');
+			const div = document.createElement('div');
+			let vnode = v('div', [
+				d({
+					node: myDomNode,
+					onDetach: () => {
+						onDetachCallCount++;
+					}
+				})
+			]);
+			const [Widget, meta] = getWidget(vnode);
+			const r = renderer(() => w(Widget, {}));
+			r.mount({ domNode: div, sync: true });
+			assert.strictEqual(onDetachCallCount, 0);
+			meta.setRenderResult(vnode);
+			assert.strictEqual(onDetachCallCount, 0);
+			meta.setRenderResult(null);
+			assert.strictEqual(onDetachCallCount, 1);
+			meta.setRenderResult(vnode);
+			assert.strictEqual(onDetachCallCount, 1);
+		});
 	});
 
 	describe('deferred properties', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds two new APIs for the `dom` pragma, `onUpdate` and `onDetach` that are called when the dom node is updated and removed respectively. This will enable support for integrations such as mounting a react component within a Dojo application.

Resolves #828 
