### PR TITLE
Handle ignored children in decorate

### DIFF
--- a/src/testing/decorate.ts
+++ b/src/testing/decorate.ts
@@ -66,7 +66,9 @@ export function decorate(actual: RenderResult, expected: RenderResult, instructi
 
 	let node = nodes.shift();
 	while (node) {
-		const [actualNodes, expectedNodes] = node;
+		const [actualNodes, expectedNodes] = node.map((nodes) =>
+			nodes.filter((node) => node != null && node !== true && node !== false)
+		);
 		let childNodes: DecorateTuple[] = [];
 		while (expectedNodes.length > 0) {
 			let actualNode: DNode | { [index: string]: any } = actualNodes.shift();

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -14,6 +14,23 @@ const noop: any = () => {};
 
 class ChildWidget extends WidgetBase<{ id: string; func?: () => void }> {}
 
+const ConditionalRender = create({ icache })(({ middleware: { icache } }) => {
+	return v('div', {}, [
+		icache.get('render')
+			? v('div', {
+					onclick: () => {
+						icache.set('render', false);
+					}
+			  })
+			: null,
+		v('div', {
+			onclick: () => {
+				icache.set('render', true);
+			}
+		})
+	]);
+});
+
 class MyWidget extends WidgetBase {
 	_count = 0;
 	_result = 'result';
@@ -220,6 +237,19 @@ describe('test renderer', () => {
 					])
 				)
 			);
+		});
+
+		it('trigger property when there are undefined children in actual render', () => {
+			const WrappedRoot = wrap('div');
+			const WrappedChild = wrap('div');
+			const WrappedConditional = wrap('div');
+			const baseTemplate = assertion(() => w(WrappedRoot, {}, [w(WrappedChild, { onclick: noop })]));
+			const r = renderer(() => w(ConditionalRender, {}));
+			r.expect(baseTemplate);
+			r.property(WrappedChild, 'onclick');
+			r.expect(baseTemplate.prepend(WrappedRoot, () => [w(WrappedConditional, { onclick: noop })]));
+			r.property(WrappedConditional, 'onclick');
+			r.expect(baseTemplate);
 		});
 
 		it('should call properties in the correct order', () => {

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -239,15 +239,15 @@ describe('test renderer', () => {
 			);
 		});
 
-		it('trigger property when there are undefined children in actual render', () => {
+		it('triggers property when there are undefined children in actual render', () => {
 			const WrappedRoot = wrap('div');
 			const WrappedChild = wrap('div');
 			const WrappedConditional = wrap('div');
-			const baseTemplate = assertion(() => w(WrappedRoot, {}, [w(WrappedChild, { onclick: noop })]));
+			const baseTemplate = assertion(() => v(WrappedRoot.tag, {}, [v(WrappedChild.tag, { onclick: noop })]));
 			const r = renderer(() => w(ConditionalRender, {}));
 			r.expect(baseTemplate);
 			r.property(WrappedChild, 'onclick');
-			r.expect(baseTemplate.prepend(WrappedRoot, () => [w(WrappedConditional, { onclick: noop })]));
+			r.expect(baseTemplate.prepend(WrappedRoot, () => [v(WrappedConditional.tag, { onclick: noop })]));
 			r.property(WrappedConditional, 'onclick');
 			r.expect(baseTemplate);
 		});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Allows finding wrapped nodes when the actual array has additional children that are undefined or booleans.

This fix resolves the failure that led to #839 being created, but the actual bug was not what we originally thought.
Resolves #839 