### PR TITLE
Wrap children result in an array if not already in one

### DIFF
--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -280,6 +280,9 @@ export function assertion(renderFunc: () => DNode | DNode[]) {
 			const node = findNode(render, wrapped);
 			node.children = node.children || [];
 			let childrenResult = children();
+			if (!Array.isArray(childrenResult)) {
+				childrenResult = [childrenResult];
+			}
 			switch (type) {
 				case 'prepend':
 					node.children = [...childrenResult, ...node.children];

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -758,5 +758,19 @@ describe('test renderer', () => {
 				))
 			);
 		});
+
+		it('Should wrap single children in an array when calling setChildren', () => {
+			const factory = create().children<string>();
+			const TestWidget = factory(() => 'foo');
+			const App = create()(() => {
+				return <TestWidget>bar</TestWidget>;
+			});
+			const WrappedTestWudget = wrap(TestWidget);
+
+			const testAssertion = assertion(() => <WrappedTestWudget>bar</WrappedTestWudget>);
+			const r = renderer(() => <App />);
+
+			r.expect(testAssertion.setChildren(WrappedTestWudget, () => 'bar'));
+		});
 	});
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Wraps children result in array if not already in one. This fixes tests that fail with single children when using the `mjs` files.

Resolves #843 
