### PR TITLE
Adds Event Handler Options

### DIFF
--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -21,30 +21,30 @@ export interface TypedTargetEvent<T extends EventTarget, Y extends EventType = E
 /**
  * Cannot extend the global due to TS error: `All declarations of 'target' must have identical modifiers.`
  */
-export interface DojoEvent<T extends EventTarget = EventTarget> extends Event {
+export interface DojoEvent<T extends EventTarget | null = EventTarget | null> extends Event {
 	target: T;
 }
 
 declare global {
-	interface MouseEvent<T extends EventTarget = EventTarget> {
+	interface MouseEvent<T extends EventTarget | null = EventTarget | null> {
 		target: T;
 	}
-	interface PointerEvent<T extends EventTarget = EventTarget> {
+	interface PointerEvent<T extends EventTarget | null = EventTarget | null> {
 		target: T;
 	}
-	interface TouchEvent<T extends EventTarget = EventTarget> {
+	interface TouchEvent<T extends EventTarget | null = EventTarget | null> {
 		target: T;
 	}
-	interface KeyboardEvent<T extends EventTarget = EventTarget> {
+	interface KeyboardEvent<T extends EventTarget | null = EventTarget | null> {
 		target: T;
 	}
-	interface FocusEvent<T extends EventTarget = EventTarget> {
+	interface FocusEvent<T extends EventTarget | null = EventTarget | null> {
 		target: T;
 	}
-	interface UIEvent<T extends EventTarget = EventTarget> {
+	interface UIEvent<T extends EventTarget | null = EventTarget | null> {
 		target: T;
 	}
-	interface WheelEvent<T extends EventTarget = EventTarget> {
+	interface WheelEvent<T extends EventTarget | null = EventTarget | null> {
 		target: T;
 	}
 }
@@ -52,63 +52,112 @@ declare global {
 /*
  These are the event handlers.
  */
-export type EventHandlerResult = boolean | void;
-
 export interface EventHandler {
-	(event: Event): EventHandlerResult;
+	(event: Event): void | boolean;
 }
 
-export interface DojoEventHandler {
-	(event: DojoEvent): EventHandlerResult;
+interface PointerEventHandler<E extends EventTarget | null = EventTarget | null> {
+	(event: PointerEvent<E>): void | boolean;
 }
 
-export interface FocusEventHandler {
-	(event: FocusEvent): EventHandlerResult;
+interface MouseEventHandler<E extends EventTarget | null = EventTarget | null> {
+	(event: MouseEvent<E>): void | boolean;
 }
 
-export interface KeyboardEventHandler {
-	(event: KeyboardEvent): EventHandlerResult;
+interface DojoEventHandler<E extends EventTarget | null = EventTarget | null> {
+	(event: DojoEvent<E>): void | boolean;
 }
 
-export interface MouseEventHandler<T extends EventTarget> {
-	(ev: MouseEvent<T>): boolean | void;
+interface KeyboardEventHandler<E extends EventTarget | null = EventTarget | null> {
+	(event: KeyboardEvent<E>): void | boolean;
 }
 
-export interface PointerEventHandler {
-	(event: PointerEvent): EventHandlerResult;
+interface UIEventHandler<E extends EventTarget | null = EventTarget | null> {
+	(event: UIEvent<E>): void | boolean;
 }
 
-export interface TouchEventHandler {
-	(event: TouchEvent): EventHandlerResult;
+interface FocusEventHandler<E extends EventTarget | null = EventTarget | null> {
+	(event: FocusEvent<E>): void | boolean;
 }
 
-export interface WheelEventHandler {
-	(event: WheelEvent): EventHandlerResult;
+interface WheelEventHandler<E extends EventTarget | null = EventTarget | null> {
+	(event: WheelEvent<E>): void | boolean;
 }
 
-export interface UIEventHandler {
-	(ev: UIEvent): boolean | void;
+interface TouchEventHandler<E extends EventTarget | null = EventTarget | null> {
+	(event: TouchEvent<E>): void | boolean;
 }
 
-export type BlurEventHandler = FocusEventHandler;
-export type ChangeEventHandler = EventHandler;
-export type ClickEventHandler = MouseEventHandler<EventTarget>;
-export type DoubleClickEventHandler = MouseEventHandler<EventTarget>;
-export type InputEventHandler = EventHandler;
-export type KeyDownEventHandler = KeyboardEventHandler;
-export type KeyPressEventHandler = KeyboardEventHandler;
-export type KeyUpEventHandler = KeyboardEventHandler;
-export type LoadEventHandler = EventHandler;
-export type MouseDownEventHandler = MouseEventHandler<EventTarget>;
-export type MouseEnterEventHandler = MouseEventHandler<EventTarget>;
-export type MouseLeaveEventHandler = MouseEventHandler<EventTarget>;
-export type MouseMoveEventHandler = MouseEventHandler<EventTarget>;
-export type MouseOutEventHandler = MouseEventHandler<EventTarget>;
-export type MouseOverEventHandler = MouseEventHandler<EventTarget>;
-export type MouseUpEventHandler = MouseEventHandler<EventTarget>;
-export type MouseWheelEventHandler = (event?: MouseWheelEvent | WheelEvent) => EventHandlerResult;
-export type ScrollEventHandler = (event?: UIEvent) => EventHandlerResult;
-export type SubmitEventHandler = EventHandler;
+interface TouchEventHandlerWithOptions<E extends EventTarget | null = EventTarget | null> {
+	handler: TouchEventHandler<E>;
+}
+
+interface DojoEventWithOptions<T extends EventTarget | null> extends EventOptions {
+	handler: DojoEventHandler<T>;
+}
+
+interface FocusEventWithOptions<T extends EventTarget | null> extends EventOptions {
+	handler: FocusEventHandler<T>;
+}
+
+interface KeyboardEventWithOptions<T extends EventTarget | null> extends EventOptions {
+	handler: KeyboardEventHandler<T>;
+}
+
+interface MouseEventWithOptions<T extends EventTarget | null> extends EventOptions {
+	handler: MouseEventHandler<T>;
+}
+
+interface PointerEventWithOptions<T extends EventTarget | null> extends EventOptions {
+	handler: PointerEventHandler<T>;
+}
+
+interface TouchEventWithOptions<T extends EventTarget | null> extends EventOptions {
+	handler: TouchEventHandler<T>;
+}
+
+interface UIEventWithOptions<T extends EventTarget | null> extends EventOptions {
+	handler: UIEventHandler<T>;
+}
+
+interface WheelEventWithOptions<T extends EventTarget | null> extends EventOptions {
+	handler: WheelEventHandler<T>;
+}
+
+export type VNodePropertiesWheelEventHandler<E extends EventTarget | null = EventTarget | null> =
+	| WheelEventWithOptions<E>
+	| WheelEventHandler<E>;
+export type VNodePropertiesMouseEventHandler<E extends EventTarget | null = EventTarget | null> =
+	| MouseEventWithOptions<E>
+	| MouseEventHandler<E>;
+export type VNodePropertiesFocusEventHandler<E extends EventTarget | null = EventTarget | null> =
+	| FocusEventWithOptions<E>
+	| FocusEventHandler<E>;
+export type VNodePropertiesUIEventHandler<E extends EventTarget | null = EventTarget | null> =
+	| UIEventWithOptions<E>
+	| UIEventHandler<E>;
+export type VNodePropertiesKeyboardEventHandler<E extends EventTarget | null = EventTarget | null> =
+	| KeyboardEventWithOptions<E>
+	| KeyboardEventHandler<E>;
+export type VNodePropertiesEventHandler<E extends EventTarget | null = EventTarget | null> =
+	| DojoEventWithOptions<E>
+	| DojoEventHandler<E>;
+export type VNodePropertiesPointerEventHandler<E extends EventTarget | null = EventTarget | null> =
+	| PointerEventWithOptions<E>
+	| PointerEventHandler<E>;
+export type VNodePropertiesTouchEventHandler<E extends EventTarget | null = EventTarget | null> =
+	| TouchEventHandlerWithOptions<E>
+	| TouchEventHandler<E>;
+
+export type VNodeHandlers =
+	| VNodePropertiesMouseEventHandler
+	| VNodePropertiesWheelEventHandler
+	| VNodePropertiesTouchEventHandler
+	| VNodePropertiesPointerEventHandler
+	| VNodePropertiesEventHandler
+	| VNodePropertiesKeyboardEventHandler
+	| VNodePropertiesUIEventHandler
+	| VNodePropertiesFocusEventHandler;
 
 export interface TransitionStrategy {
 	enter(element: Element, enterAnimation: string, enterAnimationActive?: SupportedClassName): void;
@@ -182,38 +231,6 @@ export interface EventOptions {
 
 interface EventWithOptions extends EventOptions {
 	handler: EventHandler;
-}
-
-interface DojoEventWithOptions extends EventOptions {
-	handler: DojoEventHandler;
-}
-
-interface FocusEventWithOptions extends EventOptions {
-	handler: FocusEventHandler;
-}
-
-interface KeyboardEventWithOptions extends EventOptions {
-	handler: KeyboardEventHandler;
-}
-
-interface MouseEventWithOptions<T extends EventTarget> extends EventOptions {
-	handler: MouseEventHandler<T>;
-}
-
-interface PointerEventWithOptions extends EventOptions {
-	handler: PointerEventHandler;
-}
-
-interface TouchEventWithOptions extends EventOptions {
-	handler: TouchEventHandler;
-}
-
-interface UIEventWithOptions extends EventOptions {
-	handler: UIEventHandler;
-}
-
-interface WheelEventWithOptions extends EventOptions {
-	handler: WheelEventHandler;
 }
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
@@ -428,13 +445,47 @@ export interface AriaAttributes {
 	'aria-valuetext'?: string;
 }
 
-export interface VNodeProperties<T extends EventTarget = EventTarget> extends AriaAttributes {
+export interface VNodeEvents<T extends EventTarget | null = EventTarget | null> {
+	onpointermove?: VNodePropertiesPointerEventHandler<T>;
+	onpointerdown?: VNodePropertiesPointerEventHandler<T>;
+	onpointerup?: VNodePropertiesPointerEventHandler<T>;
+	onpointerover?: VNodePropertiesPointerEventHandler<T>;
+	onpointerout?: VNodePropertiesPointerEventHandler<T>;
+	onpointerenter?: VNodePropertiesPointerEventHandler<T>;
+	onpointerleave?: VNodePropertiesPointerEventHandler<T>;
+	onpointercancel?: VNodePropertiesPointerEventHandler<T>;
+	onblur?: VNodePropertiesFocusEventHandler<T>;
+	onchange?: VNodePropertiesEventHandler<T>;
+	onclick?: VNodePropertiesMouseEventHandler<T>;
+	ondblclick?: VNodePropertiesMouseEventHandler<T>;
+	onfocus?: VNodePropertiesFocusEventHandler<T>;
+	oninput?: VNodePropertiesEventHandler<T>;
+	onkeydown?: VNodePropertiesKeyboardEventHandler<T>;
+	onkeypress?: VNodePropertiesKeyboardEventHandler<T>;
+	onkeyup?: VNodePropertiesKeyboardEventHandler<T>;
+	onload?: VNodePropertiesEventHandler<T>;
+	onmousedown?: VNodePropertiesMouseEventHandler<T>;
+	onmouseenter?: VNodePropertiesMouseEventHandler<T>;
+	onmouseleave?: VNodePropertiesMouseEventHandler<T>;
+	onmousemove?: VNodePropertiesMouseEventHandler<T>;
+	onmouseout?: VNodePropertiesMouseEventHandler<T>;
+	onmouseover?: VNodePropertiesMouseEventHandler<T>;
+	onmouseup?: VNodePropertiesMouseEventHandler<T>;
+	onmousewheel?: VNodePropertiesWheelEventHandler<T>;
+	onscroll?: VNodePropertiesUIEventHandler<T>;
+	onsubmit?: VNodePropertiesEventHandler<T>;
+	ontouchcancel?: VNodePropertiesTouchEventHandler<T>;
+	ontouchend?: VNodePropertiesTouchEventHandler<T>;
+	ontouchmove?: VNodePropertiesTouchEventHandler<T>;
+	ontouchstart?: VNodePropertiesTouchEventHandler<T>;
+}
+
+export interface VNodeProperties<T extends EventTarget | null = EventTarget | null>
+	extends VNodeEvents<T>,
+		AriaAttributes {
 	enterAnimation?: SupportedClassName;
-
 	exitAnimation?: SupportedClassName;
-
 	enterAnimationActive?: SupportedClassName;
-
 	exitAnimationActive?: SupportedClassName;
 
 	/**
@@ -451,23 +502,9 @@ export interface VNodeProperties<T extends EventTarget = EventTarget> extends Ar
 	 * An object literal like `{height:'100px'}` which allows styles to be changed dynamically. All values must be strings.
 	 */
 	readonly styles?: Partial<CSSStyleDeclaration>;
-
-	// Pointer Events
-	onpointermove?: PointerEventHandler | PointerEventWithOptions;
-	onpointerdown?: PointerEventHandler | PointerEventWithOptions;
-	onpointerup?: PointerEventHandler | PointerEventWithOptions;
-	onpointerover?: PointerEventHandler | PointerEventWithOptions;
-	onpointerout?: PointerEventHandler | PointerEventWithOptions;
-	onpointerenter?: PointerEventHandler | PointerEventWithOptions;
-	onpointerleave?: PointerEventHandler | PointerEventWithOptions;
-	onpointercancel?: PointerEventHandler | PointerEventWithOptions;
 	// For Pointer Event Polyfill see: https://github.com/jquery/PEP
 	readonly 'touch-action'?: string;
 	// From Element
-	ontouchcancel?: PointerEventHandler | PointerEventWithOptions;
-	ontouchend?: TouchEventHandler | TouchEventWithOptions;
-	ontouchmove?: TouchEventHandler | TouchEventWithOptions;
-	ontouchstart?: TouchEventHandler | TouchEventWithOptions;
 	// From HTMLFormElement
 	readonly action?: string;
 	readonly encoding?: string;
@@ -476,26 +513,6 @@ export interface VNodeProperties<T extends EventTarget = EventTarget> extends Ar
 	readonly name?: string;
 	readonly target?: string;
 	// From HTMLElement
-	onblur?: FocusEventHandler | FocusEventWithOptions;
-	onchange?: DojoEventHandler | DojoEventWithOptions;
-	onclick?: MouseEventHandler<T> | MouseEventWithOptions<T>;
-	ondblclick?: MouseEventHandler<T> | MouseEventWithOptions<T>;
-	onfocus?: FocusEventHandler | FocusEventWithOptions;
-	oninput?: DojoEventHandler | DojoEventWithOptions;
-	onkeydown?: KeyboardEventHandler | KeyboardEventWithOptions;
-	onkeypress?: KeyboardEventHandler | KeyboardEventWithOptions;
-	onkeyup?: KeyboardEventHandler | KeyboardEventWithOptions;
-	onload?: DojoEventHandler | DojoEventWithOptions;
-	onmousedown?: MouseEventHandler<T> | MouseEventWithOptions<T>;
-	onmouseenter?: MouseEventHandler<T> | MouseEventWithOptions<T>;
-	onmouseleave?: MouseEventHandler<T> | MouseEventWithOptions<T>;
-	onmousemove?: MouseEventHandler<T> | MouseEventWithOptions<T>;
-	onmouseout?: MouseEventHandler<T> | MouseEventWithOptions<T>;
-	onmouseover?: MouseEventHandler<T> | MouseEventWithOptions<T>;
-	onmouseup?: MouseEventHandler<T> | MouseEventWithOptions<T>;
-	onmousewheel?: WheelEventHandler | WheelEventWithOptions;
-	onscroll?: UIEventHandler | UIEventWithOptions;
-	onsubmit?: DojoEventHandler | DojoEventWithOptions;
 	readonly spellcheck?: boolean;
 	readonly tabIndex?: number;
 	readonly disabled?: boolean;
@@ -526,7 +543,7 @@ export interface VNodeProperties<T extends EventTarget = EventTarget> extends Ar
 	readonly focus?: boolean | NodeOperationPredicate;
 
 	/**
-	 * determines is the element needs to be clicked
+	 * determines if the element needs to be clicked
 	 */
 	readonly click?: boolean | NodeOperationPredicate;
 

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -18,31 +18,6 @@ export interface TypedTargetEvent<T extends EventTarget, Y extends EventType = E
 	target: T;
 }
 
-/*
- These are the event handlers.
- */
-export type EventHandlerResult = boolean | void;
-
-export interface EventHandler {
-	(event?: Event): EventHandlerResult;
-}
-
-export interface FocusEventHandler {
-	(event?: FocusEvent): EventHandlerResult;
-}
-
-export interface KeyboardEventHandler {
-	(event?: KeyboardEvent): EventHandlerResult;
-}
-
-export interface MouseEventHandler {
-	(event?: MouseEvent): EventHandlerResult;
-}
-
-export interface UIEventHandler {
-	(ev: UIEvent): boolean | void;
-}
-
 /**
  * Cannot extend the global due to TS error: `All declarations of 'target' must have identical modifiers.`
  */
@@ -74,22 +49,63 @@ declare global {
 	}
 }
 
+/*
+ These are the event handlers.
+ */
+export type EventHandlerResult = boolean | void;
+
+export interface EventHandler {
+	(event: Event): EventHandlerResult;
+}
+
+export interface DojoEventHandler {
+	(event: DojoEvent): EventHandlerResult;
+}
+
+export interface FocusEventHandler {
+	(event: FocusEvent): EventHandlerResult;
+}
+
+export interface KeyboardEventHandler {
+	(event: KeyboardEvent): EventHandlerResult;
+}
+
+export interface MouseEventHandler<T extends EventTarget> {
+	(ev: MouseEvent<T>): boolean | void;
+}
+
+export interface PointerEventHandler {
+	(event: PointerEvent): EventHandlerResult;
+}
+
+export interface TouchEventHandler {
+	(event: TouchEvent): EventHandlerResult;
+}
+
+export interface WheelEventHandler {
+	(event: WheelEvent): EventHandlerResult;
+}
+
+export interface UIEventHandler {
+	(ev: UIEvent): boolean | void;
+}
+
 export type BlurEventHandler = FocusEventHandler;
 export type ChangeEventHandler = EventHandler;
-export type ClickEventHandler = MouseEventHandler;
-export type DoubleClickEventHandler = MouseEventHandler;
+export type ClickEventHandler = MouseEventHandler<EventTarget>;
+export type DoubleClickEventHandler = MouseEventHandler<EventTarget>;
 export type InputEventHandler = EventHandler;
 export type KeyDownEventHandler = KeyboardEventHandler;
 export type KeyPressEventHandler = KeyboardEventHandler;
 export type KeyUpEventHandler = KeyboardEventHandler;
 export type LoadEventHandler = EventHandler;
-export type MouseDownEventHandler = MouseEventHandler;
-export type MouseEnterEventHandler = MouseEventHandler;
-export type MouseLeaveEventHandler = MouseEventHandler;
-export type MouseMoveEventHandler = MouseEventHandler;
-export type MouseOutEventHandler = MouseEventHandler;
-export type MouseOverEventHandler = MouseEventHandler;
-export type MouseUpEventHandler = MouseEventHandler;
+export type MouseDownEventHandler = MouseEventHandler<EventTarget>;
+export type MouseEnterEventHandler = MouseEventHandler<EventTarget>;
+export type MouseLeaveEventHandler = MouseEventHandler<EventTarget>;
+export type MouseMoveEventHandler = MouseEventHandler<EventTarget>;
+export type MouseOutEventHandler = MouseEventHandler<EventTarget>;
+export type MouseOverEventHandler = MouseEventHandler<EventTarget>;
+export type MouseUpEventHandler = MouseEventHandler<EventTarget>;
 export type MouseWheelEventHandler = (event?: MouseWheelEvent | WheelEvent) => EventHandlerResult;
 export type ScrollEventHandler = (event?: UIEvent) => EventHandlerResult;
 export type SubmitEventHandler = EventHandler;
@@ -165,7 +181,39 @@ export interface EventOptions {
 }
 
 interface EventWithOptions extends EventOptions {
+	handler: EventHandler;
+}
+
+interface DojoEventWithOptions extends EventOptions {
+	handler: DojoEventHandler;
+}
+
+interface FocusEventWithOptions extends EventOptions {
+	handler: FocusEventHandler;
+}
+
+interface KeyboardEventWithOptions extends EventOptions {
+	handler: KeyboardEventHandler;
+}
+
+interface MouseEventWithOptions<T extends EventTarget> extends EventOptions {
+	handler: MouseEventHandler<T>;
+}
+
+interface PointerEventWithOptions extends EventOptions {
+	handler: PointerEventHandler;
+}
+
+interface TouchEventWithOptions extends EventOptions {
+	handler: TouchEventHandler;
+}
+
+interface UIEventWithOptions extends EventOptions {
 	handler: UIEventHandler;
+}
+
+interface WheelEventWithOptions extends EventOptions {
+	handler: WheelEventHandler;
 }
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
@@ -405,21 +453,21 @@ export interface VNodeProperties<T extends EventTarget = EventTarget> extends Ar
 	readonly styles?: Partial<CSSStyleDeclaration>;
 
 	// Pointer Events
-	onpointermove?(ev: PointerEvent<T>): boolean | void;
-	onpointerdown?(ev: PointerEvent<T>): boolean | void;
-	onpointerup?(ev: PointerEvent<T>): boolean | void;
-	onpointerover?(ev: PointerEvent<T>): boolean | void;
-	onpointerout?(ev: PointerEvent<T>): boolean | void;
-	onpointerenter?(ev: PointerEvent<T>): boolean | void;
-	onpointerleave?(ev: PointerEvent<T>): boolean | void;
-	onpointercancel?(ev: PointerEvent<T>): boolean | void;
+	onpointermove?: PointerEventHandler | PointerEventWithOptions;
+	onpointerdown?: PointerEventHandler | PointerEventWithOptions;
+	onpointerup?: PointerEventHandler | PointerEventWithOptions;
+	onpointerover?: PointerEventHandler | PointerEventWithOptions;
+	onpointerout?: PointerEventHandler | PointerEventWithOptions;
+	onpointerenter?: PointerEventHandler | PointerEventWithOptions;
+	onpointerleave?: PointerEventHandler | PointerEventWithOptions;
+	onpointercancel?: PointerEventHandler | PointerEventWithOptions;
 	// For Pointer Event Polyfill see: https://github.com/jquery/PEP
 	readonly 'touch-action'?: string;
 	// From Element
-	ontouchcancel?(ev: TouchEvent<T>): boolean | void;
-	ontouchend?(ev: TouchEvent<T>): boolean | void;
-	ontouchmove?(ev: TouchEvent<T>): boolean | void;
-	ontouchstart?(ev: TouchEvent<T>): boolean | void;
+	ontouchcancel?: PointerEventHandler | PointerEventWithOptions;
+	ontouchend?: TouchEventHandler | TouchEventWithOptions;
+	ontouchmove?: TouchEventHandler | TouchEventWithOptions;
+	ontouchstart?: TouchEventHandler | TouchEventWithOptions;
 	// From HTMLFormElement
 	readonly action?: string;
 	readonly encoding?: string;
@@ -428,26 +476,26 @@ export interface VNodeProperties<T extends EventTarget = EventTarget> extends Ar
 	readonly name?: string;
 	readonly target?: string;
 	// From HTMLElement
-	onblur?(ev: FocusEvent<T>): boolean | void;
-	onchange?(ev: DojoEvent<T>): boolean | void;
-	onclick?(ev: MouseEvent<T>): boolean | void;
-	ondblclick?(ev: MouseEvent<T>): boolean | void;
-	onfocus?(ev: FocusEvent<T>): boolean | void;
-	oninput?(ev: DojoEvent<T>): boolean | void;
-	onkeydown?(ev: KeyboardEvent<T>): boolean | void;
-	onkeypress?(ev: KeyboardEvent<T>): boolean | void;
-	onkeyup?(ev: KeyboardEvent<T>): boolean | void;
-	onload?(ev: DojoEvent<T>): boolean | void;
-	onmousedown?(ev: MouseEvent<T>): boolean | void;
-	onmouseenter?(ev: MouseEvent<T>): boolean | void;
-	onmouseleave?(ev: MouseEvent<T>): boolean | void;
-	onmousemove?(ev: MouseEvent<T>): boolean | void;
-	onmouseout?(ev: MouseEvent<T>): boolean | void;
-	onmouseover?(ev: MouseEvent<T>): boolean | void;
-	onmouseup?(ev: MouseEvent<T>): boolean | void;
-	onmousewheel?(ev: WheelEvent<T>): boolean | void;
-	onscroll?: UIEventHandler | EventWithOptions;
-	onsubmit?(ev: DojoEvent<T>): boolean | void;
+	onblur?: FocusEventHandler | FocusEventWithOptions;
+	onchange?: DojoEventHandler | DojoEventWithOptions;
+	onclick?: MouseEventHandler<T> | MouseEventWithOptions<T>;
+	ondblclick?: MouseEventHandler<T> | MouseEventWithOptions<T>;
+	onfocus?: FocusEventHandler | FocusEventWithOptions;
+	oninput?: DojoEventHandler | DojoEventWithOptions;
+	onkeydown?: KeyboardEventHandler | KeyboardEventWithOptions;
+	onkeypress?: KeyboardEventHandler | KeyboardEventWithOptions;
+	onkeyup?: KeyboardEventHandler | KeyboardEventWithOptions;
+	onload?: DojoEventHandler | DojoEventWithOptions;
+	onmousedown?: MouseEventHandler<T> | MouseEventWithOptions<T>;
+	onmouseenter?: MouseEventHandler<T> | MouseEventWithOptions<T>;
+	onmouseleave?: MouseEventHandler<T> | MouseEventWithOptions<T>;
+	onmousemove?: MouseEventHandler<T> | MouseEventWithOptions<T>;
+	onmouseout?: MouseEventHandler<T> | MouseEventWithOptions<T>;
+	onmouseover?: MouseEventHandler<T> | MouseEventWithOptions<T>;
+	onmouseup?: MouseEventHandler<T> | MouseEventWithOptions<T>;
+	onmousewheel?: WheelEventHandler | WheelEventWithOptions;
+	onscroll?: UIEventHandler | UIEventWithOptions;
+	onsubmit?: DojoEventHandler | DojoEventWithOptions;
 	readonly spellcheck?: boolean;
 	readonly tabIndex?: number;
 	readonly disabled?: boolean;

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -39,6 +39,10 @@ export interface MouseEventHandler {
 	(event?: MouseEvent): EventHandlerResult;
 }
 
+export interface UIEventHandler {
+	(ev: UIEvent): boolean | void;
+}
+
 /**
  * Cannot extend the global due to TS error: `All declarations of 'target' must have identical modifiers.`
  */
@@ -152,6 +156,16 @@ export interface Classes {
 	[widgetKey: string]: {
 		[classKey: string]: SupportedClassName[];
 	};
+}
+
+export interface EventOptions {
+	passive?: boolean;
+	capture?: boolean;
+	once?: boolean;
+}
+
+interface EventWithOptions extends EventOptions {
+	handler: UIEventHandler;
 }
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
@@ -432,7 +446,7 @@ export interface VNodeProperties<T extends EventTarget = EventTarget> extends Ar
 	onmouseover?(ev: MouseEvent<T>): boolean | void;
 	onmouseup?(ev: MouseEvent<T>): boolean | void;
 	onmousewheel?(ev: WheelEvent<T>): boolean | void;
-	onscroll?(ev: UIEvent<T>): boolean | void;
+	onscroll?: UIEventHandler | EventWithOptions;
 	onsubmit?(ev: DojoEvent<T>): boolean | void;
 	readonly spellcheck?: boolean;
 	readonly tabIndex?: number;

--- a/src/core/interfaces.d.ts
+++ b/src/core/interfaces.d.ts
@@ -229,10 +229,6 @@ export interface EventOptions {
 	once?: boolean;
 }
 
-interface EventWithOptions extends EventOptions {
-	handler: EventHandler;
-}
-
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 
 export type NodeOperationPredicate = () => boolean;

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -73,8 +73,7 @@ import {
 	TimeAttributes,
 	TrackAttributes,
 	VideoAttributes,
-	EventOptions,
-	EventWithOptions
+	EventOptions
 } from './interfaces';
 import { Registry, isWidget, isWidgetBaseConstructor, isWidgetFunction, isWNodeFactory } from './Registry';
 import { auto } from './diff';
@@ -1548,10 +1547,6 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		}
 	}
 
-	function isInstanceOfEventWithOptions(value: any): value is EventWithOptions {
-		return value;
-	}
-
 	function setProperties(
 		domNode: HTMLElement,
 		currentProperties: VNodeProperties = {},
@@ -1616,11 +1611,14 @@ export function renderer(renderer: () => RenderResult): Renderer {
 					setValue(domNode, propValue, previousValue);
 				} else if (propName !== 'key' && propValue !== previousValue) {
 					const type = typeof propValue;
-					if (isInstanceOfEventWithOptions(propValue)) {
+					if (type === 'object' && propValue && 'handler' in propValue) {
 						const { handler, ...eventOptions } = propValue;
 						updateEvent(domNode, propName.substr(2), handler, previousValue, eventOptions);
-					}
-					if (type === 'function' && propName.lastIndexOf('on', 0) === 0 && includesEventsAndAttributes) {
+					} else if (
+						type === 'function' &&
+						propName.lastIndexOf('on', 0) === 0 &&
+						includesEventsAndAttributes
+					) {
 						updateEvent(domNode, propName.substr(2), propValue, previousValue);
 					} else if (type === 'string' && propName !== 'innerHTML' && includesEventsAndAttributes) {
 						updateAttribute(domNode, propName, propValue, nextWrapper.namespace);

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -131,7 +131,44 @@ export namespace tsx.JSX {
 		time: TimeAttributes;
 		track: TrackAttributes;
 		video: VideoAttributes;
-		[key: string]: VNodeProperties;
+		[key: string]:
+			| VNodeProperties
+			| CanvasAttributes
+			| ColAttributes
+			| DetailsAttributes
+			| DialogAttributes
+			| EmbedAttributes
+			| FieldsetAttributes
+			| FormAttributes
+			| IFrameAttributes
+			| ImgAttributes
+			| ButtonAttributes
+			| InputAttributes
+			| LabelAttributes
+			| LinkAttributes
+			| MapAttributes
+			| MenuAttributes
+			| MeterAttributes
+			| MetaAttributes
+			| AnchorAttributes
+			| ObjectAttributes
+			| OlAttributes
+			| OptionAttributes
+			| OutputAttributes
+			| ParamAttributes
+			| ProgressAttributes
+			| QuoteAttributes
+			| SlotAttributes
+			| SelectAttributes
+			| SourceAttributes
+			| StyleAttributes
+			| TableAttributes
+			| TextareaAttributes
+			| ThAttributes
+			| TimeAttributes
+			| SVGAttributes
+			| VideoAttributes
+			| TrackAttributes;
 	}
 	export interface ElementChildrenAttribute {
 		__children__: {};

--- a/src/testing/decorate.ts
+++ b/src/testing/decorate.ts
@@ -102,12 +102,13 @@ export function decorate(actual: RenderResult, expected: RenderResult, instructi
 								(actualNode as any).children[0] = newActualChildren;
 							}
 						}
-					} else if (
-						instruction.type === 'property' &&
-						isNode(actualNode) &&
-						typeof actualNode.properties[instruction.key] === 'function'
-					) {
-						actualNode.properties[instruction.key](...instruction.params);
+					} else if (instruction.type === 'property' && isNode(actualNode)) {
+						const prop = actualNode.properties[instruction.key];
+						if (typeof prop === 'function') {
+							prop(...instruction.params);
+						} else if (prop && typeof prop.handler === 'function') {
+							prop.handler(...instruction.params);
+						}
 					}
 				}
 				wrappedNodeIds.push(expectedNode.id);

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -12,7 +12,8 @@ import {
 	WidgetBaseInterface,
 	DefaultChildrenWNodeFactory,
 	VNode,
-	DefaultMiddlewareResult
+	DefaultMiddlewareResult,
+	VNodeHandlers
 } from '../core/interfaces';
 import { WidgetBase } from '../core/WidgetBase';
 import { isWidgetFunction } from '../core/Registry';
@@ -57,7 +58,7 @@ export type KnownKeys<T> = { [K in keyof T]: string extends K ? never : number e
 	? U
 	: never;
 export type FunctionPropertyNames<T> = {
-	[K in keyof T]: T[K] extends ((...args: any[]) => any | undefined) ? K : never
+	[K in keyof T]: T[K] extends ((...args: any[]) => any) ? K : T[K] extends VNodeHandlers ? K : never
 }[keyof T];
 export type RequiredVNodeProperties = Required<Pick<VNodeProperties, KnownKeys<VNodeProperties>>>;
 

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -5601,6 +5601,23 @@ jsdomDescribe('vdom', () => {
 			});
 		});
 
+		it('will allow event options', () => {
+			const onscroll = stub();
+			const handleScroll = {
+				passive: true,
+				handler: onscroll
+			};
+			const renderFunction = () => v('div', { onscroll: handleScroll });
+			const [Widget] = getWidget(renderFunction());
+			const r = renderer(() => w(Widget, {}));
+			const div = document.createElement('div');
+			r.mount({ domNode: div, sync: true });
+			const root = div.childNodes[0] as HTMLInputElement;
+
+			sendEvent(root, 'onscroll');
+			assert.isTrue(onscroll.calledWith(onscroll, { passive: true }));
+		});
+
 		it('updates the value property', () => {
 			let typedKeys = '';
 			const handleInput = (evt: Event) => {

--- a/tests/testing/unit/harness/harness.tsx
+++ b/tests/testing/unit/harness/harness.tsx
@@ -301,7 +301,11 @@ describe('harness', () => {
 			const h = harness(() => w(MyWidget, {}));
 			h.trigger('*[key="span"]', (node: WNode | VNode) => {
 				if (isVNode(node)) {
-					return node.properties.onclick;
+					const onclick = node.properties.onclick;
+					if (onclick && typeof onclick !== 'function') {
+						return onclick.handler;
+					}
+					return onclick;
 				}
 			});
 			h.expect(() =>


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

Adds ability to use event handler options as described here: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener. The syntax would be the following:

```
const scrollElementDiv = v('div', { onscroll: {
	passive: true,
	handler: (event: UIEvent) => {
		// handle onscroll event here
	}
} });
```
As describe in the open issue, this would allow events on elements to be label as `passive`, preventing the warning on chrome. This will also allow a developer to use the options `capture` and `once`.


Resolves #810
