### PR TITLE
Fix non-object functional child case for modifying wrapped children in test renders 

### DIFF
--- a/src/testing/decorate.ts
+++ b/src/testing/decorate.ts
@@ -83,7 +83,16 @@ export function decorate(actual: RenderResult, expected: RenderResult, instructi
 						const expectedChild: any = expectedNode.children && expectedNode.children[0];
 						const actualChild: any = isNode(actualNode) && actualNode.children && actualNode.children[0];
 
-						if (typeof expectedChild === 'object') {
+						if (typeof expectedChild === 'function' || typeof actualChild === 'function') {
+							if (typeof expectedChild === 'function') {
+								const newExpectedChildren = expectedChild();
+								(expectedNode as any).children[0] = newExpectedChildren;
+							}
+							if (typeof actualChild === 'function') {
+								const newActualChildren = actualChild(...instruction.params);
+								(actualNode as any).children[0] = newActualChildren;
+							}
+						} else if (typeof expectedChild === 'object') {
 							const keys = Object.keys(expectedChild);
 							for (let i = 0; i < keys.length; i++) {
 								const key = keys[i];
@@ -95,13 +104,6 @@ export function decorate(actual: RenderResult, expected: RenderResult, instructi
 									const newActualChildren = actualChild[key](...(instruction.params[key] || []));
 									actualChild[key] = newActualChildren;
 								}
-							}
-						} else if (typeof expectedChild === 'function') {
-							const newExpectedChildren = expectedChild();
-							(expectedNode as any).children[0] = newExpectedChildren;
-							if (typeof actualChild === 'function') {
-								const newActualChildren = actualChild(...instruction.params);
-								(actualNode as any).children[0] = newActualChildren;
 							}
 						}
 					} else if (

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -111,6 +111,11 @@ function findNode<T extends Wrapped<any>>(renderResult: RenderResult, wrapped: T
 		}
 		if (isVNode(node) || isWNode(node)) {
 			const children = node.children || [];
+			for (let i = 0; i < children.length; i++) {
+				if (typeof children[i] === 'function') {
+					children[i] = (children[i] as any)();
+				}
+			}
 			nodes = [...children, ...nodes];
 		} else if (node && typeof node === 'object') {
 			nodes = [

--- a/tests/testing/unit/assertRender.tsx
+++ b/tests/testing/unit/assertRender.tsx
@@ -46,8 +46,8 @@ class WidgetWithMap extends WidgetBase {
 }
 
 function getExpectedError() {
-	const mockWidgetName = (MockWidget as any).name || 'Widget-5';
-	const widgetWithChildrenName = (MockWidget as any).name ? 'WidgetWithNamedChildren' : 'Widget-6';
+	const mockWidgetName = (MockWidget as any).name || 'Widget-6';
+	const widgetWithChildrenName = (MockWidget as any).name ? 'WidgetWithNamedChildren' : 'Widget-7';
 	return `
 <div
 (A)	classes={["one","two","three"]}

--- a/tests/testing/unit/assertion.tsx
+++ b/tests/testing/unit/assertion.tsx
@@ -219,6 +219,25 @@ describe('new/assertion', () => {
 	});
 
 	it('can set a child of a functional child widget', () => {
+		const AWidget = create().children<{ (): RenderResult }>()(({ children }) => <div>{children()[0]()}</div>);
+		const ParentWidget = create()(() => (
+			<div>
+				<AWidget>{() => <div>bar</div>}</AWidget>
+			</div>
+		));
+		const WrappedWidget = wrap(AWidget);
+		const r = renderer(() => <ParentWidget />);
+		r.child(WrappedWidget, { foo: [] });
+		const WrappedDiv = wrap('div');
+		const testAssertion = assertion(() => (
+			<div>
+				<WrappedWidget>{() => <WrappedDiv>foo</WrappedDiv>}</WrappedWidget>
+			</div>
+		));
+		r.expect(testAssertion.setChildren(WrappedDiv, () => ['bar']));
+	});
+
+	it('can set a child of a functional child widget that is a property on an object', () => {
 		const AWidget = create().children<{ bar: RenderResult; foo(): RenderResult }>()(({ children }) => (
 			<div>
 				{children()[0].foo()}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This properly calls and compares functions that are not part of objects, resolving the other part of #775 that was missed by the previous fix
Resolves #775
