### PR TITLE
Support setting properties on named children that are a render result for assertions

### DIFF
--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -125,6 +125,9 @@ function findNode<T extends Wrapped<any>>(renderResult: RenderResult, wrapped: T
 							const result = node[key]();
 							node[key] = result;
 							return Array.isArray(result) ? [...result, ...newNodes] : [result, ...newNodes];
+						} else if (typeof node[key] === 'object') {
+							const result = node[key];
+							return Array.isArray(result) ? [...result, ...newNodes] : [result, ...newNodes];
 						}
 						return newNodes;
 					},

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -494,6 +494,34 @@ describe('test renderer', () => {
 			);
 		});
 
+		it('Should be able to set a property on a named child that is a render result', () => {
+			const Bar = create().children<{ bar: RenderResult }>()(({ children }) => <div>{children()[0].bar}</div>);
+			const Foo = create()(function Foo() {
+				return (
+					<div>
+						<Bar>
+							{{
+								bar: <div disabled={true}>foo</div>
+							}}
+						</Bar>
+					</div>
+				);
+			});
+			const r = renderer(() => <Foo />);
+			const WrappedBar = wrap(Bar);
+			const WrappedDiv = wrap('div');
+			const testAssertion = assertion(() => (
+				<div>
+					<WrappedBar>
+						{{
+							bar: <WrappedDiv>foo</WrappedDiv>
+						}}
+					</WrappedBar>
+				</div>
+			));
+			r.expect(testAssertion.setProperty(WrappedDiv, 'disabled', true));
+		});
+
 		it('Should use custom comparator for the template assertion', () => {
 			const factory = create();
 			const WrappedSpan = wrap('span');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support to find nodes in named children that are render results.

Resolves #853 
