### PR TITLE
Use the middleware key as the middleware id in the test renderer

### DIFF
--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -468,7 +468,6 @@ export function renderer(renderFunc: () => WNode, options: RendererOptions = {})
 		const resolveMiddleware = (middlewares: any, mocks: any[]) => {
 			const keys = Object.keys(middlewares);
 			const results: any = {};
-			const uniqueId = uuid();
 			const mockMiddlewareMap = new Map(mocks);
 
 			for (let i = 0; i < keys.length; i++) {
@@ -479,7 +478,7 @@ export function renderer(renderFunc: () => WNode, options: RendererOptions = {})
 					isMock = true;
 				}
 				const payload: any = {
-					id: uniqueId,
+					id: keys[i],
 					properties: () => {
 						return { ...properties };
 					},

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -800,5 +800,18 @@ describe('test renderer', () => {
 
 			r.expect(testAssertion.setChildren(WrappedTestWudget, () => 'bar'));
 		});
+
+		it('should return a consistent middleware id', () => {
+			const something = create()(({ id }) => {
+				return { id };
+			});
+			const factory = create({ something });
+			const Widget = factory(({ middleware: { something } }) => {
+				return something.id;
+			});
+
+			const r = renderer(() => <Widget />);
+			r.expect(assertion(() => 'something'));
+		});
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
This should make it easier to test things that leverage the middleware id, by not using a `uuid` and instead using the middleware key itself which is unique enough for the widget under test.
