### PR TITLE
Ensure that resources are correctly initialised even if the resource already has been previous created.

### DIFF
--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -1023,6 +1023,18 @@ const resourceMiddlewareFactory = factory(
 							invalidator();
 						}
 					}
+				} else if (next) {
+					const id = next.template.id || 'global';
+					const resourceMap = templateToResourceMap.get(next.template.template);
+					const {
+						template: { initOptions }
+					} = next;
+					if (resourceMap && initOptions) {
+						const resource = resourceMap.get(id);
+						if (resource) {
+							resource.init(initOptions);
+						}
+					}
 				}
 				if (next) {
 					const nextOptions = next.options;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

When a resource is reused with the same id in a newly created widget instance then the we need to process the init options.