### PR TITLE
`pending` API to expose the state of asynchronous icache setters

### DIFF
--- a/docs/en/middleware/supplemental.md
+++ b/docs/en/middleware/supplemental.md
@@ -185,6 +185,8 @@ import icache from '@dojo/framework/core/middleware/icache';
     -   Remove the item from the cache.
 -   `icache.clear(invalidate: boolean = true)`
     -   Clears all values currently stored in the widget's local cache.
+-   `icache.pending(key: string)`
+    -   Returns the status of async setters for the key
 
 The current cache value is passed when a function is passed to `icache.set`, the example below demonstrates using the current value to for an incrementing number.
 

--- a/src/core/middleware/icache.ts
+++ b/src/core/middleware/icache.ts
@@ -50,6 +50,7 @@ export interface ICacheResult<S = void> {
 	has<T extends void extends S ? any : keyof S>(key: void extends S ? any : T): boolean;
 	delete<T extends void extends S ? any : keyof S>(key: void extends S ? any : T, invalidate?: boolean): void;
 	clear(invalidate?: boolean): void;
+	pending<T extends void extends S ? any : keyof S>(key: void extends S ? any : T): boolean;
 }
 
 const icacheFactory = factory(
@@ -119,6 +120,10 @@ const icacheFactory = factory(
 				return undefined;
 			}
 			return cachedValue.value;
+		};
+		api.pending = (key: any): boolean => {
+			let cachedValue = cacheMap.get(key);
+			return Boolean(cachedValue && cachedValue.status === 'pending');
 		};
 		return api;
 	}

--- a/tests/core/unit/middleware/icache.ts
+++ b/tests/core/unit/middleware/icache.ts
@@ -126,11 +126,13 @@ describe('icache middleware', () => {
 		});
 		icache.set('test', () => promiseOne);
 		assert.isUndefined(icache.get('test'));
+		assert.isTrue(icache.pending('test'));
 		assert.isTrue(invalidatorStub.notCalled);
 		resolverOne('value');
 		await promiseOne;
 
 		assert.isTrue(invalidatorStub.calledOnce);
+		assert.isFalse(icache.pending('test'));
 		assert.strictEqual(icache.get('test'), 'value');
 	});
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

In  order to be able to determine the status of an async `icache.set`/`icache.getOrSet` this new API, `.pending` returns if the promise is still unresolved.
