### PR TITLE
Support redirect in routing configuration

### DIFF
--- a/docs/en/routing/supplemental.md
+++ b/docs/en/routing/supplemental.md
@@ -9,6 +9,7 @@ The routing configuration API is constructed with the following properties:
 -   `outlet: string`: The `outlet` name for the route. This is used by the `Outlet` widget to determine what needs to be rendered.
 -   `defaultRoute: boolean` (optional): Marks the outlet as default, the application will redirect to this route automatically if no route or an unknown route is found on application load.
 -   `defaultParams: { [index: string]: string }` (optional): Associated default parameters (`path` and `query`), required if the default route has required params.
+-   `redirect: string` (optional): A path to redirect to when matched exactly, params can be referenced from the matched route by the using the `{}` syntax
 -   `children: RouteConfig[]` (optional): Nested child routing configuration.
 
 > src/routes.ts
@@ -25,6 +26,7 @@ export default [
 		id: 'about',
 		path: 'about',
 		outlet: 'about-overview',
+		redirect: 'about/company'
 		children: [
 			{
 				id: 'about-services',

--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -187,7 +187,7 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 	private _register(config: RouteConfig[], routes?: Route[], parentRoute?: Route): void {
 		routes = routes ? routes : this._routes;
 		for (let i = 0; i < config.length; i++) {
-			let { path, outlet, children, defaultRoute = false, defaultParams = {}, id, title } = config[i];
+			let { path, outlet, children, defaultRoute = false, defaultParams = {}, id, title, redirect } = config[i];
 			let [parsedPath, queryParamString] = path.split('?');
 			let queryParams: string[] = [];
 			parsedPath = this._stripLeadingSlash(parsedPath);
@@ -200,6 +200,7 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 				title,
 				path: parsedPath,
 				segments,
+				redirect,
 				defaultParams: parentRoute ? { ...parentRoute.defaultParams, ...defaultParams } : defaultParams,
 				children: [],
 				fullPath: parentRoute ? `${parentRoute.fullPath}/${parsedPath}` : parsedPath,
@@ -348,6 +349,15 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 		}
 
 		if (matchedRoute) {
+			if (matchedRoute.route.redirect && matchedRoute.type === 'index') {
+				let { redirect } = matchedRoute.route;
+				const params = { ...matchedRoute.params };
+				Object.keys(params).forEach((paramKey) => {
+					redirect = redirect.replace(`{${paramKey}}`, params[paramKey]);
+				});
+				this.setPath(redirect);
+				return;
+			}
 			if (matchedRoute.type === 'partial') {
 				matchedRoute.type = 'error';
 			}

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -19,6 +19,7 @@ export interface Route {
 	params: string[];
 	segments: string[];
 	children: Route[];
+	redirect?: string;
 	fullPath: string;
 	fullParams: string[];
 	fullQueryParams: string[];
@@ -34,6 +35,7 @@ export interface RouteConfig {
 	path: string;
 	outlet: string;
 	children?: RouteConfig[];
+	redirect?: string;
 	defaultParams?: Params;
 	defaultRoute?: boolean;
 	title?: string;

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -675,4 +675,34 @@ describe('Router', () => {
 			assert.strictEqual(contextMap!.size, 2);
 		});
 	});
+
+	describe('redirect', () => {
+		it('should redirect to path on matched route', () => {
+			const router = new Router(
+				[
+					{
+						path: 'foo/{param}',
+						id: 'foo',
+						outlet: 'main',
+						redirect: 'foo/{param}/bar',
+						defaultParams: {
+							param: 'default-param'
+						},
+						defaultRoute: true,
+						children: [
+							{
+								path: 'bar',
+								id: 'bar',
+								outlet: 'bar'
+							}
+						]
+					}
+				],
+				{ HistoryManager }
+			);
+			const contextMap = router.getOutlet('bar');
+			assert.isOk(contextMap);
+			assert.strictEqual(contextMap!.size, 1);
+		});
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for configuring a redirect for routes in the configuration.
