### PR TITLE
Fix redirect on an application load

### DIFF
--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -93,6 +93,7 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 	public start() {
 		const { HistoryManager = HashHistory, base, window } = this._options;
 		this._history = new HistoryManager({ onChange: this._onChange, base, window });
+		this._history.start();
 		if (this._matchedRoutes.errorRoute && this._defaultRoute) {
 			const path = this.link(this._defaultRoute);
 			if (path) {

--- a/src/routing/history/HashHistory.ts
+++ b/src/routing/history/HashHistory.ts
@@ -3,13 +3,16 @@ import { History, HistoryOptions, OnChangeFunction } from './../interfaces';
 
 export class HashHistory implements History {
 	private _onChangeFunction: OnChangeFunction;
-	private _current: string;
+	private _current = '/';
 	private _window: Window;
 
 	constructor({ window = global.window, onChange }: HistoryOptions) {
 		this._onChangeFunction = onChange;
 		this._window = window;
 		this._window.addEventListener('hashchange', this._onChange, false);
+	}
+
+	start() {
 		this._current = this.normalizePath(this._window.location.hash);
 		this._onChangeFunction(this._current);
 	}

--- a/src/routing/history/HashHistory.ts
+++ b/src/routing/history/HashHistory.ts
@@ -9,10 +9,10 @@ export class HashHistory implements History {
 	constructor({ window = global.window, onChange }: HistoryOptions) {
 		this._onChangeFunction = onChange;
 		this._window = window;
-		this._window.addEventListener('hashchange', this._onChange, false);
 	}
 
 	start() {
+		this._window.addEventListener('hashchange', this._onChange, false);
 		this._current = this.normalizePath(this._window.location.hash);
 		this._onChangeFunction(this._current);
 	}

--- a/src/routing/history/MemoryHistory.ts
+++ b/src/routing/history/MemoryHistory.ts
@@ -6,6 +6,9 @@ export class MemoryHistory implements History {
 
 	constructor({ onChange }: HistoryOptions) {
 		this._onChangeFunction = onChange;
+	}
+
+	start() {
 		this._onChange();
 	}
 

--- a/src/routing/history/StateHistory.ts
+++ b/src/routing/history/StateHistory.ts
@@ -47,10 +47,10 @@ export class StateHistory implements HistoryInterface {
 		if (!leadingSlash.test(this._base)) {
 			this._base = `/${this._base}`;
 		}
-		this._window.addEventListener('popstate', this._onChange, false);
 	}
 
 	start() {
+		this._window.addEventListener('popstate', this._onChange, false);
 		this._onChange();
 	}
 

--- a/src/routing/history/StateHistory.ts
+++ b/src/routing/history/StateHistory.ts
@@ -48,6 +48,9 @@ export class StateHistory implements HistoryInterface {
 			this._base = `/${this._base}`;
 		}
 		this._window.addEventListener('popstate', this._onChange, false);
+	}
+
+	start() {
 		this._onChange();
 	}
 

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -207,6 +207,8 @@ export interface HistoryConstructor {
  * History interface
  */
 export interface History {
+	start(): void;
+
 	/**
 	 * Sets the path on the history manager
 	 */

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -207,6 +207,9 @@ export interface HistoryConstructor {
  * History interface
  */
 export interface History {
+	/**
+	 * Start the history manager
+	 */
 	start(): void;
 
 	/**

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -678,21 +678,20 @@ describe('Router', () => {
 
 	describe('redirect', () => {
 		it('should redirect from a default route', () => {
+			debugger;
 			const router = new Router(
 				[
 					{
 						path: '/',
 						id: 'foo',
 						outlet: 'main',
-						redirect: 'foo/bar',
-						defaultRoute: true,
-						children: [
-							{
-								path: 'foo/bar',
-								id: 'bar',
-								outlet: 'bar'
-							}
-						]
+						redirect: '/foo/bar',
+						defaultRoute: true
+					},
+					{
+						path: 'foo/bar',
+						id: 'bar',
+						outlet: 'bar'
 					}
 				],
 				{ HistoryManager }

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -677,6 +677,31 @@ describe('Router', () => {
 	});
 
 	describe('redirect', () => {
+		it('should redirect from a default route', () => {
+			const router = new Router(
+				[
+					{
+						path: '/',
+						id: 'foo',
+						outlet: 'main',
+						redirect: 'foo/bar',
+						defaultRoute: true,
+						children: [
+							{
+								path: 'foo/bar',
+								id: 'bar',
+								outlet: 'bar'
+							}
+						]
+					}
+				],
+				{ HistoryManager }
+			);
+			const contextMap = router.getOutlet('bar');
+			assert.isOk(contextMap);
+			assert.strictEqual(contextMap!.size, 1);
+		});
+
 		it('should redirect to path on matched route', () => {
 			const router = new Router(
 				[

--- a/tests/routing/unit/history/HashHistory.ts
+++ b/tests/routing/unit/history/HashHistory.ts
@@ -48,6 +48,7 @@ describe('HashHistory', () => {
 	it('Calls onChange for current hash', () => {
 		const onChange = stub();
 		const history = new HashHistory({ onChange, window: mockWindow });
+		history.start();
 		assert.isTrue(onChange.calledWith('current'));
 		assert.isTrue(onChange.calledOnce);
 		assert.strictEqual(history.current, 'current');
@@ -56,6 +57,7 @@ describe('HashHistory', () => {
 	it('Calls onChange on hash change', () => {
 		const onChange = stub();
 		const history = new HashHistory({ onChange, window: mockWindow });
+		history.start();
 		assert.isTrue(onChange.calledWith('current'));
 		assert.isTrue(onChange.calledOnce);
 		assert.strictEqual(history.current, 'current');
@@ -68,6 +70,7 @@ describe('HashHistory', () => {
 	it('Calls onChange on set', () => {
 		const onChange = stub();
 		const history = new HashHistory({ onChange, window: mockWindow });
+		history.start();
 		assert.isTrue(onChange.calledWith('current'));
 		assert.isTrue(onChange.calledOnce);
 		assert.strictEqual(history.current, 'current');
@@ -80,18 +83,21 @@ describe('HashHistory', () => {
 	it('should add hash prefix', () => {
 		const onChange = stub();
 		const history = new HashHistory({ onChange, window: mockWindow });
+		history.start();
 		assert.strictEqual(history.prefix('hash'), '#hash');
 	});
 
 	it('should not add hash prefix if it already exists', () => {
 		const onChange = stub();
 		const history = new HashHistory({ onChange, window: mockWindow });
+		history.start();
 		assert.strictEqual(history.prefix('#hash'), '#hash');
 	});
 
 	it('destroying removes the hashchange event listener', () => {
 		const onChange = stub();
 		const history = new HashHistory({ onChange, window: mockWindow });
+		history.start();
 		assert.isTrue(mockWindow.removeEventListener.notCalled);
 		history.destroy();
 		assert.isTrue(mockWindow.removeEventListener.calledOnce);

--- a/tests/routing/unit/history/MemoryHistory.ts
+++ b/tests/routing/unit/history/MemoryHistory.ts
@@ -8,6 +8,7 @@ describe('MemoryHistory', () => {
 	it('Calls onChange on set', () => {
 		const onChange = stub();
 		const history = new MemoryHistory({ onChange });
+		history.start();
 		assert.isTrue(onChange.calledWith('/'));
 		assert.isTrue(onChange.calledOnce);
 		assert.strictEqual(history.current, '/');
@@ -20,6 +21,7 @@ describe('MemoryHistory', () => {
 	it('Does not call onChange on set if paths match', () => {
 		const onChange = stub();
 		const history = new MemoryHistory({ onChange });
+		history.start();
 		assert.isTrue(onChange.calledWith('/'));
 		assert.isTrue(onChange.calledOnce);
 		assert.strictEqual(history.current, '/');
@@ -30,6 +32,7 @@ describe('MemoryHistory', () => {
 	it('should not add any prefix', () => {
 		const onChange = stub();
 		const history = new MemoryHistory({ onChange });
+		history.start();
 		assert.strictEqual(history.prefix('hash'), 'hash');
 	});
 });

--- a/tests/routing/unit/history/StateHistory.ts
+++ b/tests/routing/unit/history/StateHistory.ts
@@ -33,16 +33,21 @@ describe('StateHistory', () => {
 
 	it('initializes current path to current location', () => {
 		sandbox.contentWindow!.history.pushState({}, '', '/foo?bar');
-		assert.equal(new StateHistory({ onChange, window: sandbox.contentWindow! }).current, 'foo?bar');
+		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+		history.start();
+		assert.equal(history.current, 'foo?bar');
 	});
 
 	it('location defers to the global object', () => {
 		let location = window.location.pathname.slice(1);
-		assert.equal(new StateHistory({ onChange }).current, location + window.location.search);
+		const history = new StateHistory({ onChange });
+		history.start();
+		assert.equal(history.current, location + window.location.search);
 	});
 
 	it('prefixes sanatizes path removing / and # characters', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+		history.start();
 		assert.equal(history.prefix('#/foo'), 'foo');
 		assert.equal(history.prefix('#foo'), 'foo');
 		assert.equal(history.prefix('/foo'), 'foo');
@@ -50,6 +55,7 @@ describe('StateHistory', () => {
 
 	it('update path', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+		history.start();
 		history.set('/foo');
 		assert.equal(history.current, 'foo');
 		assert.equal(sandbox.contentWindow!.location.pathname, '/foo');
@@ -57,6 +63,7 @@ describe('StateHistory', () => {
 
 	it('update path, does not update path if path is set to the current value', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+		history.start();
 		const beforeLength = sandbox.contentWindow!.history.length;
 		history.set('bar');
 		history.set('bar');
@@ -66,6 +73,7 @@ describe('StateHistory', () => {
 
 	it('update path, adds leading slash if necessary', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+		history.start();
 		history.set('foo');
 		assert.equal(history.current, 'foo');
 		assert.equal(sandbox.contentWindow!.location.pathname, '/foo');
@@ -73,6 +81,7 @@ describe('StateHistory', () => {
 
 	it('emits change when path is updated', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+		history.start();
 		assert.deepEqual(onChange.firstCall.args, [
 			sandbox.contentWindow!.location.pathname.slice(1) + sandbox.contentWindow!.location.search
 		]);
@@ -83,6 +92,7 @@ describe('StateHistory', () => {
 	it('does not emit change if path is set to the current value', () => {
 		sandbox.contentWindow!.history.pushState({}, '', '/foo');
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+		history.start();
 		history.set('/foo');
 		assert.isTrue(onChange.calledOnce);
 	});
@@ -113,18 +123,23 @@ describe('StateHistory', () => {
 		it('initializes current path, taking out the base, with trailing slash', () => {
 			add('app-base', '/foo/', true);
 			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar?baz');
-			assert.equal(new StateHistory({ onChange, window: sandbox.contentWindow! }).current, 'bar?baz');
+			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+			history.start();
+			assert.equal(history.current, 'bar?baz');
 		});
 
 		it('initializes current path, taking out the base, without trailing slash', () => {
 			add('app-base', '/foo/', true);
 			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar?baz');
-			assert.equal(new StateHistory({ onChange, window: sandbox.contentWindow! }).current, 'bar?baz');
+			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+			history.start();
+			assert.equal(history.current, 'bar?baz');
 		});
 
 		it('#set expands the path with the base when pushing state, with trailing slash', () => {
 			add('app-base', '/foo/', true);
 			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+			history.start();
 			history.set('/foo/bar');
 			assert.equal(history.current, 'bar');
 			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/bar');
@@ -137,6 +152,7 @@ describe('StateHistory', () => {
 		it('#set expands the path with the base when pushing state, without trailing slash', () => {
 			add('app-base', '/foo/', true);
 			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+			history.start();
 			history.set('bar');
 			assert.equal(history.current, 'bar');
 			assert.equal(sandbox.contentWindow!.location.pathname, '/foo/bar');
@@ -150,6 +166,7 @@ describe('StateHistory', () => {
 			add('app-base', '/foo/bar/', true);
 			sandbox.contentWindow!.history.pushState({}, '', '/');
 			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+			history.start();
 			history.set('baz');
 			assert.strictEqual(sandbox.contentWindow!.location.pathname, '/foo/bar/baz');
 			assert.equal(history.current, 'baz');
@@ -159,6 +176,7 @@ describe('StateHistory', () => {
 			sandbox.contentWindow!.history.pushState({}, '', '/foo/bar/');
 			add('app-base', 'foo/bar', true);
 			const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+			history.start();
 			assert.strictEqual(sandbox.contentWindow!.location.pathname, '/foo/bar/');
 			history.set('baz');
 			assert.strictEqual(sandbox.contentWindow!.location.pathname, '/foo/bar/baz');
@@ -167,12 +185,14 @@ describe('StateHistory', () => {
 
 		it('Warns in debug mode if the base option has been set on history options', () => {
 			add('dojo-debug', true, true);
-			new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
+			const history = new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
+			history.start();
 			assert.isTrue(consoleWarnStub.calledOnce);
 		});
 
 		it('Does not warn when not in debug mode if the base option has been set on history options', () => {
-			new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
+			const history = new StateHistory({ onChange, base: '/foo/', window: sandbox.contentWindow! });
+			history.start();
 			assert.isTrue(consoleWarnStub.notCalled);
 		});
 	});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

For redirecting on application load the router needs to make sure the history manager instance is set before processing the initial path in case it requires a redirect (which needs the history instance).

This is breaking as it requires introducing a "start" function to the history managers.
