### PR TITLE
Support replace for the router and history managers

### DIFF
--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -90,6 +90,15 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 		this._history.set(path);
 	}
 
+	/**
+	 * Replaces the path against the registered history manager
+	 *
+	 * @param path The path to set on the history manager
+	 */
+	public replacePath(path: string): void {
+		this._history.replace(path);
+	}
+
 	public start() {
 		const { HistoryManager = HashHistory, base, window } = this._options;
 		this._history = new HistoryManager({ onChange: this._onChange, base, window });

--- a/src/routing/history/HashHistory.ts
+++ b/src/routing/history/HashHistory.ts
@@ -11,7 +11,7 @@ export class HashHistory implements History {
 		this._window = window;
 	}
 
-	start() {
+	public start() {
 		this._window.addEventListener('hashchange', this._onChange, false);
 		this._current = this.normalizePath(this._window.location.hash);
 		this._onChangeFunction(this._current);
@@ -30,6 +30,12 @@ export class HashHistory implements History {
 
 	public set(path: string) {
 		this._window.location.hash = this.prefix(path);
+		this._onChange();
+	}
+
+	public replace(path: string) {
+		const { pathname, search } = this._window.location;
+		this._window.location.replace(pathname + search + this.prefix(path));
 		this._onChange();
 	}
 

--- a/src/routing/history/MemoryHistory.ts
+++ b/src/routing/history/MemoryHistory.ts
@@ -8,7 +8,7 @@ export class MemoryHistory implements History {
 		this._onChangeFunction = onChange;
 	}
 
-	start() {
+	public start() {
 		this._onChange();
 	}
 
@@ -22,6 +22,10 @@ export class MemoryHistory implements History {
 		}
 		this._current = path;
 		this._onChange();
+	}
+
+	public replace(path: string) {
+		this.set(path);
 	}
 
 	public get current(): string {

--- a/src/routing/history/StateHistory.ts
+++ b/src/routing/history/StateHistory.ts
@@ -49,7 +49,7 @@ export class StateHistory implements HistoryInterface {
 		}
 	}
 
-	start() {
+	public start() {
 		this._window.addEventListener('popstate', this._onChange, false);
 		this._onChange();
 	}
@@ -69,6 +69,16 @@ export class StateHistory implements HistoryInterface {
 		}
 
 		this._window.history.pushState({}, '', this._setBasePath(value));
+		this._onChange();
+	}
+
+	public replace(path: string) {
+		const value = stripBase(this._base, path);
+		if (this._current === value) {
+			return;
+		}
+
+		this._window.history.replaceState({}, '', this._setBasePath(value));
 		this._onChange();
 	}
 

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -113,6 +113,11 @@ export interface RouterInterface {
 	setPath(path: string): void;
 
 	/**
+	 * Replaces the path on the underlying history manager
+	 */
+	replacePath(path: string): void;
+
+	/**
 	 * Returns the outlet context if matched
 	 */
 	getRoute(outletId: string): RouteContext | undefined;
@@ -216,6 +221,11 @@ export interface History {
 	 * Sets the path on the history manager
 	 */
 	set(path: string): void;
+
+	/**
+	 * Replaces the path on the history manager
+	 */
+	replace(path: string): void;
 
 	/**
 	 * Adds a prefix to the path if the history manager requires

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -678,7 +678,6 @@ describe('Router', () => {
 
 	describe('redirect', () => {
 		it('should redirect from a default route', () => {
-			debugger;
 			const router = new Router(
 				[
 					{

--- a/tests/routing/unit/history/HashHistory.ts
+++ b/tests/routing/unit/history/HashHistory.ts
@@ -23,6 +23,23 @@ class MockLocation {
 	get hash() {
 		return this._hash;
 	}
+
+	get pathname() {
+		return 'pathname';
+	}
+
+	get search() {
+		return '';
+	}
+
+	replace(value: string) {
+		const [, hash] = value.split('#');
+		const newHash = hash[0] !== '#' ? `#${hash}` : hash;
+		if (newHash !== this._hash) {
+			this._hash = newHash;
+			this._change();
+		}
+	}
 }
 
 class MockWindow {
@@ -75,6 +92,19 @@ describe('HashHistory', () => {
 		assert.isTrue(onChange.calledOnce);
 		assert.strictEqual(history.current, 'current');
 		history.set('new');
+		assert.isTrue(onChange.calledTwice);
+		assert.isTrue(onChange.secondCall.calledWith('new'));
+		assert.strictEqual(history.current, 'new');
+	});
+
+	it('Calls onChange on replace', () => {
+		const onChange = stub();
+		const history = new HashHistory({ onChange, window: mockWindow });
+		history.start();
+		assert.isTrue(onChange.calledWith('current'));
+		assert.isTrue(onChange.calledOnce);
+		assert.strictEqual(history.current, 'current');
+		history.replace('new');
 		assert.isTrue(onChange.calledTwice);
 		assert.isTrue(onChange.secondCall.calledWith('new'));
 		assert.strictEqual(history.current, 'new');

--- a/tests/routing/unit/history/MemoryHistory.ts
+++ b/tests/routing/unit/history/MemoryHistory.ts
@@ -18,6 +18,19 @@ describe('MemoryHistory', () => {
 		assert.strictEqual(history.current, 'new');
 	});
 
+	it('Calls onChange on replace', () => {
+		const onChange = stub();
+		const history = new MemoryHistory({ onChange });
+		history.start();
+		assert.isTrue(onChange.calledWith('/'));
+		assert.isTrue(onChange.calledOnce);
+		assert.strictEqual(history.current, '/');
+		history.replace('new');
+		assert.isTrue(onChange.calledTwice);
+		assert.isTrue(onChange.secondCall.calledWith('new'));
+		assert.strictEqual(history.current, 'new');
+	});
+
 	it('Does not call onChange on set if paths match', () => {
 		const onChange = stub();
 		const history = new MemoryHistory({ onChange });

--- a/tests/routing/unit/history/StateHistory.ts
+++ b/tests/routing/unit/history/StateHistory.ts
@@ -61,6 +61,14 @@ describe('StateHistory', () => {
 		assert.equal(sandbox.contentWindow!.location.pathname, '/foo');
 	});
 
+	it('replace path', () => {
+		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
+		history.start();
+		history.replace('/foo');
+		assert.equal(history.current, 'foo');
+		assert.equal(sandbox.contentWindow!.location.pathname, '/foo');
+	});
+
 	it('update path, does not update path if path is set to the current value', () => {
 		const history = new StateHistory({ onChange, window: sandbox.contentWindow! });
 		history.start();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

For `redirect` the new route should replace the current one so that the browser navigation behaves as expected. To support a `replace` feature has been added to both the router and the history managers.