### PR TITLE
Fix the typings for the arguments on the test renderer child api

### DIFF
--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -39,15 +39,29 @@ export interface PropertyInstruction {
 export type Instruction = ChildInstruction | PropertyInstruction;
 
 export interface Child {
+	<T extends OptionalWNodeFactory<{ properties: any; children: any }>>(
+		wrapped: Wrapped<T>,
+		params: T['children'] extends (...args: any[]) => RenderResult
+			? Parameters<T['children']>
+			: T['children'] extends { [index: string]: any }
+				? {
+						[P in keyof T['children']]?: Parameters<T['children'][P]> extends never
+							? []
+							: Parameters<T['children'][P]>
+				  }
+				: never
+	): void;
 	<T extends WNodeFactory<{ properties: any; children: any }>>(
 		wrapped: Wrapped<T>,
-		params: T['children'] extends { [index: string]: any }
-			? {
-					[P in keyof T['children']]?: Parameters<T['children'][P]> extends never
-						? []
-						: Parameters<T['children'][P]>
-			  }
-			: T['children'] extends (...args: any[]) => RenderResult ? Parameters<T['children']> : never
+		params: T['children'] extends (...args: any[]) => RenderResult
+			? Parameters<T['children']>
+			: T['children'] extends { [index: string]: any }
+				? {
+						[P in keyof T['children']]?: Parameters<T['children'][P]> extends never
+							? []
+							: Parameters<T['children'][P]>
+				  }
+				: never
 	): void;
 }
 

--- a/tests/testing/unit/assertion.tsx
+++ b/tests/testing/unit/assertion.tsx
@@ -227,7 +227,7 @@ describe('new/assertion', () => {
 		));
 		const WrappedWidget = wrap(AWidget);
 		const r = renderer(() => <ParentWidget />);
-		r.child(WrappedWidget, { foo: [] });
+		r.child(WrappedWidget, []);
 		const WrappedDiv = wrap('div');
 		const testAssertion = assertion(() => (
 			<div>

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -322,10 +322,13 @@ describe('test renderer', () => {
 				return '';
 			});
 
-			const childObjectFactory = create().children<{
-				top: (value: string) => RenderResult;
-				bottom: (value: string) => RenderResult;
-			}>();
+			const childObjectFactory = create().children<
+				| {
+						top: (value: string) => RenderResult;
+						bottom: (value: string) => RenderResult;
+				  }
+				| undefined
+			>();
 
 			const ChildObjectFactory = childObjectFactory(function ChildObjectFactory() {
 				return '';
@@ -369,6 +372,8 @@ describe('test renderer', () => {
 
 			r.child(WrappedChildObjectFactory, { top: ['top'], bottom: ['bottom'] });
 			r.child(WrappedChildFunctionWidget, ['func']);
+			// This errors
+			// r.child(WrappedChildFunctionWidget, [1]);
 			r.child(WrappedParentChildObjectFactory, { top: ['parent-top'], bottom: ['parent-bottom'] });
 			r.child(WrappedNestedChildObjectFactory, { top: ['nested-top'], bottom: ['nested-bottom'] });
 			r.child(WrappedNestedChildFunctionWidget, ['nested-function']);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fix the `child` typings for widgets with optional children and functional children.
