### PR TITLE
Update insertSiblings type definition

### DIFF
--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -172,7 +172,12 @@ export interface AssertionResult {
 	): AssertionResult;
 	insertAfter<T extends WidgetFactory>(target: Wrapped<T>, children: TemplateChildren): AssertionResult;
 	insertSiblings<T extends WidgetBaseInterface>(
-		target: T,
+		target: Wrapped<Constructor<T>>,
+		children: TemplateChildren,
+		type?: 'before' | 'after'
+	): AssertionResult;
+	insertSiblings<T extends WidgetFactory>(
+		target: Wrapped<T>,
 		children: TemplateChildren,
 		type?: 'before' | 'after'
 	): AssertionResult;

--- a/tests/testing/unit/assertion.tsx
+++ b/tests/testing/unit/assertion.tsx
@@ -317,9 +317,14 @@ describe('new/assertion', () => {
 		r.expect(baseAssertion.append(WrappedHeader, () => ['append']));
 	});
 
-	it('can set children after with insert', () => {
+	it('can set children after with insert after', () => {
 		const r = renderer(() => w(MyWidget, { after: true }));
 		r.expect(baseAssertion.insertAfter(WrappedList, () => [v('span', ['after'])]));
+	});
+
+	it('can set children after with insert sibling', () => {
+		const r = renderer(() => w(MyWidget, { after: true }));
+		r.expect(baseAssertion.insertSiblings(WrappedList, () => [v('span', ['after'])], 'after'));
 	});
 
 	it('can insert after a node in the root', () => {
@@ -328,9 +333,14 @@ describe('new/assertion', () => {
 		r.expect(insertionAssertion);
 	});
 
-	it('can set children before with insert', () => {
+	it('can set children before with insert before', () => {
 		const r = renderer(() => w(MyWidget, { before: true }));
 		r.expect(baseAssertion.insertBefore(WrappedList, () => [v('span', ['before'])]));
+	});
+
+	it('can set children before with insert sibling ', () => {
+		const r = renderer(() => w(MyWidget, { before: true }));
+		r.expect(baseAssertion.insertSiblings(WrappedList, () => [v('span', ['before'])], 'before'));
 	});
 
 	it('can be used with tsx', () => {


### PR DESCRIPTION
**Type:** Bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #870 
Updates type definitions for `insertSiblings` function
