### PR TITLE
Support for custom resource APIs

### DIFF
--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -321,6 +321,8 @@ export interface ResourceWithMeta<MIDDLEWARE_DATA> {
 	};
 }
 
+export type ResourceApi<API extends CustomTemplate> = { [K in keyof API]: (...args: Parameters<API[K]>) => void };
+
 export interface Resource<MIDDLEWARE_DATA = {}> {
 	<RESOURCE_DATA, CUSTOM_API>(
 		options: {
@@ -388,9 +390,9 @@ export interface Resource<MIDDLEWARE_DATA = {}> {
 	};
 	template<TEMPLATE extends ResourceWrapper<any, any, any> | TemplateWrapper<any, any>>(
 		template: TEMPLATE | undefined | void
-	): TEMPLATE extends ResourceWrapper<any, infer RESOURCE_DATA, any>
+	): TEMPLATE extends ResourceWrapper<any, infer RESOURCE_DATA, infer API>
 		? {
-				template: TEMPLATE['template']['api'];
+				template: API extends CustomTemplate ? ResourceApi<API> : undefined;
 				createOptions(setter: OptionSetter, id?: string): ReadOptions;
 				get(options: ReadOptionsData, settings: { meta: true }): ResourceWithMeta<RESOURCE_DATA>;
 				get(options: ReadOptionsData): (RESOURCE_DATA | undefined)[];
@@ -405,9 +407,9 @@ export interface Resource<MIDDLEWARE_DATA = {}> {
 				): ResourceWithMeta<RESOURCE_DATA>;
 				get(ids: string[]): (RESOURCE_DATA | undefined)[];
 		  }
-		: TEMPLATE extends TemplateWrapper<infer RESOURCE_DATA, any>
+		: TEMPLATE extends TemplateWrapper<infer RESOURCE_DATA, infer API>
 			? {
-					template: TEMPLATE['api'];
+					template: API extends CustomTemplate ? ResourceApi<API> : undefined;
 					createOptions(setter: OptionSetter, id?: string): ReadOptions;
 					get(options: ReadOptionsData, settings: { meta: true }): ResourceWithMeta<RESOURCE_DATA>;
 					get(options: ReadOptionsData): (RESOURCE_DATA | undefined)[];
@@ -739,7 +741,7 @@ const middleware = factory(
 							});
 						};
 
-						return (instance as any)[key](args, { put, del });
+						(instance as any)[key](args, { put, del });
 					};
 					return api;
 				},

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -1221,13 +1221,7 @@ jsdomDescribe('Resources Middleware', () => {
 			const App = factory(function App({ middleware: { resource } }) {
 				let error = false;
 				try {
-					const {
-						get,
-						createOptions,
-						template: { read }
-					} = resource.template(undefined);
-					const options = createOptions(testOptionsSetter);
-					get(options(), { read });
+					resource.template(undefined);
 				} catch {
 					error = true;
 				}

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -113,7 +113,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should support passing a template to a widget with the `resource` middleware', () => {
-			const resource = createResourceMiddleware<{ data: TestData }>();
+			const resource = createResourceMiddleware<TestData>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>({
 				idKey: 'value',
@@ -145,7 +145,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should support passing a template to a widget using the template factory', () => {
-			const resource = createResourceMiddleware<{ data: TestData }>();
+			const resource = createResourceMiddleware<TestData>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>('value');
 			const Widget = factory(function App({ properties, middleware: { resource } }) {
@@ -173,7 +173,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should support passing a template to a widget using the short hand', () => {
-			const resource = createResourceMiddleware<{ data: TestData }>();
+			const resource = createResourceMiddleware<TestData>();
 			const factory = create({ resource });
 			const Widget = factory(function App({ properties, middleware: { resource } }) {
 				const {
@@ -197,7 +197,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('should update data when options changed', () => {
-			const factory = create({ resource: createResourceMiddleware<{ data: TestData }>() });
+			const factory = create({ resource: createResourceMiddleware<TestData>() });
 			const Widget = factory(({ properties, middleware: { resource } }) => {
 				const { getOrRead, createOptions } = resource;
 				const {
@@ -235,7 +235,7 @@ jsdomDescribe('Resources Middleware', () => {
 			assert.strictEqual(domNode.innerHTML, '<div><div>[{"value":"2"}]</div><button></button></div>');
 		});
 		it('Should be able to change the options used for a resource', () => {
-			const factory = create({ resource: createResourceMiddleware<{ data: TestData }>() });
+			const factory = create({ resource: createResourceMiddleware<TestData>() });
 			const template = createResourceTemplate<TestData>('value');
 
 			const WidgetOne = factory(({ properties, middleware: { resource } }) => {
@@ -281,7 +281,7 @@ jsdomDescribe('Resources Middleware', () => {
 			assert.strictEqual(root.innerHTML, '<div><button></button><div>[{"value":"0"}]</div></div>');
 		});
 		it('Should transform data using the transform configuration', () => {
-			const resource = createResourceMiddleware<{ data: { id: string } }>();
+			const resource = createResourceMiddleware<{ id: string }>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>({
 				idKey: 'value',
@@ -313,7 +313,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should transform data using the transform configuration with meta getOrRead', () => {
-			const resource = createResourceMiddleware<{ data: { id: string } }>();
+			const resource = createResourceMiddleware<{ id: string }>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>({
 				idKey: 'value',
@@ -345,7 +345,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should transform queries using the transform configuration', () => {
-			const resource = createResourceMiddleware<{ data: { id: string } }>();
+			const resource = createResourceMiddleware<{ id: string }>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>('value');
 			const Widget = factory(function App({ properties, middleware: { resource } }) {
@@ -380,7 +380,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should transform queries using the transform configuration with meta getOrRead', () => {
-			const resource = createResourceMiddleware<{ data: { id: string } }>();
+			const resource = createResourceMiddleware<{ id: string }>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>('value');
 			const Widget = factory(function App({ properties, middleware: { resource } }) {
@@ -415,7 +415,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should by able to filter with transformed data and not transform properties', () => {
-			const factory = create({ resource: createResourceMiddleware<{ data: TestData & { foo?: string } }>() });
+			const factory = create({ resource: createResourceMiddleware<TestData & { foo?: string }>() });
 			const Widget = factory(({ properties, middleware: { resource } }) => {
 				const { getOrRead, createOptions } = resource;
 				const {
@@ -447,7 +447,7 @@ jsdomDescribe('Resources Middleware', () => {
 		});
 		it('Should by able to filter non string values by reference with getOrRead', () => {
 			const root = document.createElement('div');
-			const factory = create({ resource: createResourceMiddleware<{ data: { value: number } }>() });
+			const factory = create({ resource: createResourceMiddleware<{ value: number }>() });
 			const Widget = factory(({ properties, middleware: { resource } }) => {
 				const { getOrRead, createOptions } = resource;
 				const {
@@ -467,7 +467,7 @@ jsdomDescribe('Resources Middleware', () => {
 			assert.strictEqual(root.innerHTML, '<div>[{"value":10}]</div>');
 		});
 		it('Should not call read if the request has been satisfied by one or more request', () => {
-			const resource = createResourceMiddleware<{ data: { value: string } }>();
+			const resource = createResourceMiddleware<{ value: string }>();
 			const factory = create({ resource });
 			const rawTemplate = {
 				idKey: 'value' as const,
@@ -825,7 +825,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should be able to update the data in using a template factory with resource middleware', () => {
-			const factory = create({ resource: createResourceMiddleware<{ data: TestData }>() });
+			const factory = create({ resource: createResourceMiddleware<TestData>() });
 			const template = createResourceTemplate<TestData>('value');
 
 			const WidgetOne = factory(({ properties, middleware: { resource } }) => {
@@ -872,7 +872,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should be able to update the data in using a template factory', () => {
-			const factory = create({ resource: createResourceMiddleware<{ data: TestData }>() });
+			const factory = create({ resource: createResourceMiddleware<TestData>() });
 			const template = createResourceTemplate<TestData>('value');
 
 			const WidgetOne = factory(({ properties, middleware: { resource } }) => {
@@ -913,7 +913,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should be able to update the data in using a shorthand', () => {
-			const factory = create({ resource: createResourceMiddleware<{ data: TestData }>() });
+			const factory = create({ resource: createResourceMiddleware<TestData>() });
 			const WidgetOne = factory(({ properties, middleware: { resource } }) => {
 				const { getOrRead, createOptions } = resource;
 				const {
@@ -954,10 +954,10 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should be able to share resource options across between widgets', () => {
-			const factory = create({ resource: createResourceMiddleware<{ data: TestData }>() });
+			const factory = create({ resource: createResourceMiddleware<TestData>() });
 			const template = createResourceTemplate<TestData>('value');
 
-			const WidgetOne = factory(({ properties, id, middleware: { resource } }) => {
+			const WidgetOne = factory(({ properties, middleware: { resource } }) => {
 				const { createOptions } = resource;
 				const {
 					resource: { options = createOptions(testOptionsSetter) }
@@ -1013,7 +1013,7 @@ jsdomDescribe('Resources Middleware', () => {
 			assert.strictEqual(root.innerHTML, '<div><button></button><div>[{"value":"1"}]</div></div>');
 		});
 		it('Should be able to share search query across widgets', () => {
-			const factory = create({ resource: createResourceMiddleware<{ data: TestData }>() });
+			const factory = create({ resource: createResourceMiddleware<TestData>() });
 			const template = createResourceTemplate<TestData>('value');
 
 			const WidgetOne = factory(({ properties, middleware: { resource } }) => {
@@ -1130,7 +1130,7 @@ jsdomDescribe('Resources Middleware', () => {
 			assert.strictEqual(domNode.innerHTML, '<div>true</div>');
 		});
 		it('Should support passing a template through multiple widgets with the `resource` middleware', () => {
-			const resource = createResourceMiddleware<{ data: TestData }>();
+			const resource = createResourceMiddleware<TestData>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>({
 				idKey: 'value',
@@ -1170,7 +1170,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should support passing a template through multiple widgets using the template factory', () => {
-			const resource = createResourceMiddleware<{ data: TestData }>();
+			const resource = createResourceMiddleware<TestData>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>('value');
 			const Widget = factory(function App({ properties, middleware: { resource } }) {
@@ -1206,9 +1206,9 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should support passing a template through multiple widgets using the short hand', () => {
-			const resource = createResourceMiddleware<{ data: TestData }>();
+			const resource = createResourceMiddleware<TestData>();
 			const factory = create({ resource });
-			const Widget = factory(function App({ properties, middleware: { resource } }) {
+			const Widget = factory(function Widget({ properties, middleware: { resource } }) {
 				const {
 					resource: { template }
 				} = properties();
@@ -1218,7 +1218,7 @@ jsdomDescribe('Resources Middleware', () => {
 				return <div>{JSON.stringify(data)}</div>;
 			});
 
-			const Wrapper = factory(function App({ properties, middleware: { resource } }) {
+			const Wrapper = factory(function Wrapper({ properties, middleware: { resource } }) {
 				const { createOptions } = resource;
 				const {
 					resource: { template, options = createOptions(testOptionsSetter) }
@@ -1538,7 +1538,7 @@ jsdomDescribe('Resources Middleware', () => {
 			assert.strictEqual(domNode.innerHTML, '<div>true</div>');
 		});
 		it('Should transform data using the transform configuration using `get`', () => {
-			const resource = createResourceMiddleware<{ data: { id: string } }>();
+			const resource = createResourceMiddleware<{ id: string }>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>({
 				idKey: 'value',
@@ -1571,7 +1571,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should transform data using the transform configuration with meta `get`', () => {
-			const resource = createResourceMiddleware<{ data: { id: string } }>();
+			const resource = createResourceMiddleware<{ id: string }>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>({
 				idKey: 'value',
@@ -1604,7 +1604,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should transform queries using the transform configuration using `get`', () => {
-			const resource = createResourceMiddleware<{ data: { id: string } }>();
+			const resource = createResourceMiddleware<{ id: string }>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>('value');
 			const Widget = factory(function App({ properties, middleware: { resource } }) {
@@ -1640,7 +1640,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should transform queries using the transform configuration with meta `get`', () => {
-			const resource = createResourceMiddleware<{ data: { id: string } }>();
+			const resource = createResourceMiddleware<{ id: string }>();
 			const factory = create({ resource });
 			const testTemplate = createResourceTemplate<TestData>('value');
 			const Widget = factory(function App({ properties, middleware: { resource } }) {
@@ -1676,7 +1676,7 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 		it('Should by able to filter with transformed data and not transform properties with `get`', () => {
-			const factory = create({ resource: createResourceMiddleware<{ data: TestData & { foo?: string } }>() });
+			const factory = create({ resource: createResourceMiddleware<TestData & { foo?: string }>() });
 			const Widget = factory(({ properties, middleware: { resource } }) => {
 				const { get, getOrRead, createOptions } = resource;
 				const {
@@ -1710,7 +1710,7 @@ jsdomDescribe('Resources Middleware', () => {
 		});
 		it('Should by able to filter non string values by reference with `get`', () => {
 			const root = document.createElement('div');
-			const factory = create({ resource: createResourceMiddleware<{ data: { value: number } }>() });
+			const factory = create({ resource: createResourceMiddleware<{ value: number }>() });
 			const Widget = factory(({ properties, middleware: { resource } }) => {
 				const { get, getOrRead, createOptions } = resource;
 				const {

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -1435,501 +1435,538 @@ jsdomDescribe('Resources Middleware', () => {
 			);
 		});
 	});
-	// describe('get', () => {
-	// 	it('Should return the requested data using `get`', () => {
-	// 		const resource = createResourceMiddleware();
-	// 		const factory = create({ resource });
-	// 		const template = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				let filteredData = [...testData];
-	// 				controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
-	// 			}
-	// 		});
-	// 		const App = factory(function App({ middleware: { resource } }) {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }));
-	// 			const data = get(template, options());
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"}]</div>'
-	// 		);
-	// 	});
-	// 	it('Should return the request data with meta using `get`', () => {
-	// 		const resource = createResourceMiddleware();
-	// 		const factory = create({ resource });
-	// 		const template = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				let filteredData = [...testData];
-	// 				controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
-	// 			}
-	// 		});
-	// 		const App = factory(function App({ middleware: { resource } }) {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }));
-	// 			const data = get(template, options(), true);
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
-	// 		);
-	// 	});
-	// 	it('Should return partial data using `get` when the request is pending', async () => {
-	// 		const resource = createResourceMiddleware();
-	// 		const factory = create({ resource });
-	// 		const template = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				const prom = createPromise();
-	// 				prom.then(() => {
-	// 					let filteredData = [...testData];
-	// 					controls.put(
-	// 						{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
-	// 						req
-	// 					);
-	// 				});
-	// 			}
-	// 		});
-	// 		const App = factory(function App({ middleware: { resource } }) {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }));
-	// 			const data = get(template, options());
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(domNode.innerHTML, '<div>[null,null,null,null,null]</div>');
-	// 		const [prom, res] = promiseArray.pop()!;
-	// 		res();
-	// 		await prom;
-	// 		resolvers.resolveRAF();
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"}]</div>'
-	// 		);
-	// 	});
-	// 	it('Should return partial data with meta using `get` when the request is pending', async () => {
-	// 		const resource = createResourceMiddleware();
-	// 		const factory = create({ resource });
-	// 		const template = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				const prom = createPromise();
-	// 				prom.then(() => {
-	// 					let filteredData = [...testData];
-	// 					controls.put(
-	// 						{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
-	// 						req
-	// 					);
-	// 				});
-	// 			}
-	// 		});
-	// 		const App = factory(function App({ middleware: { resource } }) {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }));
-	// 			const data = get(template, options(), true);
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>{"data":[{"status":"reading"},{"status":"reading"},{"status":"reading"},{"status":"reading"},{"status":"reading"}],"meta":{"status":"reading"}}</div>'
-	// 		);
-	// 		const [prom, res] = promiseArray.pop()!;
-	// 		res();
-	// 		await prom;
-	// 		resolvers.resolveRAF();
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
-	// 		);
-	// 	});
-	// 	it('Should return partial data using `get` when the request is partially pending', async () => {
-	// 		const resource = createResourceMiddleware();
-	// 		const factory = create({ resource });
-	// 		const template = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				if (offset === 0) {
-	// 					let filteredData = [...testData];
-	// 					controls.put(
-	// 						{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
-	// 						req
-	// 					);
-	// 				} else {
-	// 					const prom = createPromise();
-	// 					prom.then(() => {
-	// 						let filteredData = [...testData];
-	// 						controls.put(
-	// 							{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
-	// 							req
-	// 						);
-	// 					});
-	// 				}
-	// 			}
-	// 		});
-	// 		const App = factory(function App({ middleware: { resource } }) {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }));
-	// 			getOrRead(template, options({ page: 2 }));
-	// 			const data = get(template, options({ size: 10, page: 1 }));
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"},null,null,null,null,null]</div>'
-	// 		);
-	// 		const [prom, res] = promiseArray.pop()!;
-	// 		res();
-	// 		await prom;
-	// 		resolvers.resolveRAF();
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"},{"value":"5"},{"value":"6"},{"value":"7"},{"value":"8"},{"value":"9"}]</div>'
-	// 		);
-	// 	});
-	// 	it('Should return partial data with meta using `get` when the request is partially pending', async () => {
-	// 		const resource = createResourceMiddleware();
-	// 		const factory = create({ resource });
-	// 		const template = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				if (offset === 0) {
-	// 					let filteredData = [...testData];
-	// 					controls.put(
-	// 						{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
-	// 						req
-	// 					);
-	// 				} else {
-	// 					const prom = createPromise();
-	// 					prom.then(() => {
-	// 						let filteredData = [...testData];
-	// 						controls.put(
-	// 							{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
-	// 							req
-	// 						);
-	// 					});
-	// 				}
-	// 			}
-	// 		});
-	// 		const App = factory(function App({ middleware: { resource } }) {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }));
-	// 			getOrRead(template, options({ page: 2 }));
-	// 			const data = get(template, options({ size: 10, page: 1 }), true);
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"},{"status":"reading"},{"status":"reading"},{"status":"reading"},{"status":"reading"},{"status":"reading"}],"meta":{"status":"reading","total":200}}</div>'
-	// 		);
-	// 		const [prom, res] = promiseArray.pop()!;
-	// 		res();
-	// 		await prom;
-	// 		resolvers.resolveRAF();
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"},{"value":{"value":"5"},"status":"read"},{"value":{"value":"6"},"status":"read"},{"value":{"value":"7"},"status":"read"},{"value":{"value":"8"},"status":"read"},{"value":{"value":"9"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
-	// 		);
-	// 	});
-	// 	it('Should return partial data using `get` when the request has not been fulfilled', () => {
-	// 		const resource = createResourceMiddleware();
-	// 		const factory = create({ resource });
-	// 		const template = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				let filteredData = [...testData];
-	// 				controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
-	// 			}
-	// 		});
-	// 		const App = factory(function App({ middleware: { resource } }) {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }));
-	// 			const data = get(template, options({ size: 10 }));
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"},null,null,null,null,null]</div>'
-	// 		);
-	// 	});
-	// 	it('Should return partial data with meta using `get` when the request has not been fulfilled', () => {
-	// 		const resource = createResourceMiddleware();
-	// 		const factory = create({ resource });
-	// 		const template = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				let filteredData = [...testData];
-	// 				controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
-	// 			}
-	// 		});
-	// 		const App = factory(function App({ middleware: { resource } }) {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }));
-	// 			const data = get(template, options({ size: 10 }), true);
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"},{"status":"unread"},{"status":"unread"},{"status":"unread"},{"status":"unread"},{"status":"unread"}],"meta":{"status":"unread","total":200}}</div>'
-	// 		);
-	// 	});
-	// 	it('Should throw error if undefined is passed to `get`', () => {
-	// 		const resource = createResourceMiddleware();
-	// 		const factory = create({ resource });
-	// 		const App = factory(function App({ middleware: { resource } }) {
-	// 			const { get, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			let error = false;
-	// 			try {
-	// 				get(undefined, options());
-	// 			} catch {
-	// 				error = true;
-	// 			}
-	// 			return <div>{`${error}`}</div>;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(domNode.innerHTML, '<div>true</div>');
-	// 	});
-	// 	it('Should transform data using the transform configuration using `get`', () => {
-	// 		const resource = createResourceMiddleware<{ id: string }>();
-	// 		const factory = create({ resource });
-	// 		const testTemplate = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				let filteredData = [...testData];
-	// 				controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
-	// 			}
-	// 		});
-	// 		const Widget = factory(function App({ properties, middleware: { resource } }) {
-	// 			const {
-	// 				resource: { template }
-	// 			} = properties();
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }));
-	// 			const data = get(template, options());
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
+	describe('get', () => {
+		it('Should return the requested data using `get`', () => {
+			const resource = createResourceMiddleware();
+			const factory = create({ resource });
+			const template = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					let filteredData = [...testData];
+					controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
+				}
+			});
+			const App = factory(function App({ middleware: { resource } }) {
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read });
+				const data = get(options());
+				return <div>{JSON.stringify(data)}</div>;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"}]</div>'
+			);
+		});
+		it('Should return the request data with meta using `get`', () => {
+			const resource = createResourceMiddleware();
+			const factory = create({ resource });
+			const template = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					let filteredData = [...testData];
+					controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
+				}
+			});
+			const App = factory(function App({ middleware: { resource } }) {
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read });
+				const data = get(options(), { meta: true });
+				return <div>{JSON.stringify(data)}</div>;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
+			);
+		});
+		it('Should return partial data using `get` when the request is pending', async () => {
+			const resource = createResourceMiddleware();
+			const factory = create({ resource });
+			const template = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					const prom = createPromise();
+					prom.then(() => {
+						let filteredData = [...testData];
+						controls.put(
+							{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
+							req
+						);
+					});
+				}
+			});
+			const App = factory(function App({ middleware: { resource } }) {
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read });
+				const data = get(options());
+				return <div>{JSON.stringify(data)}</div>;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(domNode.innerHTML, '<div>[null,null,null,null,null]</div>');
+			const [prom, res] = promiseArray.pop()!;
+			res();
+			await prom;
+			resolvers.resolveRAF();
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"}]</div>'
+			);
+		});
+		it('Should return partial data with meta using `get` when the request is pending', async () => {
+			const resource = createResourceMiddleware();
+			const factory = create({ resource });
+			const template = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					const prom = createPromise();
+					prom.then(() => {
+						let filteredData = [...testData];
+						controls.put(
+							{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
+							req
+						);
+					});
+				}
+			});
+			const App = factory(function App({ middleware: { resource } }) {
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read });
+				const data = get(options(), { meta: true });
+				return <div>{JSON.stringify(data)}</div>;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>{"data":[{"status":"reading"},{"status":"reading"},{"status":"reading"},{"status":"reading"},{"status":"reading"}],"meta":{"status":"reading"}}</div>'
+			);
+			const [prom, res] = promiseArray.pop()!;
+			res();
+			await prom;
+			resolvers.resolveRAF();
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
+			);
+		});
+		it('Should return partial data using `get` when the request is partially pending', async () => {
+			const resource = createResourceMiddleware();
+			const factory = create({ resource });
+			const template = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					if (offset === 0) {
+						let filteredData = [...testData];
+						controls.put(
+							{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
+							req
+						);
+					} else {
+						const prom = createPromise();
+						prom.then(() => {
+							let filteredData = [...testData];
+							controls.put(
+								{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
+								req
+							);
+						});
+					}
+				}
+			});
+			const App = factory(function App({ middleware: { resource } }) {
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read });
+				get(options({ offset: 5 }), { read });
+				const data = get(options({ size: 10, offset: 0 }));
+				return <div>{JSON.stringify(data)}</div>;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"},null,null,null,null,null]</div>'
+			);
+			const [prom, res] = promiseArray.pop()!;
+			res();
+			await prom;
+			resolvers.resolveRAF();
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"},{"value":"5"},{"value":"6"},{"value":"7"},{"value":"8"},{"value":"9"}]</div>'
+			);
+		});
+		it('Should return partial data with meta using `get` when the request is partially pending', async () => {
+			const resource = createResourceMiddleware();
+			const factory = create({ resource });
+			const template = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					if (offset === 0) {
+						let filteredData = [...testData];
+						controls.put(
+							{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
+							req
+						);
+					} else {
+						const prom = createPromise();
+						prom.then(() => {
+							let filteredData = [...testData];
+							controls.put(
+								{ data: filteredData.slice(offset, offset + size), total: filteredData.length },
+								req
+							);
+						});
+					}
+				}
+			});
+			const App = factory(function App({ middleware: { resource } }) {
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read });
+				get(options({ offset: 5 }), { read });
+				const data = get(options({ size: 10, offset: 0 }), { meta: true });
+				return <div>{JSON.stringify(data)}</div>;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"},{"status":"reading"},{"status":"reading"},{"status":"reading"},{"status":"reading"},{"status":"reading"}],"meta":{"status":"reading","total":200}}</div>'
+			);
+			const [prom, res] = promiseArray.pop()!;
+			res();
+			await prom;
+			resolvers.resolveRAF();
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"},{"value":{"value":"5"},"status":"read"},{"value":{"value":"6"},"status":"read"},{"value":{"value":"7"},"status":"read"},{"value":{"value":"8"},"status":"read"},{"value":{"value":"9"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
+			);
+		});
+		it('Should return partial data using `get` when the request has not been fulfilled', () => {
+			const resource = createResourceMiddleware();
+			const factory = create({ resource });
+			const template = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					let filteredData = [...testData];
+					controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
+				}
+			});
+			const App = factory(function App({ middleware: { resource } }) {
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read });
+				const data = get(options({ size: 10 }));
+				return <div>{JSON.stringify(data)}</div>;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>[{"value":"0"},{"value":"1"},{"value":"2"},{"value":"3"},{"value":"4"},null,null,null,null,null]</div>'
+			);
+		});
+		it('Should return partial data with meta using `get` when the request has not been fulfilled', () => {
+			const resource = createResourceMiddleware();
+			const factory = create({ resource });
+			const template = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					let filteredData = [...testData];
+					controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
+				}
+			});
+			const App = factory(function App({ middleware: { resource } }) {
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read });
+				const data = get(options({ size: 10 }), { meta: true });
+				return <div>{JSON.stringify(data)}</div>;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"},{"status":"unread"},{"status":"unread"},{"status":"unread"},{"status":"unread"},{"status":"unread"}],"meta":{"status":"unread","total":200}}</div>'
+			);
+		});
+		it('Should transform data using the transform configuration using `get`', () => {
+			const resource = createResourceMiddleware<{ id: string }>();
+			const factory = create({ resource });
+			const testTemplate = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					let filteredData = [...testData];
+					controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
+				}
+			});
+			const Widget = factory(function App({ properties, middleware: { resource } }) {
+				const {
+					resource: { template }
+				} = properties();
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read });
+				const data = get(options());
+				return <div>{JSON.stringify(data)}</div>;
+			});
 
-	// 		const App = create({ resource: createResourceMiddleware() })(function App({ middleware: { resource } }) {
-	// 			return <Widget resource={resource({ template: testTemplate, transform: { id: 'value' } })} />;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>[{"id":"0"},{"id":"1"},{"id":"2"},{"id":"3"},{"id":"4"}]</div>'
-	// 		);
-	// 	});
-	// 	it('Should transform data using the transform configuration with meta `get`', () => {
-	// 		const resource = createResourceMiddleware<{ id: string }>();
-	// 		const factory = create({ resource });
-	// 		const testTemplate = createResourceTemplate<{ data: TestData; template: { read: (req: any) => void } }>({
-	// 			idKey: 'value',
-	// 			read: (req, controls) => {
-	// 				const { size, offset } = req;
-	// 				let filteredData = [...testData];
-	// 				controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
-	// 			}
-	// 		});
-	// 		const Widget = factory(function App({ properties, middleware: { resource } }) {
-	// 			const {
-	// 				resource: { template }
-	// 			} = properties();
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			get(options(), { read }), true);
-	// 			const data = get(template, options(), true);
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
+			const App = create({ resource: createResourceMiddleware() })(function App({ middleware: { resource } }) {
+				return <Widget resource={resource({ template: testTemplate, transform: { id: 'value' } })} />;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>[{"id":"0"},{"id":"1"},{"id":"2"},{"id":"3"},{"id":"4"}]</div>'
+			);
+		});
+		it('Should transform data using the transform configuration with meta `get`', () => {
+			const resource = createResourceMiddleware<{ id: string }>();
+			const factory = create({ resource });
+			const testTemplate = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					let filteredData = [...testData];
+					controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
+				}
+			});
+			const Widget = factory(function App({ properties, middleware: { resource } }) {
+				const {
+					resource: { template }
+				} = properties();
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options(), { read, meta: true });
+				const data = get(options(), { meta: true });
+				return <div>{JSON.stringify(data)}</div>;
+			});
 
-	// 		const App = create({ resource: createResourceMiddleware() })(function App({ middleware: { resource } }) {
-	// 			return <Widget resource={resource({ template: testTemplate, transform: { id: 'value' } })} />;
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>{"data":[{"value":{"id":"0"},"status":"read"},{"value":{"id":"1"},"status":"read"},{"value":{"id":"2"},"status":"read"},{"value":{"id":"3"},"status":"read"},{"value":{"id":"4"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
-	// 		);
-	// 	});
-	// 	it('Should transform queries using the transform configuration using `get`', () => {
-	// 		const resource = createResourceMiddleware<{ id: string }>();
-	// 		const factory = create({ resource });
-	// 		const testTemplate = createResourceTemplate<TestData>('value');
-	// 		const Widget = factory(function App({ properties, middleware: { resource } }) {
-	// 			const {
-	// 				resource: { template }
-	// 			} = properties();
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			getOrRead(template, options({ query: { id: '1' } }));
-	// 			const data = get(template, options({ query: { id: '1' } }));
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
+			const App = create({ resource: createResourceMiddleware() })(function App({ middleware: { resource } }) {
+				return <Widget resource={resource({ template: testTemplate, transform: { id: 'value' } })} />;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>{"data":[{"value":{"id":"0"},"status":"read"},{"value":{"id":"1"},"status":"read"},{"value":{"id":"2"},"status":"read"},{"value":{"id":"3"},"status":"read"},{"value":{"id":"4"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
+			);
+		});
+		it('Should transform queries using the transform configuration using `get`', () => {
+			const resource = createResourceMiddleware<{ id: string }>();
+			const factory = create({ resource });
+			const testTemplate = createResourceTemplate<TestData>('value');
+			const Widget = factory(function App({ properties, middleware: { resource } }) {
+				const {
+					resource: { template }
+				} = properties();
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options({ query: { id: '1' } }), { read });
+				const data = get(options({ query: { id: '1' } }));
+				return <div>{JSON.stringify(data)}</div>;
+			});
 
-	// 		const App = create({ resource: createResourceMiddleware() })(function App({
-	// 			id,
-	// 			middleware: { resource }
-	// 		}) {
-	// 			return (
-	// 				<Widget
-	// 					resource={resource({
-	// 						template: testTemplate({ id, data: testData }),
-	// 						transform: { id: 'value' }
-	// 					})}
-	// 				/>
-	// 			);
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>[{"id":"1"},{"id":"10"},{"id":"11"},{"id":"12"},{"id":"13"}]</div>'
-	// 		);
-	// 	});
-	// 	it('Should transform queries using the transform configuration with meta `get`', () => {
-	// 		const resource = createResourceMiddleware<{ id: string }>();
-	// 		const factory = create({ resource });
-	// 		const testTemplate = createResourceTemplate<TestData>('value');
-	// 		const Widget = factory(function App({ properties, middleware: { resource } }) {
-	// 			const {
-	// 				resource: { template }
-	// 			} = properties();
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const options = createOptions(testOptionsSetter);
-	// 			getOrRead(template, options({ query: { id: '1' } }), true);
-	// 			const data = get(template, options({ query: { id: '1' } }), true);
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
+			const App = create({ resource: createResourceMiddleware() })(function App({
+				id,
+				middleware: { resource }
+			}) {
+				return (
+					<Widget
+						resource={resource({
+							template: testTemplate({ id, data: testData }),
+							transform: { id: 'value' }
+						})}
+					/>
+				);
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>[{"id":"1"},{"id":"10"},{"id":"11"},{"id":"12"},{"id":"13"}]</div>'
+			);
+		});
+		it('Should transform queries using the transform configuration with meta `get`', () => {
+			const resource = createResourceMiddleware<{ id: string }>();
+			const factory = create({ resource });
+			const testTemplate = createResourceTemplate<TestData>('value');
+			const Widget = factory(function App({ properties, middleware: { resource } }) {
+				const {
+					resource: { template }
+				} = properties();
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				get(options({ query: { id: '1' } }), { meta: true, read });
+				const data = get(options({ query: { id: '1' } }), { meta: true });
+				return <div>{JSON.stringify(data)}</div>;
+			});
 
-	// 		const App = create({ resource: createResourceMiddleware() })(function App({
-	// 			id,
-	// 			middleware: { resource }
-	// 		}) {
-	// 			return (
-	// 				<Widget
-	// 					resource={resource({
-	// 						template: testTemplate({ id, data: testData }),
-	// 						transform: { id: 'value' }
-	// 					})}
-	// 				/>
-	// 			);
-	// 		});
-	// 		const domNode = document.createElement('div');
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(
-	// 			domNode.innerHTML,
-	// 			'<div>{"data":[{"value":{"id":"1"},"status":"read"},{"value":{"id":"10"},"status":"read"},{"value":{"id":"11"},"status":"read"},{"value":{"id":"12"},"status":"read"},{"value":{"id":"13"},"status":"read"}],"meta":{"status":"read","total":119}}</div>'
-	// 		);
-	// 	});
-	// 	it('Should by able to filter with transformed data and not transform properties with `get`', () => {
-	// 		const factory = create({ resource: createResourceMiddleware<TestData & { foo?: string }>() });
-	// 		const Widget = factory(({ properties, middleware: { resource } }) => {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const {
-	// 				resource: { template, options = createOptions(testOptionsSetter) }
-	// 			} = properties();
-	// 			getOrRead(template, options({ query: { value: '2', foo: '1' } }));
-	// 			const data = get(template, options({ query: { value: '2', foo: '1' } }));
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
+			const App = create({ resource: createResourceMiddleware() })(function App({
+				id,
+				middleware: { resource }
+			}) {
+				return (
+					<Widget
+						resource={resource({
+							template: testTemplate({ id, data: testData }),
+							transform: { id: 'value' }
+						})}
+					/>
+				);
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(
+				domNode.innerHTML,
+				'<div>{"data":[{"value":{"id":"1"},"status":"read"},{"value":{"id":"10"},"status":"read"},{"value":{"id":"11"},"status":"read"},{"value":{"id":"12"},"status":"read"},{"value":{"id":"13"},"status":"read"}],"meta":{"status":"read","total":119}}</div>'
+			);
+		});
+		it('Should by able to filter with transformed data and not transform properties with `get`', () => {
+			const factory = create({ resource: createResourceMiddleware<TestData & { foo?: string }>() });
+			const Widget = factory(({ properties, middleware: { resource } }) => {
+				const {
+					resource: { template, options = resource.createOptions(testOptionsSetter) }
+				} = properties();
+				const {
+					get,
+					template: { read }
+				} = resource.template(template);
 
-	// 		const template = createResourceTemplate<{ id: string; foo: string }>('foo');
+				get(options({ query: { value: '2', foo: '1' } }), { read });
+				const data = get(options({ query: { value: '2', foo: '1' } }));
+				return <div>{JSON.stringify(data)}</div>;
+			});
 
-	// 		const App = create({ resource: createResourceMiddleware() })(({ id, middleware: { resource } }) => {
-	// 			return (
-	// 				<Widget
-	// 					resource={resource({
-	// 						transform: { value: 'id' },
-	// 						template: template({
-	// 							id,
-	// 							data: [{ id: '1', foo: '1' }, { id: '2', foo: '1' }, { id: '3', foo: '2' }]
-	// 						})
-	// 					})}
-	// 				/>
-	// 			);
-	// 		});
+			const template = createResourceTemplate<{ id: string; foo: string }>('foo');
 
-	// 		const r = renderer(() => <App />);
-	// 		const domNode = document.createElement('div');
-	// 		r.mount({ domNode });
-	// 		assert.strictEqual(domNode.innerHTML, '<div>[{"value":"2","foo":"1"},null,null,null,null]</div>');
-	// 	});
-	// 	it('Should by able to filter non string values by reference with `get`', () => {
-	// 		const root = document.createElement('div');
-	// 		const factory = create({ resource: createResourceMiddleware<{ value: number }>() });
-	// 		const Widget = factory(({ properties, middleware: { resource } }) => {
-	// 			const { get, getOrRead, createOptions } = resource;
-	// 			const {
-	// 				resource: { template, options = createOptions((curr, next) => ({ ...curr, ...next })) }
-	// 			} = properties();
-	// 			getOrRead(template, options({ query: { value: 10 } }));
-	// 			const data = get(template, options({ query: { value: 10 } }));
-	// 			return <div>{JSON.stringify(data)}</div>;
-	// 		});
+			const App = create({ resource: createResourceMiddleware() })(({ id, middleware: { resource } }) => {
+				return (
+					<Widget
+						resource={resource({
+							transform: { value: 'id' },
+							template: template({
+								id,
+								data: [{ id: '1', foo: '1' }, { id: '2', foo: '1' }, { id: '3', foo: '2' }]
+							})
+						})}
+					/>
+				);
+			});
 
-	// 		const template = createResourceTemplate<{ value: number }>('value');
+			const r = renderer(() => <App />);
+			const domNode = document.createElement('div');
+			r.mount({ domNode });
+			assert.strictEqual(domNode.innerHTML, '<div>[{"value":"2","foo":"1"},null,null,null,null]</div>');
+		});
+		it('Should by able to filter non string values by reference with `get`', () => {
+			const root = document.createElement('div');
+			const factory = create({ resource: createResourceMiddleware<{ value: number }>() });
+			const Widget = factory(({ properties, middleware: { resource } }) => {
+				const {
+					resource: { template, options = resource.createOptions((curr, next) => ({ ...curr, ...next })) }
+				} = properties();
+				const {
+					get,
+					template: { read }
+				} = resource.template(template);
 
-	// 		const App = create({ resource: createResourceMiddleware() })(({ id }) => {
-	// 			return <Widget resource={template({ id, data: [{ value: 10 }, { value: 100 }, { value: 99 }] })} />;
-	// 		});
+				get(options({ query: { value: 10 } }), { read });
+				const data = get(options({ query: { value: 10 } }));
+				return <div>{JSON.stringify(data)}</div>;
+			});
 
-	// 		const r = renderer(() => <App />);
-	// 		r.mount({ domNode: root });
-	// 		assert.strictEqual(
-	// 			root.innerHTML,
-	// 			'<div>[{"value":10},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]</div>'
-	// 		);
-	// 	});
-	// });
+			const template = createResourceTemplate<{ value: number }>('value');
+
+			const App = create({ resource: createResourceMiddleware() })(({ id }) => {
+				return <Widget resource={template({ id, data: [{ value: 10 }, { value: 100 }, { value: 99 }] })} />;
+			});
+
+			const r = renderer(() => <App />);
+			r.mount({ domNode: root });
+			assert.strictEqual(
+				root.innerHTML,
+				'<div>[{"value":10},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]</div>'
+			);
+		});
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Extends dojo resources to support defining and providing custom APIs in a resource template. With additional support for updating/creating data within a resource.

**Creating a template with a custom API**

```tsx
const template = createResourceTemplate<Data, { save: (item: Data) => void }>({
    idKey: 'id',
    save: (item, controls) => {
        controls.push([item]);
    }
});
```

**Create resource middleware that defines a custom API**

```tsx
const resource = createResourceMiddleware<Data, { save: (item: Data) => void }>()
```
