### PR TITLE
Support nested transforms when resources are passed down through multiple widgets

### DIFF
--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -476,7 +476,7 @@ function isResourceWrapper(value: any): value is ResourceWrapper<any, any> {
 
 function transformQuery(query: ReadQuery, transformConfig: TransformConfig<any> | TransformConfig<any>[]): ReadQuery {
 	if (Array.isArray(transformConfig)) {
-		return transformConfig.reduce(
+		return [...transformConfig].reverse().reduce(
 			(query, config) => {
 				return transformQuery(query, config);
 			},

--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -367,13 +367,17 @@ export interface Resource<MIDDLEWARE_DATA = {}> {
 	};
 	<RESOURCE_DATA, MIDDLEWARE_DATA, CUSTOM_API>(
 		options: {
-			template: {
-				template: {
-					template: () => Template<RESOURCE_DATA>;
-					templateOptions?: any;
-					api: CUSTOM_API;
-				};
-			};
+			template:
+				| {
+						template: {
+							template: () => Template<RESOURCE_DATA>;
+							templateOptions?: any;
+							api: CUSTOM_API;
+						};
+				  }
+				| void
+				| undefined
+				| TemplateWrapper<RESOURCE_DATA, CUSTOM_API>;
 			options?: ReadOptions;
 			transform: TransformConfig<MIDDLEWARE_DATA, RESOURCE_DATA>;
 		}
@@ -592,6 +596,8 @@ const middleware = factory(
 
 		const resource = (
 			options:
+				| undefined
+				| void
 				| { template: undefined }
 				| TemplateWrapper<any>
 				| ResourceWrapper<any, any>
@@ -614,7 +620,7 @@ const middleware = factory(
 			transform?: TransformConfig<any, any>;
 			options?: ReadOptions;
 		} => {
-			if (!options.template) {
+			if (!options || !options.template) {
 				throw new Error('Resource cannot be undefined');
 			}
 			if (isTemplateWrapper(options)) {

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -532,13 +532,7 @@ jsdomDescribe('Resources Middleware', () => {
 				const {
 					resource: { template, options = resource.createOptions((curr, next) => ({ ...curr, ...next })) }
 				} = properties();
-				return (
-					<List
-						resource={
-							resource({ template, options, transform: { value: 'id', label: 'desc' } } as any) as any
-						}
-					/>
-				);
+				return <List resource={resource({ template, options, transform: { value: 'id', label: 'desc' } })} />;
 			});
 
 			const template = createResourceTemplate<{ uuid: string; description: string }>('uuid');

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -522,7 +522,7 @@ jsdomDescribe('Resources Middleware', () => {
 					get,
 					template: { read }
 				} = resource.template(template);
-				const items = get(options(), { read }) || [];
+				const items = get(options({ query: { value: 'id' } }), { read }) || [];
 				return <ul>{items.map((item) => <li>{item.label}</li>)}</ul>;
 			});
 
@@ -542,7 +542,10 @@ jsdomDescribe('Resources Middleware', () => {
 					<Widget
 						resource={resource({
 							transform: { id: 'uuid', desc: 'description' },
-							template: template({ data: [{ uuid: 'id', description: 'desc' }], id: '' })
+							template: template({
+								data: [{ uuid: 'id', description: 'desc' }, { uuid: '2', description: 'full' }],
+								id: ''
+							})
 						})}
 					/>
 				);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Resource templates can be passed down through multiple widgets and as such should support multiple transforms required to get to and from the original data shape.
