### PR TITLE
Pass inserted flag correctly to deferred props in test renderers

### DIFF
--- a/src/testing/decorate.ts
+++ b/src/testing/decorate.ts
@@ -34,10 +34,10 @@ function isSameType(expected: DNode | { [index: string]: any }, actual: DNode | 
 	return false;
 }
 
-export function decorateNodes(dNode: DNode[]): DecoratorResult<DNode[]>;
-export function decorateNodes(dNode: DNode): DecoratorResult<DNode>;
-export function decorateNodes(dNode: DNode | DNode[]): DecoratorResult<DNode | DNode[]>;
-export function decorateNodes(dNode: any): DecoratorResult<DNode | DNode[]> {
+export function decorateNodes(dNode: DNode[], isDeferred?: boolean): DecoratorResult<DNode[]>;
+export function decorateNodes(dNode: DNode, isDeferred?: boolean): DecoratorResult<DNode>;
+export function decorateNodes(dNode: DNode | DNode[], isDeferred?: boolean): DecoratorResult<DNode | DNode[]>;
+export function decorateNodes(dNode: any, isDeferred = false): DecoratorResult<DNode | DNode[]> {
 	let hasDeferredProperties = false;
 	function addParent(parent: WNode | VNode): void {
 		(parent.children || []).forEach((child: any) => {
@@ -47,7 +47,7 @@ export function decorateNodes(dNode: any): DecoratorResult<DNode | DNode[]> {
 		});
 		if (isVNode(parent) && typeof parent.deferredPropertiesCallback === 'function') {
 			hasDeferredProperties = true;
-			parent.properties = { ...parent.properties, ...parent.deferredPropertiesCallback(false) };
+			parent.properties = { ...parent.properties, ...parent.deferredPropertiesCallback(isDeferred) };
 		}
 	}
 	const nodes = coreDecorate(

--- a/src/testing/harness/harness.ts
+++ b/src/testing/harness/harness.ts
@@ -224,7 +224,7 @@ export function harness(renderFunc: () => WNode, options: HarnessOptions | Custo
 			_runCompares(nodes);
 			renderStack.push(nodes);
 			if (hasDeferredProperties) {
-				const { nodes: afterDeferredPropertiesNodes } = decorateNodes(render);
+				const { nodes: afterDeferredPropertiesNodes } = decorateNodes(render, true);
 				_runCompares(afterDeferredPropertiesNodes);
 				renderStack.push(afterDeferredPropertiesNodes);
 			}

--- a/src/testing/harness/support/selector.ts
+++ b/src/testing/harness/support/selector.ts
@@ -10,10 +10,10 @@ export interface DecoratorResult<T> {
 	nodes: T;
 }
 
-export function decorateNodes(dNode: DNode[]): DecoratorResult<DNode[]>;
-export function decorateNodes(dNode: DNode): DecoratorResult<DNode>;
-export function decorateNodes(dNode: DNode | DNode[]): DecoratorResult<DNode | DNode[]>;
-export function decorateNodes(dNode: any): DecoratorResult<DNode | DNode[]> {
+export function decorateNodes(dNode: DNode[], isDeferred?: boolean): DecoratorResult<DNode[]>;
+export function decorateNodes(dNode: DNode, isDeferred?: boolean): DecoratorResult<DNode>;
+export function decorateNodes(dNode: DNode | DNode[], isDeferred?: boolean): DecoratorResult<DNode | DNode[]>;
+export function decorateNodes(dNode: any, isDeferred = false): DecoratorResult<DNode | DNode[]> {
 	let hasDeferredProperties = false;
 	function addParent(parent: WNode | VNode): void {
 		(parent.children || []).forEach((child: any) => {
@@ -23,7 +23,7 @@ export function decorateNodes(dNode: any): DecoratorResult<DNode | DNode[]> {
 		});
 		if (isVNode(parent) && typeof parent.deferredPropertiesCallback === 'function') {
 			hasDeferredProperties = true;
-			parent.properties = { ...parent.properties, ...parent.deferredPropertiesCallback(false) };
+			parent.properties = { ...parent.properties, ...parent.deferredPropertiesCallback(isDeferred) };
 		}
 	}
 	const nodes = decorate(dNode, addParent, (node: DNode): node is WNode | VNode => isWNode(node) || isVNode(node));

--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -582,7 +582,7 @@ export function renderer(renderFunc: () => WNode, options: RendererOptions = {})
 		if (invalidated) {
 			let { hasDeferredProperties, nodes } = decorateNodes(render);
 			if (hasDeferredProperties) {
-				nodes = decorateNodes(render).nodes;
+				nodes = decorateNodes(render, true).nodes;
 			}
 			renderResult = nodes;
 			invalidated = false;

--- a/tests/testing/unit/harness/harness.tsx
+++ b/tests/testing/unit/harness/harness.tsx
@@ -404,6 +404,20 @@ describe('harness', () => {
 			);
 		});
 
+		it('should resolve deferred properties', () => {
+			const factory = create();
+			const Widget = factory(function Widget() {
+				return v('div', (inserted) => {
+					if (inserted) {
+						return { def: 'true' };
+					}
+					return {};
+				});
+			});
+			const h = harness(() => <Widget />);
+			h.expect(() => <div def="true" />);
+		});
+
 		it('custom compare for registry item WNode', () => {
 			const h = harness(() => w(MyWidget, {}), [
 				{

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -580,6 +580,20 @@ describe('test renderer', () => {
 			r.expect(assertion(() => w(Bar, { foo, bar })));
 		});
 
+		it('should resolve deferred properties', () => {
+			const factory = create();
+			const Widget = factory(function Widget() {
+				return v('div', (inserted) => {
+					if (inserted) {
+						return { def: 'true' };
+					}
+					return {};
+				});
+			});
+			const r = renderer(() => <Widget />);
+			r.expect(assertion(() => <div def="true" />));
+		});
+
 		it('should throw error if wrapped test node is used more than once', () => {
 			const factory = create();
 			const WrappedSpan = wrap('span');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

For deferred properties the renderers resolve to the "final", i.e. run the deferred properties twice but it doesn't pass the inserted flag correctly.

This passes the inserted flag as true for the second process.