### PR TITLE
Resources: Fix getting for an unknown id

### DIFF
--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -808,9 +808,11 @@ const middleware = factory(
 				if (Array.isArray(request)) {
 					return request.map((id) => {
 						const [synthId] = cache.getSyntheticIds(id);
-						const item = cache.get(synthId);
-						if (item) {
-							return item.value;
+						if (synthId) {
+							const item = cache.get(synthId);
+							if (item) {
+								return item.value;
+							}
 						}
 					});
 				}

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -1479,7 +1479,7 @@ jsdomDescribe('Resources Middleware', () => {
 				'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
 			);
 		});
-		it('Should be able to get a single resource using get', () => {
+		it('Should be able to `get` a resource by id', () => {
 			const resource = createResourceMiddleware();
 			const factory = create({ resource });
 			const template = createResourceTemplate<TestData>({

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -1479,6 +1479,37 @@ jsdomDescribe('Resources Middleware', () => {
 				'<div>{"data":[{"value":{"value":"0"},"status":"read"},{"value":{"value":"1"},"status":"read"},{"value":{"value":"2"},"status":"read"},{"value":{"value":"3"},"status":"read"},{"value":{"value":"4"},"status":"read"}],"meta":{"status":"read","total":200}}</div>'
 			);
 		});
+		it('Should be able to get a single resource using get', () => {
+			const resource = createResourceMiddleware();
+			const factory = create({ resource });
+			const template = createResourceTemplate<TestData>({
+				idKey: 'value',
+				read: (req, controls) => {
+					const { size, offset } = req;
+					let filteredData = [...testData];
+					controls.put({ data: filteredData.slice(offset, offset + size), total: filteredData.length }, req);
+				}
+			});
+			const App = factory(function App({ middleware: { resource } }) {
+				const {
+					get,
+					createOptions,
+					template: { read }
+				} = resource.template(template);
+				const options = createOptions(testOptionsSetter);
+				let [item] = get(['3']);
+				if (!item) {
+					get(options(), { read });
+					[item] = get(['3']);
+				}
+
+				return <div>{JSON.stringify(item)}</div>;
+			});
+			const domNode = document.createElement('div');
+			const r = renderer(() => <App />);
+			r.mount({ domNode });
+			assert.strictEqual(domNode.innerHTML, '<div>{"value":"3"}</div>');
+		});
 		it('Should return partial data using `get` when the request is pending', async () => {
 			const resource = createResourceMiddleware();
 			const factory = create({ resource });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fixes an error that occurs if get is used for an id that doesn't exist in the resource cache.