### PR TITLE
Make inputs partially only controlled

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -1679,13 +1679,13 @@ export function renderer(renderer: () => RenderResult): Renderer {
 		const domValue = _mountOptions.nodeApi.getProperty(domNode, 'value');
 		const onInputValue = _mountOptions.nodeApi.getProperty(domNode, 'oninput-value');
 		const onSelectValue = _mountOptions.nodeApi.getProperty(domNode, 'select-value');
-
+		const valueChanged = domValue !== propValue;
 		if (onSelectValue && domValue !== onSelectValue) {
 			_mountOptions.nodeApi.setProperty(domNode, 'value', onSelectValue);
 			if (domValue === onSelectValue) {
 				_mountOptions.nodeApi.setProperty(domNode, 'select-value', undefined);
 			}
-		} else if ((onInputValue && domValue === onInputValue) || propValue !== previousValue) {
+		} else if (valueChanged && ((onInputValue && domValue === onInputValue) || propValue !== previousValue)) {
 			_mountOptions.nodeApi.setProperty(domNode, 'value', propValue);
 			_mountOptions.nodeApi.setProperty(domNode, 'oninput-value', undefined);
 		}

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -5618,6 +5618,21 @@ jsdomDescribe('vdom', () => {
 			assert.strictEqual(root.value, typedKeys);
 		});
 
+		it('does not set value on dom node if the value property matches', () => {
+			const input = document.createElement('input');
+			const setStub = stub();
+			Object.defineProperty(input, 'value', {
+				get() {
+					return 'test';
+				},
+				set: setStub
+			});
+			const r = renderer(() => <div>{d({ node: input, props: { value: 'test' } })}</div>);
+			const div = document.createElement('div');
+			r.mount({ domNode: div });
+			assert.strictEqual(setStub.callCount, 0);
+		});
+
 		it('does not clear a value that was set by a testing tool which manipulates input.value directly', () => {
 			let typedKeys = '';
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changing how vdom work when setting values on an `input` element. This is to resolve an issue with Safari that jumps the caret to the end of the input when updating the value.

Resolves #886 
