### PR TITLE
Only run the inert middleware when the properties have been changed

### DIFF
--- a/src/core/middleware/inert.ts
+++ b/src/core/middleware/inert.ts
@@ -35,7 +35,7 @@ export const inert = factory(({ middleware: { node, destroy, icache } }) => {
 			if (previousSettings && enable === previousSettings.enable && invert === previousSettings.invert) {
 				return;
 			}
-
+			icache.set(key, { enable, invert });
 			if (invert) {
 				const inertNodes = inertInvertedNodeMap.get(key) || [];
 				if (enable) {

--- a/tests/core/unit/middleware/inert.ts
+++ b/tests/core/unit/middleware/inert.ts
@@ -1,21 +1,37 @@
 import global from '../../../../src/shim/global';
-const { it } = intern.getInterface('bdd');
+const { it, beforeEach } = intern.getInterface('bdd');
 const { describe: jsdomDescribe } = intern.getPlugin('jsdom');
 const { assert } = intern.getPlugin('chai');
-import { sandbox } from 'sinon';
+import { stub } from 'sinon';
 
+import icacheMiddleware from '../../../../src/core/middleware/icache';
 import inertMiddleware from '../../../../src/core/middleware/inert';
 
-const sb = sandbox.create();
+let invalidatorStub = stub();
 
 jsdomDescribe('inert middleware', () => {
+	let icache = icacheMiddleware().callback({
+		properties: () => ({}),
+		children: () => [],
+		id: 'test-cache',
+		middleware: { invalidator: invalidatorStub, destroy: stub() }
+	});
+	beforeEach(() => {
+		icache = icacheMiddleware().callback({
+			properties: () => ({}),
+			children: () => [],
+			id: 'test-cache',
+			middleware: { invalidator: invalidatorStub, destroy: stub() }
+		});
+	});
 	it('should set node inert property', () => {
 		const node = global.document.createElement('div');
 
 		const inert = inertMiddleware().callback({
 			id: 'test',
 			middleware: {
-				destroy: sb.stub(),
+				icache,
+				destroy: stub(),
 				node: {
 					get() {
 						return node;
@@ -45,7 +61,8 @@ jsdomDescribe('inert middleware', () => {
 		const inert = inertMiddleware().callback({
 			id: 'test',
 			middleware: {
-				destroy: sb.stub(),
+				icache,
+				destroy: stub(),
 				node: {
 					get() {
 						return node;
@@ -77,11 +94,12 @@ jsdomDescribe('inert middleware', () => {
 		parent.appendChild(childTwo);
 		parent.appendChild(childThree);
 		parent.appendChild(node);
-		const destroyStub = sb.stub();
+		const destroyStub = stub();
 
 		const inert = inertMiddleware().callback({
 			id: 'test',
 			middleware: {
+				icache,
 				destroy: destroyStub,
 				node: {
 					get() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This only adds/removes the inert properties to the node when the options have changed when calling the middleware