### PR TITLE
Resources: Deal with inferring resource types from widgets with custom properties

### DIFF
--- a/src/core/middleware/resources.ts
+++ b/src/core/middleware/resources.ts
@@ -245,20 +245,16 @@ type WidgetFactory<T extends WNodeFactoryTypes> =
 	| WNodeFactory<T>
 	| OptionalWNodeFactory<T>;
 
-type WidgetResourceData<W extends WidgetFactory<any>> = W extends WidgetFactory<
-	WNodeFactoryTypes<ResourceProperties<infer D, any>>
->
-	? D
+type WidgetResourceData<W extends WidgetFactory<any>> = W extends WidgetFactory<WNodeFactoryTypes<infer P>>
+	? P extends ResourceProperties<infer D, any> ? D : void
 	: void;
-type WidgetResourceApi<W extends WidgetFactory<any>> = W extends WidgetFactory<
-	WNodeFactoryTypes<ResourceProperties<infer D, infer R>>
->
-	? R extends CustomTemplate ? R : DefaultApi
+type WidgetResourceApi<W extends WidgetFactory<any>> = W extends WidgetFactory<WNodeFactoryTypes<infer P>>
+	? P extends ResourceProperties<any, infer R> ? (R extends CustomTemplate ? R : DefaultApi) : DefaultApi
 	: DefaultApi;
-type WidgetResourceTemplateApi<W extends WidgetFactory<any>> = W extends WidgetFactory<
-	WNodeFactoryTypes<ResourceProperties<infer D, infer R>>
->
-	? R extends CustomTemplate ? CustomTemplateApi<R, D> : CustomTemplateApi<DefaultApi, D>
+type WidgetResourceTemplateApi<W extends WidgetFactory<any>> = W extends WidgetFactory<WNodeFactoryTypes<infer P>>
+	? P extends ResourceProperties<infer D, infer R>
+		? R extends CustomTemplate ? CustomTemplateApi<R, D> : CustomTemplateApi<DefaultApi, D>
+		: CustomTemplateApi<DefaultApi, WidgetResourceData<W>>
 	: CustomTemplateApi<DefaultApi, WidgetResourceData<W>>;
 
 export function createResourceTemplate<

--- a/tests/core/unit/middleware/resources.tsx
+++ b/tests/core/unit/middleware/resources.tsx
@@ -237,7 +237,7 @@ jsdomDescribe('Resources Middleware', () => {
 
 		it('Should be able to infer the resource data from widget', () => {
 			const resource = createResourceMiddleware<TestData>();
-			const factory = create({ resource });
+			const factory = create({ resource }).properties<{ foo?: string }>();
 			const Widget = factory(function App({ properties, middleware: { resource } }) {
 				const {
 					resource: { template }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The types for inferring the resource data and api types worked well with widgets that did not have properties (like all the tests) but did not work properly for widgets that had custom properties defined (most widgets)
