### PR TITLE
Take in to account virtual nodes when hydrating an existing DOM structure

### DIFF
--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -152,13 +152,13 @@ export interface BaseNodeWrapper {
 	parentId: string;
 	childDomWrapperId?: string;
 	reparent?: string;
+	mergeNodes?: Node[];
 }
 
 export interface WNodeWrapper extends BaseNodeWrapper {
 	node: WNode<any>;
 	keys?: string[];
 	instance?: any;
-	mergeNodes?: Node[];
 	nodeHandlerCalled?: boolean;
 	registryItem?: Callback<any, any, any, RenderResult> | Constructor<any> | null;
 	properties: any;
@@ -2128,7 +2128,7 @@ export function renderer(renderer: () => RenderResult): Renderer {
 	function _processMergeNodes(next: DNodeWrapper, mergeNodes: Node[]) {
 		const { merge } = _mountOptions;
 		if (merge && mergeNodes.length) {
-			if (isVNodeWrapper(next)) {
+			if (isVNodeWrapper(next) && !isVirtualWrapper(next)) {
 				let {
 					node: { tag }
 				} = next;
@@ -2645,6 +2645,9 @@ export function renderer(renderer: () => RenderResult): Renderer {
 				if (parentDomNode === _allMergedNodes[0].parentNode) {
 					_insertBeforeMap.set(next, _allMergedNodes[0]);
 				}
+			}
+			if (isVirtualWrapper(next)) {
+				mergeNodes = next.mergeNodes || [];
 			}
 		} else if (_mountOptions.merge) {
 			next.merged = true;

--- a/tests/core/unit/vdom.tsx
+++ b/tests/core/unit/vdom.tsx
@@ -7468,7 +7468,7 @@ jsdomDescribe('vdom', () => {
 			const secondText = secondSpan.childNodes[0] as Text;
 			class App extends WidgetBase {
 				render() {
-					return v('div', [v('span', ['hello']), v('span', ['tests'])]);
+					return v('div', [v('virtual', [v('span', ['hello']), v('span', ['tests'])])]);
 				}
 			}
 			const r = renderer(() => w(App, {}));


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Virtual nodes should be treated the same as widgets when it comes to hydrating an existing DOM node structure. This means passing the merge node candidates down to when a virtual node is met.

