### PR TITLE
Support testing widgets with nested typed children

### DIFF
--- a/src/testing/renderer.ts
+++ b/src/testing/renderer.ts
@@ -49,8 +49,8 @@ export function isChildFunctionInstruction(value: any): value is ChildFunctionIn
 export type Instruction = ChildFunctionInstruction | ChildInstruction | PropertyInstruction;
 
 export type TransformedChildren<P> = P extends (...args: any[]) => any
-	? RenderResult
-	: { [K in keyof P]: TransformedChildren<P[K]> };
+	? Parameters<P>
+	: { [K in keyof P]: P[K] extends RenderResult ? never : Partial<TransformedChildren<P[K]>> };
 
 export interface Child {
 	<T extends WNodeFactory<{ properties: any; children: any }>>(
@@ -66,7 +66,7 @@ export interface Child {
 	<T extends WNodeFactory<{ properties: any; children: any }>>(
 		wrapped: Wrapped<T>,
 		childFactory: T['children'] extends { [index: string]: any }
-			? (children: T['children']) => TransformedChildren<T['children']>
+			? (params: <T>(args: T) => T) => TransformedChildren<T['children']>
 			: never
 	): void;
 }

--- a/tests/testing/unit/assertRender.tsx
+++ b/tests/testing/unit/assertRender.tsx
@@ -81,22 +81,22 @@ function getExpectedError() {
 (A)	>
 (A)	</${mockWidgetName}>
 (A)	<${widgetWithChildrenName}>
-(A)		{
-(A)			content: (
+(A)		{{
+(A)			"content": (
 (A)				<div>
 (A)					<span>
 (A)						Child
 (A)					</span>
 (A)				</div>
 (A)			),
-(A)			other: (
+(A)			"other": (
 (A)				<div>
 (A)					<span>
 (A)						Other
 (A)					</span>
 (A)				</div>
 (A)			)
-(A)		}
+(A)		}}
 (A)	</${widgetWithChildrenName}>
 </div>`;
 }

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -432,6 +432,53 @@ describe('test renderer', () => {
 			});
 		});
 
+		it('resolve nested children', () => {
+			interface Cells {
+				foo: RenderResult;
+			}
+			interface Children {
+				cells: Cells;
+			}
+
+			const childFunctionFactory = create().children<Children>();
+
+			const Child = childFunctionFactory(function ChildFunctionWidget() {
+				return '';
+			});
+
+			const factory = create();
+
+			const MyWidget = factory(function MyWidget() {
+				return (
+					<div>
+						<Child>
+							{{
+								cells: {
+									foo: <div>foo</div>
+								}
+							}}
+						</Child>
+					</div>
+				);
+			});
+
+			const r = renderer(() => <MyWidget />);
+
+			const expected = assertion(() => (
+				<div>
+					<Child>
+						{{
+							cells: {
+								foo: <div>foo</div>
+							}
+						}}
+					</Child>
+				</div>
+			));
+
+			r.expect(expected);
+		});
+
 		it('should selectively named children functions but resolve assert all children', () => {
 			const factory = create({ icache });
 

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -482,6 +482,8 @@ describe('test renderer', () => {
 		it('resolve nested functional children', () => {
 			interface Cells {
 				foo: (text: string) => RenderResult;
+				other: (text: string) => RenderResult;
+				boo: RenderResult;
 			}
 			interface Children {
 				cells: Cells;
@@ -503,7 +505,9 @@ describe('test renderer', () => {
 						<Child>
 							{{
 								cells: {
-									foo: (text) => <div>{text}</div>
+									foo: (text) => <div>{text}</div>,
+									other: (text) => <div>{text}</div>,
+									boo: <div>boo</div>
 								}
 							}}
 						</Child>
@@ -513,10 +517,10 @@ describe('test renderer', () => {
 
 			const r = renderer(() => <MyWidget />);
 
-			r.child(WrappedChild, (children) => {
+			r.child(WrappedChild, (params) => {
 				return {
 					cells: {
-						foo: children.cells.foo('foo')
+						foo: params(['foo'])
 					}
 				};
 			});
@@ -526,7 +530,9 @@ describe('test renderer', () => {
 					<WrappedChild>
 						{{
 							cells: {
-								foo: () => <div>foo</div>
+								foo: () => <div>foo</div>,
+								other: (text) => <div>{text}</div>,
+								boo: <div>boo</div>
 							}
 						}}
 					</WrappedChild>

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -479,6 +479,62 @@ describe('test renderer', () => {
 			r.expect(expected);
 		});
 
+		it('resolve nested functional children', () => {
+			interface Cells {
+				foo: (text: string) => RenderResult;
+			}
+			interface Children {
+				cells: Cells;
+			}
+
+			const childFunctionFactory = create().children<Children>();
+
+			const Child = childFunctionFactory(function ChildFunctionWidget() {
+				return '';
+			});
+
+			const WrappedChild = wrap(Child);
+
+			const factory = create();
+
+			const MyWidget = factory(function MyWidget() {
+				return (
+					<div>
+						<Child>
+							{{
+								cells: {
+									foo: (text) => <div>{text}</div>
+								}
+							}}
+						</Child>
+					</div>
+				);
+			});
+
+			const r = renderer(() => <MyWidget />);
+
+			r.child(WrappedChild, (children) => {
+				return {
+					cells: {
+						foo: children.cells.foo('foo')
+					}
+				};
+			});
+
+			const expected = assertion(() => (
+				<div>
+					<WrappedChild>
+						{{
+							cells: {
+								foo: () => <div>foo</div>
+							}
+						}}
+					</WrappedChild>
+				</div>
+			));
+			r.expect(expected);
+		});
+
 		it('should selectively named children functions but resolve assert all children', () => {
 			const factory = create({ icache });
 

--- a/tests/testing/unit/renderer.tsx
+++ b/tests/testing/unit/renderer.tsx
@@ -483,7 +483,11 @@ describe('test renderer', () => {
 			interface Cells {
 				foo: (text: string) => RenderResult;
 				other: (text: string) => RenderResult;
-				boo: RenderResult;
+				bar: RenderResult;
+				nested: {
+					foo: (text: number) => RenderResult;
+					bar: RenderResult;
+				};
 			}
 			interface Children {
 				cells: Cells;
@@ -507,7 +511,11 @@ describe('test renderer', () => {
 								cells: {
 									foo: (text) => <div>{text}</div>,
 									other: (text) => <div>{text}</div>,
-									boo: <div>boo</div>
+									bar: <div>boo</div>,
+									nested: {
+										foo: (num) => <div>{`${num}`}</div>,
+										bar: <div>boo</div>
+									}
 								}
 							}}
 						</Child>
@@ -520,7 +528,11 @@ describe('test renderer', () => {
 			r.child(WrappedChild, (params) => {
 				return {
 					cells: {
-						foo: params(['foo'])
+						foo: params(['foo']),
+						other: params(['1']),
+						nested: {
+							foo: params([1])
+						}
 					}
 				};
 			});
@@ -531,8 +543,12 @@ describe('test renderer', () => {
 						{{
 							cells: {
 								foo: () => <div>foo</div>,
-								other: (text) => <div>{text}</div>,
-								boo: <div>boo</div>
+								other: () => <div>1</div>,
+								bar: <div>boo</div>,
+								nested: {
+									foo: () => <div>1</div>,
+									bar: <div>boo</div>
+								}
 							}
 						}}
 					</WrappedChild>


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Provides an API to support testing widgets with complex, nested typed children, for example: 

```tsx
interface TypedChildren {
    headers: {
        headerA: (value: string, num: number) => RenderResult    
    },
    cells: {
        columnA: (value: string) => RenderResult
    },
    footer: RenderResult
}
```

Currently the test renderer's `child` API enables consumers to instruct the renderer to resolve children to one level, `renderer.child(WrappedWidget, 'child', 'params', 'for', 'renderer');` this change adds an additional overload that enables users to provide params to resolve multiple children, including nested children. The function is typed to require all functional children to have params returned and the params are typed for the functional child. Using the example child interface above, this would look like:

```tsx
renderer.child(WrappedWidget, (params) => {
    return {
        headers: {
            headerA: params(['text', 12345])
        },
        cells: {
            columnA: params(['text'])
        }
    };
}); 
```

**Note:** The `params` function was required for typings, otherwise the parameters for the functions were typed as tuples not arrays so need explicit casting i.e. `['text'] as [string]` - using an injected function seemed to be a more user friendly approach.

Includes fixes required for parsing nested children in `assertRender`

Resolves #897 
