### PR TITLE
Redirect should use replace path not set path

### DIFF
--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -365,7 +365,7 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 				Object.keys(params).forEach((paramKey) => {
 					redirect = redirect.replace(`{${paramKey}}`, params[paramKey]);
 				});
-				this.setPath(redirect);
+				this.replacePath(redirect);
 				return;
 			}
 			if (matchedRoute.type === 'partial') {

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -711,7 +711,6 @@ describe('Router', () => {
 						defaultParams: {
 							param: 'default-param'
 						},
-						defaultRoute: true,
 						children: [
 							{
 								path: 'bar',
@@ -723,8 +722,14 @@ describe('Router', () => {
 				],
 				{ HistoryManager }
 			);
+
+			const setPathSpy = sinon.spy(router, 'setPath');
+			const replacePathSpy = sinon.spy(router, 'replacePath');
+			router.setPath('foo/param');
+			assert.isTrue(setPathSpy.calledOnce);
 			const contextMap = router.getOutlet('bar');
 			assert.isOk(contextMap);
+			assert.isTrue(replacePathSpy.calledOnce);
 			assert.strictEqual(contextMap!.size, 1);
 		});
 	});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The redirect option on the routing configuration should replace the path instead of setting it otherwise the back browser controls won't work as expected.
