### PR TITLE
Support optional query params in routing configuration

### DIFF
--- a/docs/en/routing/introduction.md
+++ b/docs/en/routing/introduction.md
@@ -177,6 +177,24 @@ export default factory(function App() {
 
 If the browser is pointed to the URL path `/home/page?queryOne=modern&queryTwo=dojo`, then the query parameters are injected into the matching `Route`'s `renderer` method as an object of type `MatchDetails` and accessed via that object's `queryParams` property. Using this URL, the page would show "Hello modern-dojo". If a query parameter is not provided, then its value will be set to `undefined`.
 
+### Optional query parameters
+
+Path parameters are always required as they are part of the routes path, however query params can sometimes be optional. To define an optional query parameter add a `?` before the closing brace of the query param. This instructs the router to be able to generate links even when no value for this param has been provided.
+
+> src/routes.ts
+
+```tsx
+export default [
+	{
+		id: 'home',
+		path: 'home?{page?}',
+		outlet: 'home'
+	}
+];
+```
+
+In the example, `page` is now optional meaning that the router can generate a link without the page value and the query param will simply not be added to the URL.
+
 ### Default route and parameters
 
 -   Specify a default route by updating the routing configuration to include `defaultRoute: true` for the preferred route. The default route is used to redirect the application on initial load if no route has been provided or the requested route has not been registered.

--- a/src/routing/Router.ts
+++ b/src/routing/Router.ts
@@ -118,7 +118,6 @@ export class Router extends Evented<{ nav: NavEvent; route: RouteEvent; outlet: 
 	 * @param params Optional Params for the generated link
 	 */
 	public link(outlet: string, params: Params = {}): string | undefined {
-		debugger;
 		let route = this._routeMap[outlet];
 		if (route === undefined) {
 			return;

--- a/src/routing/interfaces.d.ts
+++ b/src/routing/interfaces.d.ts
@@ -22,7 +22,10 @@ export interface Route {
 	redirect?: string;
 	fullPath: string;
 	fullParams: string[];
-	fullQueryParams: string[];
+	fullQueryParams: {
+		param: string;
+		optional: boolean;
+	}[];
 	defaultParams: Params;
 	score: number;
 }

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -6,6 +6,7 @@ import * as sinon from 'sinon';
 import global from '../../../src/shim/global';
 import { Router } from '../../../src/routing/Router';
 import { MemoryHistory as HistoryManager } from '../../../src/routing/history/MemoryHistory';
+import { RouteConfig } from '../../../src/routing/interfaces';
 
 const routeConfig = [
 	{
@@ -105,7 +106,7 @@ const routeWithChildrenAndMultipleParams = [
 	}
 ];
 
-const routeConfigWithParamsAndQueryParams = [
+const routeConfigWithParamsAndQueryParams: RouteConfig[] = [
 	{
 		path: '/foo/{foo}?{fooQuery}',
 		outlet: 'foo',
@@ -122,6 +123,14 @@ const routeConfigWithParamsAndQueryParams = [
 				defaultParams: {
 					bar: 'bar',
 					barQuery: 'barQuery'
+				}
+			},
+			{
+				path: '/bar/{bar}?{barQuery}&{optionalQuery?}',
+				outlet: 'bar',
+				id: 'qux',
+				defaultParams: {
+					bar: 'bar'
 				}
 			}
 		]
@@ -606,6 +615,28 @@ describe('Router', () => {
 		const router = new Router(routeConfigDefaultRoute, { HistoryManager });
 		const link = router.link('unknown');
 		assert.isUndefined(link);
+	});
+
+	it('Cannot generate link when missing required query params', () => {
+		const router = new Router(routeConfigWithParamsAndQueryParams, { HistoryManager });
+		assert.strictEqual(
+			router.link('qux', {
+				foo: 'qux',
+				bar: 'baz',
+				fooQuery: 'quxQuery',
+				barQuery: 'barQuery',
+				optionalQuery: 'optional'
+			}),
+			'foo/qux/bar/baz?fooQuery=quxQuery&barQuery=barQuery&optionalQuery=optional'
+		);
+		assert.isUndefined(
+			router.link('qux', {
+				foo: 'qux',
+				bar: 'baz',
+				fooQuery: 'quxQuery',
+				optionalQuery: 'optional'
+			})
+		);
 	});
 
 	it('The router will not start automatically if autostart is set to false', () => {

--- a/tests/routing/unit/Router.ts
+++ b/tests/routing/unit/Router.ts
@@ -116,7 +116,7 @@ const routeConfigWithParamsAndQueryParams = [
 		},
 		children: [
 			{
-				path: '/bar/{bar}?{barQuery}',
+				path: '/bar/{bar}?{barQuery}&{optionalQuery?}',
 				outlet: 'bar',
 				id: 'bar',
 				defaultParams: {
@@ -578,6 +578,8 @@ describe('Router', () => {
 		router.setPath('foo/bar/bar/foo?fooQuery=bar&barQuery=foo');
 		assert.strictEqual(router.link('foo'), 'foo/bar?fooQuery=bar');
 		assert.strictEqual(router.link('bar'), 'foo/bar/bar/foo?fooQuery=bar&barQuery=foo');
+		router.setPath('foo/bar/bar/foo?fooQuery=bar&barQuery=foo&optionalQuery=optional');
+		assert.strictEqual(router.link('bar'), 'foo/bar/bar/foo?fooQuery=bar&barQuery=foo&optionalQuery=optional');
 	});
 
 	it('Should create link with params and query params with specified params', () => {
@@ -586,6 +588,17 @@ describe('Router', () => {
 		assert.strictEqual(
 			router.link('bar', { foo: 'qux', bar: 'baz', fooQuery: 'quxQuery', barQuery: 'bazQuery' }),
 			'foo/qux/bar/baz?fooQuery=quxQuery&barQuery=bazQuery'
+		);
+		assert.strictEqual(router.link('foo', { foo: 'qux', fooQuery: 'quxQuery' }), 'foo/qux?fooQuery=quxQuery');
+		assert.strictEqual(
+			router.link('bar', {
+				foo: 'qux',
+				bar: 'baz',
+				fooQuery: 'quxQuery',
+				barQuery: 'bazQuery',
+				optionalQuery: 'optional'
+			}),
+			'foo/qux/bar/baz?fooQuery=quxQuery&barQuery=bazQuery&optionalQuery=optional'
 		);
 	});
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

At the moment all query params defined in the routing configuration are considered mandatory, however there are times where a query params is optional but still need the router to generate the link correctly (depending on if the optional query param value is passed).

This changes adds a new `?` indicator if a query param is to be considered optional:

```tsx
{
    path: 'my/routes/path?{requiredQueryParam}&{optionalQueryParam?}'
}
```

The `?` before the closing brace tells the router that the param is not required.

Resolves #508 
