### PR TITLE
Link: Always pass the target attribute regardless of whether the event is intercepted

### DIFF
--- a/src/routing/Link.ts
+++ b/src/routing/Link.ts
@@ -17,7 +17,7 @@ export interface LinkProperties extends VNodeProperties {
 const factory = create({ injector }).properties<LinkProperties>();
 
 export const Link = factory(function Link({ middleware: { injector }, properties, children }) {
-	let { routerKey = 'router', to, isOutlet = true, target, params = {}, onClick, ...props } = properties();
+	let { routerKey = 'router', to, isOutlet = true, params = {}, onClick, ...props } = properties();
 	const router = injector.get<Router>(routerKey);
 	let href: string | undefined = to;
 
@@ -29,7 +29,13 @@ export const Link = factory(function Link({ middleware: { injector }, properties
 		const onclick = (event: MouseEvent) => {
 			onClick && onClick(event);
 
-			if (!event.defaultPrevented && event.button === 0 && !event.metaKey && !event.ctrlKey && !target) {
+			if (
+				!event.defaultPrevented &&
+				event.button === 0 &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!linkProps.target
+			) {
 				if (!has('build-serve') || !has('build-time-rendered')) {
 					event.preventDefault();
 					href !== undefined && router.setPath(href);

--- a/tests/routing/unit/Link.ts
+++ b/tests/routing/unit/Link.ts
@@ -129,7 +129,7 @@ describe('Link', () => {
 		const r = renderer(() => w(Link, { to: 'foo', target: '_blank' }), {
 			middleware: [[getRegistry, mockGetRegistry]]
 		});
-		const template = assertion(() => v(WrappedAnchor.tag, { href: 'foo', onclick: noop }));
+		const template = assertion(() => v(WrappedAnchor.tag, { href: 'foo', onclick: noop, target: '_blank' }));
 		r.expect(template);
 		r.property(WrappedAnchor, 'onclick', createMockEvent());
 		r.expect(template);
@@ -189,5 +189,16 @@ describe('Link', () => {
 		} catch (err) {
 			// nothing to see here
 		}
+	});
+
+	it('does pass target through to element', () => {
+		const WrappedAnchor = wrap('a');
+		const r = renderer(() => w(Link, { to: '#foo/static', isOutlet: false, target: '_blank' }), {
+			middleware: [[getRegistry, mockGetRegistry]]
+		});
+		const template = assertion(() =>
+			v(WrappedAnchor.tag, { href: '#foo/static', onclick: noop, target: '_blank' })
+		);
+		r.expect(template);
 	});
 });


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
We should always forward the target property to the anchor tag for Link.
