### PR TITLE
Register the messages for all locales

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -235,7 +235,7 @@ export function setLocale(options: SetLocaleOptions = {}): Promise<string> | str
 	if (loadFallback && fallbackLoader && fallbackLoader !== true) {
 		loaderPromises.push(fallbackLoader());
 	}
-
+	Globalize.loadMessages({ [requestedLocale]: {} });
 	if (loaderPromises.length) {
 		return loadCldrData(
 			loaderPromises,
@@ -246,8 +246,6 @@ export function setLocale(options: SetLocaleOptions = {}): Promise<string> | str
 			isLocal,
 			invalidator
 		);
-	} else if (!matchedLocale) {
-		Globalize.loadMessages({ [requestedLocale]: {} });
 	}
 
 	setI18nLocales(calculatedLocale, isDefault, isLocal);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Always register the locales with the globalize bundles

Resolves #906 
