### PR TITLE
Remove native abort controller test

### DIFF
--- a/tests/shim/unit/AbortController.ts
+++ b/tests/shim/unit/AbortController.ts
@@ -1,9 +1,7 @@
-import { AbortController, AbortSignal, ShimAbortController, ShimAbortSignal } from '../../../src/shim/AbortController';
+import { AbortController, AbortSignal, ShimAbortController } from '../../../src/shim/AbortController';
 
 let controller: AbortController;
 let signal: AbortSignal;
-
-import has from '../../../src/core/has';
 
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
@@ -14,24 +12,6 @@ registerSuite('AbortController and AbortSignal', {
 		signal = controller.signal;
 	},
 	tests: {
-		'native AbortController'() {
-			if (!has('abort-controller')) {
-				this.skip('checking native implementation');
-			}
-			assert.include(
-				ShimAbortController.toString(),
-				'native',
-				'native implementation should represent native code'
-			);
-		},
-
-		'native AbortSignal'() {
-			if (!has('abort-signal')) {
-				this.skip('checking native implementation');
-			}
-			assert.include(ShimAbortSignal.toString(), 'native', 'native implementation should represent native code');
-		},
-
 		'AbortController defaults'() {
 			assert.isFunction(controller.abort, 'should provide an `abort` method');
 			assert.isDefined(controller.signal, 'should provide a signal property');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Removes test for native abort controller which is unnecessary and fails on later versions of node.
